### PR TITLE
Hotfix/ro calc trade sorting v1.10.1

### DIFF
--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -603,7 +603,13 @@ const AddTradeModal = ({
 
     // Mensagem global visível para erros de data/hora
     if (hasDateTimeError && !newErrors.partials) {
-      newErrors.partials = 'Preencha data e horário de todas as parciais';
+      // Detectar se é erro de range (segundos/minutos inválidos) vs preenchimento
+      const hasRangeError = Object.entries(newErrors).some(([k, v]) => 
+        k.startsWith('partial_') && (v.includes('inválid') || v.includes('Hora inválida'))
+      );
+      newErrors.partials = hasRangeError 
+        ? 'Corrija os valores de horário das parciais' 
+        : 'Preencha data e horário de todas as parciais';
     }
     
     if (!editTrade) {

--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -130,6 +130,19 @@ const AddTradeModal = ({
       .replace(/(\d{2})\d+?$/, '$1');
   };
 
+  /** Valida range HH:MM ou HH:MM:SS — retorna mensagem de erro ou null */
+  const validateTimeRange = (time) => {
+    if (!time) return null;
+    const parts = time.split(':');
+    const hh = parseInt(parts[0], 10);
+    const mm = parseInt(parts[1], 10);
+    const ss = parts[2] !== undefined ? parseInt(parts[2], 10) : 0;
+    if (isNaN(hh) || hh < 0 || hh > 23) return 'Hora inválida (00-23)';
+    if (isNaN(mm) || mm < 0 || mm > 59) return 'Minuto inválido (00-59)';
+    if (isNaN(ss) || ss < 0 || ss > 59) return 'Segundo inválido (00-59)';
+    return null;
+  };
+
   // --- HELPERS DE PARCIAIS: Labels Compra/Venda conforme side ---
   
   /**
@@ -571,6 +584,12 @@ const AddTradeModal = ({
       if (!p._time || (p._time.length !== 5 && p._time.length !== 8)) {
         newErrors[`partial_${i}_time`] = 'Hora obrigatória (HH:MM ou HH:MM:SS)';
         hasDateTimeError = true;
+      } else {
+        const timeRangeErr = validateTimeRange(p._time);
+        if (timeRangeErr) {
+          newErrors[`partial_${i}_time`] = timeRangeErr;
+          hasDateTimeError = true;
+        }
       }
       // Se ambos estão preenchidos, o dateTime combinado deve ser válido
       if (p._dateBr?.length === 10 && (p._time?.length === 5 || p._time?.length === 8)) {

--- a/src/components/PlanLedgerExtract.jsx
+++ b/src/components/PlanLedgerExtract.jsx
@@ -106,13 +106,16 @@ const PlanLedgerExtract = ({ plan, trades, onClose }) => {
       };
     });
 
-    // Adicionar eventos TILT/REVENGE dos alertas
+    // Adicionar eventos TILT/REVENGE dos alertas emocionais
     if (emotional.isReady && emotional.alerts) {
       emotional.alerts.forEach(a => {
         if (a.type === 'TILT' || a.type === 'REVENGE' || a.type === 'STATUS_CRITICAL') {
+          // Associar ao trade mais próximo pela data/hora do alerta
+          const alertDate = a.date || a.tradeDate || (rows.length > 0 ? rows[rows.length - 1].date : null);
+          if (!alertDate) return; // Skip se sem data válida
           evts.push({
             type: a.type,
-            date: a.date || '-',
+            date: alertDate,
             time: a.time || '',
             message: a.message
           });

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -277,6 +277,12 @@ const TradeDetailModal = ({
                   isWin ? 'text-emerald-400/50' : 'text-red-400/50'
                 }`}>
                   {(() => {
+                    // Futuros: risco em pontos
+                    if (trade.tickerRule && trade.stopLoss && trade.entry) {
+                      const riskPts = Math.abs(trade.entry - trade.stopLoss);
+                      return `Stop: ${riskPts} pts`;
+                    }
+                    // Ações/papéis: % sobre PL
                     const plan = trade.planId && plans.length > 0 ? plans.find(p => p.id === trade.planId) : null;
                     const planPl = plan?.pl;
                     if (planPl && planPl > 0) {

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -645,4 +645,4 @@ const TradeDetailModal = ({
   );
 };
 
-export default TradeDetailModal;
+export default TradeDetailModal;// hotfix-v1.10.1

--- a/src/components/TradesList.jsx
+++ b/src/components/TradesList.jsx
@@ -135,9 +135,14 @@ const TradesList = ({
 
             return (
               <tr key={trade.id} className="group hover:bg-slate-800/30 transition-colors">
-                {/* DATA */}
+                {/* DATA + HORA */}
                 <td className="p-4 font-medium text-slate-300 whitespace-nowrap">
-                  {trade.date ? trade.date.split('-').reverse().join('/') : '-'}
+                  <div>{trade.date ? trade.date.split('-').reverse().join('/') : '-'}</div>
+                  {trade.entryTime && (
+                    <div className="text-[10px] text-slate-500 font-mono mt-0.5">
+                      {(() => { try { const t = trade.entryTime.split('T')[1]; return t ? t.substring(0, 5) : ''; } catch { return ''; } })()}
+                    </div>
+                  )}
                 </td>
 
                 {/* ALUNO (opcional) */}
@@ -211,10 +216,18 @@ const TradesList = ({
                       </span>
                     </div>
                     <div className={`text-xs ${getResultColor(result)} opacity-80`}>
-                      {resultPercentPl != null 
-                        ? `${result > 0 ? '+' : ''}${formatPercent(resultPercentPl)}`
-                        : ''
-                      }
+                      {(() => {
+                        // Futuros: mostrar risco em pontos se tem stop
+                        if (trade.tickerRule && trade.stopLoss && trade.entry) {
+                          const riskPts = Math.abs(trade.entry - trade.stopLoss);
+                          return `Stop: ${riskPts} pts`;
+                        }
+                        // Ações/papéis: mostrar % sobre PL
+                        if (resultPercentPl != null) {
+                          return `${result > 0 ? '+' : ''}${formatPercent(resultPercentPl)}`;
+                        }
+                        return '';
+                      })()}
                     </div>
                   </div>
                 </td>

--- a/src/components/TradesList.jsx
+++ b/src/components/TradesList.jsx
@@ -285,3 +285,4 @@ const TradesList = ({
 };
 
 export default TradesList;
+// hotfix-v1.10.1

--- a/src/pages/MentorDashboard.jsx
+++ b/src/pages/MentorDashboard.jsx
@@ -29,6 +29,7 @@ import MentorAlerts from '../components/MentorAlerts';
 import Loading from '../components/Loading';
 import DebugBadge from '../components/DebugBadge';
 import { useTrades } from '../hooks/useTrades';
+import { usePlans } from '../hooks/usePlans';
 import { useEmotionalProfile } from '../hooks/useEmotionalProfile';
 import { useComplianceRules } from '../hooks/useComplianceRules';
 import { 
@@ -42,6 +43,7 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
     getTradesByStudent, getTradesGroupedByStudent, getUniqueStudents, 
     getTradesAwaitingFeedback, getTradesByStudentAndStatus
   } = useTrades();
+  const { plans } = usePlans();
   
   const [selectedStudent, setSelectedStudent] = useState(null);
   const [viewingTrade, setViewingTrade] = useState(null);
@@ -174,9 +176,9 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
           </div>
         )}
         <div className="glass-card">
-          <TradesList trades={selectedStudentTrades} onViewTrade={setViewingTrade} showStudent={false} showStatus={true} />
+          <TradesList trades={selectedStudentTrades} plans={plans} onViewTrade={setViewingTrade} showStudent={false} showStatus={true} />
         </div>
-        <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} isMentor onAddFeedback={handleAddFeedback} feedbackLoading={feedbackLoading} onViewFeedbackHistory={handleViewFeedbackHistory} />
+        <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} isMentor onAddFeedback={handleAddFeedback} feedbackLoading={feedbackLoading} onViewFeedbackHistory={handleViewFeedbackHistory} />
       </div>
     );
   }
@@ -224,7 +226,7 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
             />
           </div>
           <div className="glass-card">
-            <TradesList trades={allTrades.slice(0, 20)} onViewTrade={setViewingTrade} showStudent={true} showStatus={true} />
+            <TradesList trades={allTrades.slice(0, 20)} plans={plans} onViewTrade={setViewingTrade} showStudent={true} showStatus={true} />
           </div>
         </>
       )}
@@ -375,7 +377,7 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
         </div>
       )}
 
-      <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} isMentor onAddFeedback={handleAddFeedback} feedbackLoading={feedbackLoading} onViewFeedbackHistory={handleViewFeedbackHistory} />
+      <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} isMentor onAddFeedback={handleAddFeedback} feedbackLoading={feedbackLoading} onViewFeedbackHistory={handleViewFeedbackHistory} />
       <DebugBadge component="MentorDashboard" />
     </div>
   );

--- a/src/pages/MentorDashboard.jsx
+++ b/src/pages/MentorDashboard.jsx
@@ -409,4 +409,4 @@ const StudentEmotionalCardWrapper = ({ trades, studentName, detectionConfig, sta
   );
 };
 
-export default MentorDashboard;
+export default MentorDashboard;// hotfix-v1.10.1

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -529,6 +529,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
             </div>
             <TradesList 
               trades={filteredTrades.filter(t => t.date === calendarSelectedDate)} 
+              plans={plans}
               onViewTrade={setViewingTrade} 
               onEditTrade={(t) => { setEditingTrade(t); setShowAddModal(true); }} 
               onDeleteTrade={deleteTrade} 
@@ -554,6 +555,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
         isOpen={!!viewingTrade} 
         onClose={() => setViewingTrade(null)} 
         trade={viewingTrade} 
+        plans={plans} 
         onViewFeedbackHistory={handleViewFeedbackHistory}
       />
 

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -569,3 +569,4 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
 };
 
 export default StudentDashboard;
+// hotfix-v1.10.1

--- a/src/pages/StudentFeedbackPage.jsx
+++ b/src/pages/StudentFeedbackPage.jsx
@@ -238,7 +238,11 @@ const StudentFeedbackPage = () => {
       // Crescente: mais antigo primeiro
       const dateCompare = (a.date || '').localeCompare(b.date || '');
       if (dateCompare !== 0) return dateCompare;
-      return (a.entryTime || '').localeCompare(b.entryTime || '');
+      const timeCompare = (a.entryTime || '').localeCompare(b.entryTime || '');
+      if (timeCompare !== 0) return timeCompare;
+      const aTs = a.createdAt?.seconds || a.createdAt?.toMillis?.() || 0;
+      const bTs = b.createdAt?.seconds || b.createdAt?.toMillis?.() || 0;
+      return aTs - bTs;
     });
     return result;
   }, [trades, statusFilter, tickerFilter, periodFilter, searchTerm]);

--- a/src/pages/StudentFeedbackPage.jsx
+++ b/src/pages/StudentFeedbackPage.jsx
@@ -144,6 +144,11 @@ const TradeListItem = ({ trade, isSelected, onClick }) => {
         </div>
         <div className="flex items-center gap-1.5 mt-0.5 text-xs text-slate-500">
           <span>{formatDateShort(trade.date)}</span>
+          {trade.entryTime && (
+            <span className="font-mono text-slate-600">
+              {(() => { try { return trade.entryTime.split('T')[1]?.substring(0, 5) || ''; } catch { return ''; } })()}
+            </span>
+          )}
           <span>•</span>
           <span className="truncate">{trade.setup || 'Sem setup'}</span>
           {messageCount > 0 && (
@@ -230,7 +235,10 @@ const StudentFeedbackPage = () => {
       const pA = STATUS_CONFIG[a.status || 'OPEN']?.priority || 99;
       const pB = STATUS_CONFIG[b.status || 'OPEN']?.priority || 99;
       if (pA !== pB) return pA - pB;
-      return (b.date || '').localeCompare(a.date || '');
+      // Crescente: mais antigo primeiro
+      const dateCompare = (a.date || '').localeCompare(b.date || '');
+      if (dateCompare !== 0) return dateCompare;
+      return (a.entryTime || '').localeCompare(b.entryTime || '');
     });
     return result;
   }, [trades, statusFilter, tickerFilter, periodFilter, searchTerm]);

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description SemVer 2.0.0 — MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
  * 
  * CHANGELOG:
+ * - 1.10.1: Hotfix — RO/RR com tickSize, validação HH:MM:SS range, data+hora em listas, risco pts vs %
  * - 1.10.0: Issue #41 — Campo Stop Loss, HH:MM:SS parciais, red flag NO_STOP, compliance RR via resultado
  * - 1.9.0: Sistema Emocional v2 — Fase 1.5.0 (UI Completa: Extrato Ledger + Alertas Mentor)
  * - 1.8.0: Sistema Emocional v2 — Fase 1.4.0 (Perfil Emocional do Aluno)
@@ -16,7 +17,7 @@
 export const VERSION = {
   major: 1,
   minor: 10,
-  patch: 0,
+  patch: 1,
   prerelease: null,
   build: '20260225',
 

--- a/src/version.js
+++ b/src/version.js
@@ -46,4 +46,4 @@ export const VERSION = {
   }
 };
 
-export default VERSION;
+export default VERSION;// hotfix-v1.10.1


### PR DESCRIPTION
## fix(v1.10.1): RO/RR Compliance, AccountFilterBar, Time Validation, Trade Sorting

### Resumo

Hotfix que corrige cálculo de risco operacional para contratos futuros, recálculo de compliance em edição de trades, padroniza seletor de contas entre telas, valida range de segundos em parciais, adiciona data+hora nas listas de trades, e exibe risco em pontos para futuros.

---

### Versões

| Componente | De | Para | Tipo |
|------------|------|------|------|
| Frontend | v1.10.0 | v1.10.1 | PATCH |
| Cloud Functions | v1.6.0 | v1.7.0 | MINOR (nova callable) |

---

### Fixes

#### 1. RO/RR — tickSize na fórmula (CF)
**Bug:** `calculateTradeCompliance` usava `|entry - stop| * qty * tickValue` — tratava pontos como reais.
**Fix:** `(|entry - stop| / tickSize) * tickValue * qty`. Exemplo WINFUT: 135 pts de risco → `(135/5)*1*1 = R$ 27`, não R$ 135.
**RR:** Mesmo fix — resultado convertido de R$ para pontos antes de dividir pelo risco em pontos.

#### 2. onTradeUpdated — recálculo completo na edição (CF)
**Bug:** Recalculava compliance apenas se `result` ou `planId` mudava. Editar `stopLoss`, `entry`, `exit`, `qty`, `side` não triggerava recálculo. Red flags antigas persistiam.
**Fix:** Detecta mudança em `['stopLoss', 'entry', 'exit', 'qty', 'side']`. Reconstrói red flags por completo (remove compliance flags antigos, recria conforme novo cálculo). Guard contra loop infinito (ignora updates que só mudaram campos de compliance).

#### 3. recalculateCompliance callable (CF — MINOR)
Nova Cloud Function callable para migrar trades existentes. Recalcula compliance + red flags de todos os trades de um plano.
```javascript
const fn = httpsCallable(getFunctions(), 'recalculateCompliance');
await fn({ planId: 'xxx' }); // ou { planId: 'xxx', tradeId: 'yyy' }
```

#### 4. AccountFilterBar no TradesJournal
**Bug:** TradesJournal usava `<select>` customizado com fonte desproporcional e default em "Demo".
**Fix:** Substituído por `AccountFilterBar` (mesmo componente do StudentDashboard). Default: "Reais". Refatorado state de `all_real`/`all_demo` para `accountTypeFilter` + `accountId: 'all'|id`.

#### 5. Validação de segundos nas parciais
**Bug:** `maskTime` aceitava `09:30:75` — sem validação de range.
**Fix:** `validateTimeRange()` rejeita HH>23, MM>59, SS>59. Mensagem de erro contextual: "Corrija os valores de horário" (range) vs "Preencha data e horário" (campo vazio).

#### 6. Data + Hora nas listas de trades
**Mudança:** `TradesList` agora exibe DD/MM + HH:MM abaixo da data. Mesmo padrão visual do `PlanLedgerExtract`.

#### 7. Risco em pontos (futuros) vs % (ações)
**Mudança:** `TradesList` e `TradeDetailModal` exibem "Stop: X pts" para trades com `tickerRule`, e "% sobre PL" para ações/papéis.

#### 8. Ordenação crescente robusta
**Fix:** Sort com fallback `createdAt` para trades mesma data sem `entryTime`. Aplicado em `TradesJournal` e `StudentFeedbackPage`.

#### 9. Eventos sem data no PlanLedgerExtract
**Bug:** Alertas emocionais (`STATUS_CRITICAL`) sem `date` geravam "undefined/" no painel de eventos.
**Fix:** Fallback para data do último trade do plano. Skip se nenhuma data válida.

#### 10. plans propagado para todos os callers
**Mudança:** `MentorDashboard` e `StudentDashboard` agora passam `plans={plans}` para `TradesList` e `TradeDetailModal`, habilitando exibição de % sobre PL e risco em pontos.

---

### Arquivos modificados (10)

| Arquivo | Mudanças |
|---------|----------|
| `functions/index.js` | tickSize no compliance, onTradeUpdated completo, recalculateCompliance callable |
| `src/components/AddTradeModal.jsx` | validateTimeRange, mensagem erro contextual |
| `src/components/TradesList.jsx` | Data+hora, risco pts vs %, plans prop |
| `src/components/TradeDetailModal.jsx` | Risco pts vs %, plans prop |
| `src/components/PlanLedgerExtract.jsx` | Fix eventos sem data |
| `src/pages/TradesJournal.jsx` | AccountFilterBar, default real, sort robusto |
| `src/pages/StudentDashboard.jsx` | plans em TradesList/TradeDetailModal |
| `src/pages/MentorDashboard.jsx` | usePlans + plans em TradesList/TradeDetailModal |
| `src/pages/StudentFeedbackPage.jsx` | Sort crescente robusto, horário no TradeListItem |
| `src/version.js` | v1.10.1 |

### Retrocompatibilidade

- `plans=[]` default em TradesList/TradeDetailModal — callers sem plans não quebram
- `accountTypeFilter` novo state, mas lógica interna idêntica
- CF: onTradeUpdated guard previne loop, trades sem campos novos passam direto
- `recalculateCompliance` é aditivo (não altera behavior existente)

### Deploy

```bash
cd functions && firebase deploy --only functions
```

### Teste

- [ ] Criar trade WINFUT com stop → RO calcula em R$ (não pontos) → badge correto
- [ ] Editar trade (mudar stop) → compliance recalcula, badge atualiza
- [ ] Editar trade conforme → tornar fora do RO → badge aparece
- [ ] TradesJournal: AccountFilterBar igual ao StudentDashboard, default "Reais"
- [ ] Parcial com `09:30:75` → erro "Segundo inválido (00-59)"
- [ ] TradesList mostra DD/MM + HH:MM
- [ ] TradesList mostra "Stop: X pts" para futuros
- [ ] PlanLedgerExtract: sem "undefined/" nos eventos
- [ ] MentorDashboard: TradesList mostra % sobre PL

Closes #18, closes #49
