### PR TITLE
Feature/stop loss field #41

### DIFF
--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -472,9 +472,10 @@ const AddTradeModal = ({
   // --- HANDLERS DE PARCIAIS ---
 
   const addPartialRow = () => {
-    // Default: copia a data da primeira parcial para conveniência
+    // Default: copia a data da primeira parcial e hora da última parcial preenchida
     const defaultDateBr = partials[0]?._dateBr || isoToBr(formData.entryDate);
-    setPartials(prev => [...prev, { type: 'ENTRY', price: '', qty: '', dateTime: '', seq: prev.length + 1, _dateBr: defaultDateBr, _time: '' }]);
+    const lastFilledTime = [...partials].reverse().find(p => p._time)?._time || '';
+    setPartials(prev => [...prev, { type: 'ENTRY', price: '', qty: '', dateTime: '', seq: prev.length + 1, _dateBr: defaultDateBr, _time: lastFilledTime }]);
   };
 
   const updatePartialRow = (index, field, value) => {
@@ -740,7 +741,7 @@ const AddTradeModal = ({
                   </div>
                   
                   {/* Header — Item 1: "Tipo" ao invés de "Ponta" + Item 2: Data e Hora separados */}
-                  <div className="grid grid-cols-[80px_1fr_70px_100px_80px_28px] gap-2 text-[10px] text-slate-500 uppercase tracking-wider px-1">
+                  <div className="grid grid-cols-[80px_1fr_70px_100px_95px_28px] gap-2 text-[10px] text-slate-500 uppercase tracking-wider px-1">
                     <span>Tipo</span>
                     <span>Preço</span>
                     <span>Qtd</span>
@@ -751,7 +752,7 @@ const AddTradeModal = ({
                   
                   {/* Rows */}
                   {partials.map((p, i) => (
-                    <div key={i} className="grid grid-cols-[80px_1fr_70px_100px_80px_28px] gap-2 items-center">
+                    <div key={i} className="grid grid-cols-[80px_1fr_70px_100px_95px_28px] gap-2 items-center">
                       {/* Item 1: Select com labels Compra/Venda conforme side */}
                       <select
                         value={p.type}

--- a/src/components/PlanLedgerExtract.jsx
+++ b/src/components/PlanLedgerExtract.jsx
@@ -16,7 +16,7 @@
 import { useMemo } from 'react';
 import { 
   X, ScrollText, Trophy, Skull, AlertTriangle, Flame, Zap, 
-  TrendingUp, TrendingDown, Brain, Shield, ShieldAlert, ShieldX, Scale
+  TrendingUp, TrendingDown, Brain, Shield, ShieldAlert, ShieldOff, Scale
 } from 'lucide-react';
 import { useMasterData } from '../hooks/useMasterData';
 import { useEmotionalProfile } from '../hooks/useEmotionalProfile';
@@ -150,7 +150,7 @@ const PlanLedgerExtract = ({ plan, trades, onClose }) => {
       case 'TILT': return <Flame className="w-3.5 h-3.5 text-orange-400" />;
       case 'REVENGE': return <Zap className="w-3.5 h-3.5 text-red-400" />;
       case 'STATUS_CRITICAL': return <AlertTriangle className="w-3.5 h-3.5 text-red-400" />;
-      case 'RO_FORA': return <ShieldX className="w-3.5 h-3.5 text-amber-400" />;
+      case 'RO_FORA': return <ShieldOff className="w-3.5 h-3.5 text-amber-400" />;
       case 'RR_FORA': return <Scale className="w-3.5 h-3.5 text-amber-400" />;
       case 'NO_STOP': return <ShieldAlert className="w-3.5 h-3.5 text-red-400" />;
       default: return <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />;
@@ -299,7 +299,7 @@ const PlanLedgerExtract = ({ plan, trades, onClose }) => {
                         )}
                         {row.complianceFlags?.includes('RO_FORA') && (
                           <span className="text-amber-400 text-[10px] font-bold flex items-center gap-0.5" title="Risco operacional fora do plano">
-                            <ShieldX className="w-3 h-3" /> RO
+                            <ShieldOff className="w-3 h-3" /> RO
                           </span>
                         )}
                         {row.complianceFlags?.includes('RR_FORA') && (

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -4,6 +4,7 @@
  * @description Modal de detalhes do trade com navegação para histórico de feedback e exibição de parciais
  * 
  * CHANGELOG (produto):
+ * - 1.10.0: resultPercent exibe % sobre PL do plano (nova prop plans[]). Sem plano → não exibe %
  * - 1.6.0: Exibição de parciais (Compra/Venda), médias ponderadas, resultInPoints, formatação moeda
  * - 1.5.0: Botão "Ver conversa completa" sempre visível para permitir início de interação
  * - 1.4.0: Fix erro "Objects are not valid as React child" - formatDate trata Timestamp Firebase
@@ -121,6 +122,7 @@ const TradeDetailModal = ({
   isOpen, 
   onClose, 
   trade, 
+  plans = [],
   isMentor = false,
   onAddFeedback,
   feedbackLoading = false,
@@ -274,7 +276,14 @@ const TradeDetailModal = ({
                 <p className={`text-xs ${
                   isWin ? 'text-emerald-400/50' : 'text-red-400/50'
                 }`}>
-                  {formatPercent(trade.resultPercent)}
+                  {(() => {
+                    const plan = trade.planId && plans.length > 0 ? plans.find(p => p.id === trade.planId) : null;
+                    const planPl = plan?.pl;
+                    if (planPl && planPl > 0) {
+                      return formatPercent((trade.result / planPl) * 100);
+                    }
+                    return '';
+                  })()}
                 </p>
               </div>
               

--- a/src/components/TradesList.jsx
+++ b/src/components/TradesList.jsx
@@ -3,6 +3,7 @@
  * @version 1.2.1
  * @description Componente de apresentação (Dumb Component) responsável por listar os trades.
  * * CHANGELOG:
+ * - 1.10.0: resultPercent exibe % sobre PL do plano (não variação de preço). Nova prop plans[].
  * - 1.2.1: Default de showStatus alterado para true (Status visível por padrão para todos)
  * - 1.2.0: Adicionado prop showStatus para exibir coluna de status do feedback
  * - 1.1.0: Risk Guardian (Alertas visuais de violação de regras)
@@ -67,12 +68,20 @@ const StatusBadge = ({ status }) => {
 
 const TradesList = ({ 
   trades = [], 
+  plans = [],
   onViewTrade, 
   onEditTrade, 
   onDeleteTrade,
   showStatus = true, // AGORA É TRUE POR PADRÃO
   showStudent = false
 }) => {
+
+  // Helper: resolve PL do plano para calcular % sobre PL
+  const getPlanPl = (trade) => {
+    if (!trade.planId || plans.length === 0) return null;
+    const plan = plans.find(p => p.id === trade.planId);
+    return plan?.pl || null;
+  };
 
   // Helper de Estilo: Cores para LONG/SHORT
   const getSideColor = (side) => {
@@ -114,7 +123,9 @@ const TradesList = ({
         <tbody className="divide-y divide-slate-800/50 text-sm">
           {trades.map((trade) => {
             const result = Number(trade.result) || 0;
-            const percent = Number(trade.resultPercent) || 0;
+            // % sobre PL do plano (não variação de preço)
+            const planPl = getPlanPl(trade);
+            const resultPercentPl = planPl && planPl > 0 ? (result / planPl) * 100 : null;
             
             // Lógica do Risk Guardian
             const hasViolations = trade.hasRedFlags || (Array.isArray(trade.redFlags) && trade.redFlags.length > 0);
@@ -200,7 +211,10 @@ const TradesList = ({
                       </span>
                     </div>
                     <div className={`text-xs ${getResultColor(result)} opacity-80`}>
-                      {result > 0 ? '+' : ''}{formatPercent(percent)}
+                      {resultPercentPl != null 
+                        ? `${result > 0 ? '+' : ''}${formatPercent(resultPercentPl)}`
+                        : ''
+                      }
                     </div>
                   </div>
                 </td>

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -4,6 +4,7 @@
  * @description Hook responsável pelo gerenciamento de trades (CRUD) + Sistema de Feedback + Parciais
  * 
  * CHANGELOG (produto):
+ * - 1.10.0: stopLoss field — persiste no addTrade e updateTrade
  * - 1.6.0: Sistema de parciais (1 Trade → N Parciais)
  *   - addPartial(): Adiciona parcial a um trade existente
  *   - updatePartial(): Atualiza parcial existente
@@ -210,6 +211,7 @@ export const useTrades = (overrideStudentId = null) => {
         date: legacyDate, entryTime, exitTime, duration,
         ticker: tradeData.ticker?.toUpperCase() || '',
         entry, exit, qty, 
+        stopLoss: tradeData.stopLoss != null ? parseFloat(tradeData.stopLoss) : null,
         resultCalculated: Math.round(result * 100) / 100,
         result: tradeData.resultOverride != null && !isNaN(parseFloat(tradeData.resultOverride))
           ? Math.round(parseFloat(tradeData.resultOverride) * 100) / 100 
@@ -312,6 +314,11 @@ export const useTrades = (overrideStudentId = null) => {
       const qty = parseFloat(updates.qty ?? currentTrade.qty);
       const side = updates.side || currentTrade.side;
       const tickerRule = updates.tickerRule || currentTrade.tickerRule;
+
+      // Propagar stopLoss se presente no update
+      if (updates.stopLoss !== undefined) {
+        updateData.stopLoss = updates.stopLoss != null ? parseFloat(updates.stopLoss) : null;
+      }
 
       let newResult = currentTrade.result;
 

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -4,6 +4,7 @@
  * @description Diário de trades com navegação para FeedbackPage
  * 
  * CHANGELOG (produto):
+ * - 1.10.0: Ordenação crescente (mais antigo primeiro), plans passado para TradesList
  * - 1.6.0: Suporte a parciais via AddTradeModal
  * - 1.4.0: Adicionado suporte a onNavigateToFeedback
  */
@@ -93,6 +94,13 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
     else if (filters.result === 'losses') result = result.filter(t => t.result < 0);
     if (filters.search) result = searchTrades(result, filters.search);
     
+    // Ordenação crescente: mais antigo primeiro
+    result.sort((a, b) => {
+      const dateCompare = (a.date || '').localeCompare(b.date || '');
+      if (dateCompare !== 0) return dateCompare;
+      return (a.entryTime || '').localeCompare(b.entryTime || '');
+    });
+
     return result;
   }, [trades, filters, selectedAccounts]);
 
@@ -204,6 +212,7 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
       <div className="glass-card">
         <TradesList 
           trades={filteredTrades} 
+          plans={plans}
           onViewTrade={setViewingTrade} 
           onEditTrade={(t) => { setEditingTrade(t); setShowAddModal(true); }} 
           onDeleteTrade={async (trade) => { try { await deleteTrade(trade.id, trade.htfUrl, trade.ltfUrl); } catch (err) { console.error(err); } }} 
@@ -228,6 +237,7 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
         isOpen={!!viewingTrade} 
         onClose={() => setViewingTrade(null)} 
         trade={viewingTrade}
+        plans={plans}
         onViewFeedbackHistory={handleViewFeedbackHistory}
         getPartials={getPartials}
       />

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description SemVer 2.0.0 — MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
  * 
  * CHANGELOG:
+ * - 1.10.0: Issue #41 — Campo Stop Loss, HH:MM:SS parciais, red flag NO_STOP, compliance RR via resultado
  * - 1.9.0: Sistema Emocional v2 — Fase 1.5.0 (UI Completa: Extrato Ledger + Alertas Mentor)
  * - 1.8.0: Sistema Emocional v2 — Fase 1.4.0 (Perfil Emocional do Aluno)
  * - 1.7.1: Hotfix: Filtro master de conta no dashboard aluno (AccountFilterBar)
@@ -14,10 +15,10 @@
  */
 export const VERSION = {
   major: 1,
-  minor: 9,
+  minor: 10,
   patch: 0,
   prerelease: null,
-  build: '20260223',
+  build: '20260225',
 
   get number() {
     return `${this.major}.${this.minor}.${this.patch}`;
@@ -40,7 +41,7 @@ export const VERSION = {
   },
 
   get date() {
-    return '2026-02-23';
+    return '2026-02-25';
   }
 };
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>feat(v1.10.0): Stop Loss + Compliance + HH:MM:SS + Extrato (#41)</h2>
<h3>Resumo</h3>
<p>Implementa campo de stop loss no registro de trades, cálculo de risco operacional real, detecção de trades sem proteção, e exibição de compliance financeiro no extrato do plano. Corrige exibição de percentual (agora sobre PL do plano) e ordena listas cronologicamente.</p>
<hr>
<h3>Streams</h3>
<h4>Stream A — Campo Stop Loss</h4>
<ul>
<li>Novo campo <code>stopLoss</code> no <code>AddTradeModal</code> entre Side e Qty</li>
<li>Validação de coerência: LONG → stop &lt; entry, SHORT → stop &gt; entry</li>
<li>Badge visual "Sem stop" (amber) quando campo vazio e entry preenchido</li>
<li>Persistência explícita com parse <code>number|null</code> em <code>useTrades</code> (addTrade + updateTrade)</li>
<li>Grid do formulário ajustado para 3 colunas (<code>lg:grid-cols-3</code>)</li>
</ul>
<h4>Stream B — Red Flags &amp; Compliance (Cloud Functions v1.6.0)</h4>
<ul>
<li>Novo <code>RED_FLAG_TYPES.NO_STOP</code> (<code>TRADE_SEM_STOP</code>)</li>
<li><code>onTradeCreated</code>: trade sem stop → red flag + notificação mentor</li>
<li><code>calculateTradeCompliance</code> reescrito:
<ul>
<li>Sem stop → <code>riskPercent = 100%</code> (todo PL em risco)</li>
<li>Com stop → cálculo real: <code>|entry - stop| × qty × tickValue / planPl</code></li>
<li>RR via resultado efetivo quando não há <code>takeProfit</code>: <code>result / riskAmount</code></li>
</ul>
</li>
</ul>
<h4>Stream C — Segundos nas Parciais</h4>
<ul>
<li><code>maskTime</code> aceita <code>HH:MM:SS</code> (8 chars), backward compat com <code>HH:MM</code> (5 chars)</li>
<li><code>combineDateTimeISO</code> não força <code>:00</code> quando seconds presentes</li>
<li><code>extractTime</code> retorna <code>HH:MM:SS</code> quando seconds são não-zero</li>
<li>Coluna Hora ampliada para 95px, placeholder <code>HH:MM:SS</code></li>
<li>Nova parcial copia horário da última parcial preenchida</li>
</ul>
<h4>Stream D — Compliance no Extrato do Plano</h4>
<ul>
<li><code>PlanLedgerExtract</code>: lê <code>trade.compliance</code> e <code>trade.redFlags</code> por linha</li>
<li>Coluna Evento exibe badges empilhados: <code>S/STOP</code> (red), <code>RO</code> (amber), <code>RR</code> (amber)</li>
<li>Painel Eventos no footer inclui <code>RO_FORA</code>, <code>RR_FORA</code>, <code>NO_STOP</code> com ícones e mensagens</li>
</ul>
<h4>Fixes adicionais</h4>
<ul>
<li><strong>resultPercent</strong>: substituído em <code>TradesList</code> e <code>TradeDetailModal</code> — agora calcula <code>(result / plan.pl) × 100</code> em vez de variação de preço (irrelevante para futuros)</li>
<li><strong>Ordenação</strong>: <code>TradesJournal</code> ordena crescente (mais antigo primeiro) com secondary sort por <code>entryTime</code></li>
</ul>
<hr>
<h3>Arquivos modificados (8)</h3>

Arquivo | Ação
-- | --
src/components/AddTradeModal.jsx | EDIT — stopLoss field, HH:MM:SS, grid 3 cols
src/components/TradesList.jsx | EDIT — nova prop plans[], % sobre PL
src/components/TradeDetailModal.jsx | EDIT — nova prop plans[], % sobre PL
src/components/PlanLedgerExtract.jsx | EDIT — badges RO/RR/NO_STOP, painel eventos
src/hooks/useTrades.js | EDIT — stopLoss no addTrade/updateTrade
src/pages/TradesJournal.jsx | EDIT — sort ASC, propaga plans
src/version.js | EDIT — v1.10.0+20260225
functions/index.js | EDIT — v1.6.0, NO_STOP, compliance reescrito


<h3>Retrocompatibilidade</h3>
<ul>
<li>Trades existentes sem <code>stopLoss</code> → <code>undefined/null</code> → fallback funciona (riskPercent=100 apenas para novos trades via CF)</li>
<li><code>plans=[]</code> default em TradesList/TradeDetailModal → callers sem plans não quebram, apenas não exibem %</li>
<li>Parciais <code>HH:MM</code> continuam válidas (validação <code>length &gt;= 5</code>)</li>
<li>Firestore rules sem alteração (stopLoss coberto por rules existentes)</li>
</ul>
<h3>Deploy</h3>
<pre><code class="language-bash"># Cloud Functions primeiro (v1.6.0)
cd functions &amp;&amp; firebase deploy --only functions

# Frontend via Vercel (automático no push)
</code></pre>
<h3>Teste</h3>
<ul>
<li>[ ] Criar trade COM stop → verificar badge ausente, riskPercent &lt; 100%, RR calculado</li>
<li>[ ] Criar trade SEM stop → verificar badge "Sem stop" no form, red flag NO_STOP, riskPercent=100%</li>
<li>[ ] Parciais com HH:MM:SS → verificar máscara, validação, persistência</li>
<li>[ ] Nova parcial herda horário da anterior</li>
<li>[ ] TradesList mostra % sobre PL (não variação de preço)</li>
<li>[ ] TradeDetailModal mostra % sobre PL</li>
<li>[ ] PlanLedgerExtract mostra badges RO/RR/NO_STOP na coluna Evento</li>
<li>[ ] PlanLedgerExtract mostra eventos de compliance no painel footer</li>
<li>[ ] Ordenação crescente no diário de trades</li>
</ul>
<p>Closes #41</p></body></html><!--EndFragment-->
</body>
</html>