### PR TITLE
fix(v1.10.2): Sort, planId lock, Max DD, WR Planejado, conformidade, mentor feedback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,7 +77,8 @@ const AppContent = () => {
     getTradesGroupedByStudent, 
     allTrades,
     addFeedbackComment,
-    updateTradeStatus
+    updateTradeStatus,
+    getPartials
   } = useTrades();
   const { plans } = usePlans();
 
@@ -189,12 +190,17 @@ const AppContent = () => {
       // Busca trade atualizado do allTrades para dados em tempo real
       const currentTrade = allTrades.find(t => t.id === feedbackTrade.id) || feedbackTrade;
       
+      // Enriquece com PL do plano para cálculo de resultado % sobre PL
+      const tradePlan = currentTrade.planId ? plans.find(p => p.id === currentTrade.planId) : null;
+      const enrichedTrade = tradePlan ? { ...currentTrade, _planPl: tradePlan.pl } : currentTrade;
+      
       return (
         <FeedbackPage
-          trade={currentTrade}
+          trade={enrichedTrade}
           onBack={handleBackFromFeedback}
           onAddComment={handleAddFeedbackComment}
           onUpdateStatus={handleUpdateTradeStatus}
+          getPartials={getPartials}
         />
       );
     }

--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -12,7 +12,8 @@ import {
   Plus,
   Trash2,
   Layers,
-  ShieldAlert
+  ShieldAlert,
+  Lock
 } from 'lucide-react';
 import { useAccounts } from '../hooks/useAccounts';
 import { useMasterData } from '../hooks/useMasterData';
@@ -700,11 +701,18 @@ const AddTradeModal = ({
             {/* PLANO */}
             <div className="relative" ref={planDropdownRef}>
               <label className="input-label">Plano *</label>
+              {editTrade ? (
+                <div className="input-dark w-full flex justify-between opacity-60 cursor-not-allowed" title="Para mudar o plano, exclua e recrie o trade">
+                  <div className="flex items-center gap-3"><Wallet className="w-4 h-4 text-blue-400"/><span>{selectedPlan ? selectedPlan.name : 'Plano não encontrado'}</span></div>
+                  <Lock className="w-4 h-4 text-slate-500"/>
+                </div>
+              ) : (
               <button type="button" onClick={() => setShowPlanDropdown(!showPlanDropdown)} className={`input-dark w-full flex justify-between ${errors.planId ? 'border-red-500' : ''}`}>
                 <div className="flex items-center gap-3"><Wallet className="w-4 h-4 text-blue-400"/><span>{selectedPlan ? selectedPlan.name : 'Selecione...'}</span></div>
                 <ChevronDown className="w-4 h-4 text-slate-500"/>
               </button>
-              {showPlanDropdown && (
+              )}
+              {!editTrade && showPlanDropdown && (
                 <div className="absolute top-full w-full mt-2 bg-slate-800 border border-slate-700 rounded-xl shadow-xl z-50 max-h-48 overflow-y-auto">
                   {plans.map(p => <button key={p.id} type="button" onClick={() => handlePlanSelect(p.id)} className="w-full text-left px-4 py-3 hover:bg-slate-700 text-sm text-white border-b border-slate-700/50">{p.name}</button>)}
                 </div>

--- a/src/components/TradesList.jsx
+++ b/src/components/TradesList.jsx
@@ -3,6 +3,7 @@
  * @version 1.2.1
  * @description Componente de apresentação (Dumb Component) responsável por listar os trades.
  * * CHANGELOG:
+ * - 1.10.2: Sort interno ASC (data + entryTime + createdAt fallback). Garante ordem em todo caller.
  * - 1.10.0: resultPercent exibe % sobre PL do plano (não variação de preço). Nova prop plans[].
  * - 1.2.1: Default de showStatus alterado para true (Status visível por padrão para todos)
  * - 1.2.0: Adicionado prop showStatus para exibir coluna de status do feedback
@@ -97,6 +98,20 @@ const TradesList = ({
     return 'text-slate-400';
   };
 
+  // Sort interno: ASC por data, depois entryTime, fallback createdAt
+  const sortedTrades = [...trades].sort((a, b) => {
+    const dateA = a.date || '';
+    const dateB = b.date || '';
+    if (dateA !== dateB) return dateA.localeCompare(dateB);
+    const timeA = a.entryTime || '';
+    const timeB = b.entryTime || '';
+    if (timeA && timeB) return timeA.localeCompare(timeB);
+    // Fallback: createdAt (Firestore timestamp ou ISO string)
+    const caA = a.createdAt?.toDate?.()?.toISOString?.() || a.createdAt || '';
+    const caB = b.createdAt?.toDate?.()?.toISOString?.() || b.createdAt || '';
+    return caA.toString().localeCompare(caB.toString());
+  });
+
   // Calcula número de colunas dinâmicas
   const baseColumns = 6; // Data, Ticker, Setup, Lado, Imagens, Resultado, Ações
   const extraColumns = (showStatus ? 1 : 0) + (showStudent ? 1 : 0);
@@ -121,7 +136,7 @@ const TradesList = ({
 
         {/* CORPO DA TABELA */}
         <tbody className="divide-y divide-slate-800/50 text-sm">
-          {trades.map((trade) => {
+          {sortedTrades.map((trade) => {
             const result = Number(trade.result) || 0;
             // % sobre PL do plano (não variação de preço)
             const planPl = getPlanPl(trade);

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -5,6 +5,7 @@
  * @see version.js para versão do produto
  * 
  * CHANGELOG:
+ * - 1.10.2: TradeInfoCard exibe Stop Loss, RR, Resultado % sobre PL, Red Flags (RO% removido — redundante com RR)
  * - 1.4.0: Prop embedded para uso dentro de StudentFeedbackPage master-detail
  *   - embedded=true: sem padding, sem header, sem botão voltar, grid 2 colunas (info + chat)
  *   - embedded=false (default): comportamento original (tela cheia, 2 colunas)
@@ -21,7 +22,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { 
   ChevronLeft, Send, HelpCircle, Lock, User, GraduationCap,
-  Calendar, TrendingUp, TrendingDown, Clock, AlertCircle,
+  Calendar, TrendingUp, TrendingDown, Clock, AlertCircle, AlertTriangle,
   BarChart3, Brain, Maximize2, X, CheckCircle, MessageSquare, Loader2,
   Layers, ArrowDownRight, ArrowUpRight
 } from 'lucide-react';
@@ -127,6 +128,77 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
           <span className="text-white font-mono text-lg">{trade.qty}</span>
         </div>
       </div>
+
+      {/* Métricas de Risco — Stop, RR, Resultado % PL */}
+      {(() => {
+        const entry = Number(trade.entry) || 0;
+        const exit = Number(trade.exit) || 0;
+        const stopLoss = trade.stopLoss != null ? Number(trade.stopLoss) : null;
+        const result = Number(trade.result) || 0;
+        const tickerRule = trade.tickerRule;
+        
+        // Calcula risco em pontos/preço
+        const riskPts = stopLoss != null && entry ? Math.abs(entry - stopLoss) : null;
+        
+        // RR Ratio — usa rrRatio salvo, ou calcula via movement/risk
+        let rrCalc = null;
+        if (stopLoss != null && riskPts > 0) {
+          const movePts = trade.side === 'LONG' ? exit - entry : entry - exit;
+          rrCalc = movePts / riskPts;
+        }
+        const rrRatio = trade.rrRatio || trade.rr || rrCalc;
+        
+        // Resultado % sobre PL (usa planPl se disponível via _planPl prop)
+        const planPl = Number(trade._planPl) || 0;
+        const resultPercentPl = planPl > 0 ? (result / planPl) * 100 : null;
+        
+        // Verifica se há dados para exibir
+        const hasData = stopLoss != null || rrRatio != null || resultPercentPl != null;
+        if (!hasData) return null;
+        
+        return (
+          <div className="grid grid-cols-3 gap-3">
+            {stopLoss != null && (
+              <div className="bg-red-500/5 border border-red-500/20 rounded-xl p-3 text-center">
+                <span className="text-[10px] text-red-400/70 uppercase tracking-wider block mb-1">Stop Loss</span>
+                <span className="text-red-400 font-mono font-bold">{stopLoss}</span>
+                {riskPts != null && (
+                  <span className="text-[10px] text-slate-500 block mt-0.5">
+                    {tickerRule ? `${riskPts.toFixed(tickerRule.tickSize < 1 ? 2 : 0)} pts` : `${riskPts.toFixed(2)}`}
+                  </span>
+                )}
+              </div>
+            )}
+            {rrRatio != null && (
+              <div className={`${rrRatio >= 1 ? 'bg-blue-500/5 border-blue-500/20' : 'bg-amber-500/5 border-amber-500/20'} border rounded-xl p-3 text-center`}>
+                <span className="text-[10px] text-slate-500 uppercase tracking-wider block mb-1">RR</span>
+                <span className={`font-mono font-bold ${rrRatio >= 1 ? 'text-blue-400' : 'text-amber-400'}`}>{Number(rrRatio).toFixed(2)}:1</span>
+              </div>
+            )}
+            {resultPercentPl != null && (
+              <div className={`${resultPercentPl >= 0 ? 'bg-emerald-500/5 border-emerald-500/20' : 'bg-red-500/5 border-red-500/20'} border rounded-xl p-3 text-center`}>
+                <span className="text-[10px] text-slate-500 uppercase tracking-wider block mb-1">% s/ PL</span>
+                <span className={`font-mono font-bold ${resultPercentPl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{resultPercentPl >= 0 ? '+' : ''}{resultPercentPl.toFixed(2)}%</span>
+              </div>
+            )}
+          </div>
+        );
+      })()}
+
+      {/* Red Flags */}
+      {trade.redFlags && Array.isArray(trade.redFlags) && trade.redFlags.length > 0 && (
+        <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-3">
+          <div className="flex items-center gap-2 text-amber-400 mb-2">
+            <AlertTriangle className="w-4 h-4" />
+            <span className="text-xs font-bold uppercase tracking-wider">Violações ({trade.redFlags.length})</span>
+          </div>
+          <div className="space-y-1">
+            {trade.redFlags.map((flag, i) => (
+              <p key={i} className="text-xs text-amber-300/80">• {typeof flag === 'string' ? flag : flag.message || flag.rule || 'Violação'}</p>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Parciais — exibe quando trade tem dados carregados */}
       {trade._loadedPartials?.length > 0 && (

--- a/src/pages/MentorDashboard.jsx
+++ b/src/pages/MentorDashboard.jsx
@@ -87,7 +87,19 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
 
   const filteredPendingTrades = useMemo(() => {
     if (!pendingFilter) return [];
-    return getTradesByStudentAndStatus(pendingFilter.studentEmail, pendingFilter.status);
+    const trades = getTradesByStudentAndStatus(pendingFilter.studentEmail, pendingFilter.status);
+    // Sort crescente: mais antigo primeiro (date → entryTime → createdAt)
+    return [...trades].sort((a, b) => {
+      const dateA = a.date || '';
+      const dateB = b.date || '';
+      if (dateA !== dateB) return dateA.localeCompare(dateB);
+      const timeA = a.entryTime || '';
+      const timeB = b.entryTime || '';
+      if (timeA && timeB) return timeA.localeCompare(timeB);
+      const tsA = a.createdAt?.seconds || 0;
+      const tsB = b.createdAt?.seconds || 0;
+      return tsA - tsB;
+    });
   }, [pendingFilter, getTradesByStudentAndStatus]);
 
   const overallStats = useMemo(() => {
@@ -298,7 +310,11 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
                           <span className="font-bold text-white">{trade.ticker}</span>
                           <span className={`text-xs px-2 py-0.5 rounded ${trade.side === 'LONG' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-red-500/20 text-red-400'}`}>{trade.side}</span>
                         </div>
-                        <p className="text-sm text-slate-500">{trade.date?.split('-').reverse().join('/')} • {trade.setup || 'Sem setup'}</p>
+                        <p className="text-sm text-slate-500">
+                          {trade.date?.split('-').reverse().join('/')}
+                          {trade.entryTime && <span className="font-mono text-slate-600 ml-1">{(() => { try { return trade.entryTime.split('T')[1]?.substring(0, 5); } catch { return ''; } })()}</span>}
+                          {' • '}{trade.setup || 'Sem setup'}
+                        </p>
                       </div>
                     </div>
                     <div className="flex items-center gap-4">

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -1,9 +1,11 @@
 /**
  * StudentDashboard
- * @version 1.2.0
+ * @version 1.3.0
  * @description Dashboard com filtro master de conta, View As Student, extrato emocional
  * 
  * CHANGELOG:
+ * - 1.10.2: Max Drawdown peak-to-trough, WR Planejado vs Clássico, Taxa de Conformidade
+ *   - Fix: delete trade no calendário (trade.id extraction)
  * - 1.2.0: PlanLedgerExtract (extrato emocional) substituindo PlanExtractModal no ícone — Fase 1.5.0
  * - 1.1.0: Filtro master de conta (AccountFilterBar) — tipo + individual, cascata para planos/trades/saldo
  * - 1.0.8: Fix navegação para histórico de feedback (botão "Ver conversa")
@@ -197,14 +199,14 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
       const plan = plans.find(p => p.id === selectedPlanId);
       if (plan) {
         const acc = accounts.find(a => a.id === plan.accountId);
-        return acc ? (acc.currentBalance || acc.initialBalance || 0) : 0;
+        return acc ? (acc.currentBalance ?? acc.initialBalance ?? 0) : 0;
       }
     }
     if (filters.accountId !== 'all') {
       const acc = accounts.find(a => a.id === filters.accountId);
-      return acc ? (acc.currentBalance || acc.initialBalance || 0) : 0;
+      return acc ? (acc.currentBalance ?? acc.initialBalance ?? 0) : 0;
     }
-    return filteredAccountsByType.reduce((sum, acc) => sum + (acc.currentBalance || acc.initialBalance || 0), 0);
+    return filteredAccountsByType.reduce((sum, acc) => sum + (acc.currentBalance ?? acc.initialBalance ?? 0), 0);
   }, [filteredAccountsByType, filters.accountId, accounts, selectedPlanId, plans]);
 
   const drawdown = useMemo(() => {
@@ -212,6 +214,80 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
     const loss = Math.min(0, aggregatedCurrentBalance - aggregatedInitialBalance);
     return Math.abs(loss / aggregatedInitialBalance) * 100;
   }, [aggregatedInitialBalance, aggregatedCurrentBalance]);
+
+  // Max Drawdown: peak-to-trough na série histórica de PL acumulado
+  const maxDrawdownData = useMemo(() => {
+    if (filteredTrades.length === 0) return { maxDD: 0, maxDDPercent: 0, maxDDDate: null };
+    
+    // Ordenar por data ASC
+    const sorted = [...filteredTrades].sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+    
+    let cumPnL = 0;
+    let peak = 0;
+    let maxDD = 0;
+    let maxDDDate = null;
+    
+    for (const trade of sorted) {
+      cumPnL += Number(trade.result) || 0;
+      if (cumPnL > peak) peak = cumPnL;
+      const dd = peak - cumPnL;
+      if (dd > maxDD) {
+        maxDD = dd;
+        maxDDDate = trade.date;
+      }
+    }
+    
+    const maxDDPercent = aggregatedInitialBalance > 0 ? (maxDD / aggregatedInitialBalance) * 100 : 0;
+    return { maxDD, maxDDPercent, maxDDDate };
+  }, [filteredTrades, aggregatedInitialBalance]);
+
+  // WR Planejado: trade vencedor somente se rrRatio >= plan.rrTarget
+  const winRatePlanned = useMemo(() => {
+    if (filteredTrades.length === 0 || plansToShow.length === 0) return null;
+    
+    const plansMap = {};
+    plansToShow.forEach(p => { plansMap[p.id] = p; });
+    
+    let eligible = 0;
+    let disciplinedWins = 0;
+    
+    for (const trade of filteredTrades) {
+      const plan = plansMap[trade.planId];
+      if (!plan || !plan.rrTarget) continue;
+      eligible++;
+      
+      // Trade vencedor apenas se alcançou o RR target do plano
+      const rrAchieved = Number(trade.rrRatio || trade.rr || 0);
+      if (trade.result > 0 && rrAchieved >= Number(plan.rrTarget)) {
+        disciplinedWins++;
+      }
+    }
+    
+    if (eligible === 0) return null;
+    return {
+      rate: (disciplinedWins / eligible) * 100,
+      eligible,
+      disciplinedWins,
+      gap: stats.winRate - ((disciplinedWins / eligible) * 100)
+    };
+  }, [filteredTrades, plansToShow, stats.winRate]);
+
+  // Taxa de conformidade: % trades sem red flags
+  const complianceRate = useMemo(() => {
+    if (filteredTrades.length === 0) return null;
+    
+    const withFlags = filteredTrades.filter(t => 
+      t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0)
+    ).length;
+    
+    const compliant = filteredTrades.length - withFlags;
+    return {
+      rate: (compliant / filteredTrades.length) * 100,
+      compliant,
+      total: filteredTrades.length,
+      violations: withFlags
+    };
+  }, [filteredTrades]);
 
   // Handler para navegar para histórico de feedback
   const handleViewFeedbackHistory = (trade) => {
@@ -487,16 +563,42 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
           <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${stats.winRate >= 50 ? 'bg-blue-500/20' : 'bg-amber-500/20'}`}><Target className={`w-5 h-5 ${stats.winRate >= 50 ? 'text-blue-400' : 'text-amber-400'}`} /></div>
           <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Win Rate</p>
           <p className="text-xl lg:text-2xl font-bold text-white">{formatPercent(stats.winRate)}</p>
+          {winRatePlanned && (
+            <div className="mt-1.5 flex items-center gap-1.5" title={`WR Planejado: ${winRatePlanned.rate.toFixed(1)}% (${winRatePlanned.disciplinedWins}/${winRatePlanned.eligible} trades atingiram RR target)`}>
+              <span className="text-[11px] text-slate-500">Planejado:</span>
+              <span className={`text-xs font-bold font-mono ${winRatePlanned.rate >= stats.winRate ? 'text-emerald-400' : 'text-amber-400'}`}>{winRatePlanned.rate.toFixed(1)}%</span>
+              {winRatePlanned.gap > 0 && <span className="text-[11px] text-amber-400/70">↓{winRatePlanned.gap.toFixed(0)}%</span>}
+            </div>
+          )}
         </div>
         <div className="glass-card p-5 relative overflow-hidden">
           <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${stats.profitFactor >= 1 ? 'bg-purple-500/20' : 'bg-red-500/20'}`}><Activity className={`w-5 h-5 ${stats.profitFactor >= 1 ? 'text-purple-400' : 'text-red-400'}`} /></div>
           <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Profit Factor</p>
           <p className="text-xl lg:text-2xl font-bold text-white">{stats.profitFactor === Infinity ? '∞' : stats.profitFactor.toFixed(2)}</p>
+          {complianceRate && (
+            <div className="mt-1.5 flex items-center gap-1.5" title={`${complianceRate.compliant}/${complianceRate.total} trades sem violações`}>
+              <span className="text-[11px] text-slate-500">Conformidade:</span>
+              <span className={`text-xs font-bold font-mono ${complianceRate.rate >= 80 ? 'text-emerald-400' : complianceRate.rate >= 60 ? 'text-amber-400' : 'text-red-400'}`}>{complianceRate.rate.toFixed(0)}%</span>
+              {complianceRate.violations > 0 && <span className="text-[11px] text-red-400/70">({complianceRate.violations} ⚠️)</span>}
+            </div>
+          )}
         </div>
         <div className="glass-card p-5 relative overflow-hidden">
           <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${drawdown < 5 ? 'bg-emerald-500/20' : 'bg-red-500/20'}`}><TrendingDown className={`w-5 h-5 ${drawdown < 5 ? 'text-emerald-400' : 'text-red-400'}`} /></div>
           <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Drawdown</p>
           <p className={`text-xl lg:text-2xl font-bold ${drawdown < 5 ? 'text-emerald-400' : 'text-red-400'}`}>-{drawdown.toFixed(1)}%</p>
+          {maxDrawdownData.maxDD > 0 && (
+            <div className="mt-1.5 space-y-0.5" title={maxDrawdownData.maxDDDate ? `Pior vale em ${maxDrawdownData.maxDDDate.split('-').reverse().join('/')}` : ''}>
+              <div className="flex items-center gap-1.5">
+                <span className="text-[11px] text-slate-500">Max DD:</span>
+                <span className="text-xs font-bold font-mono text-red-400">-{maxDrawdownData.maxDDPercent.toFixed(1)}%</span>
+                <span className="text-[11px] text-red-400/70">({formatCurrency(-maxDrawdownData.maxDD)})</span>
+              </div>
+              {maxDrawdownData.maxDDDate && (
+                <span className="text-[11px] text-slate-600 font-mono">{maxDrawdownData.maxDDDate.split('-').reverse().join('/')}</span>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -532,7 +634,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
               plans={plans}
               onViewTrade={setViewingTrade} 
               onEditTrade={(t) => { setEditingTrade(t); setShowAddModal(true); }} 
-              onDeleteTrade={deleteTrade} 
+              onDeleteTrade={(trade) => deleteTrade(trade.id || trade)} 
             />
           </div>
         </div>


### PR DESCRIPTION
## fix(v1.10.2): Sort, planId lock, Max DD, WR Planejado, conformidade, mentor feedback

### Resumo

Hotfix que corrige ordenação de trades, trava planId em edição, adiciona métricas avançadas ao dashboard (Max Drawdown peak-to-trough, Win Rate Planejado, Taxa de Conformidade), limpa redundância no feedback (RO% removido), e corrige exibição de horário/parciais no fluxo do mentor.

---

### Versões

| Componente | De | Para | Tipo |
|------------|------|------|------|
| Frontend | v1.10.1 | v1.10.2 | PATCH |

---

### Fixes e Features

#### 1. TradesList — Sort interno ASC
**Bug:** Trades vinham do Firestore DESC e callers como o calendário do StudentDashboard não reordenavam.
**Fix:** Sort interno `date → entryTime → createdAt` ASC. Todo caller se beneficia automaticamente.

#### 2. AddTradeModal — planId travado em edit
**Fix:** Em modo edição, plano exibe como `div` desabilitada com ícone Lock. Tooltip: "Para mudar o plano, exclua e recrie o trade". Zero regressão.

#### 3. StudentDashboard — Delete fix
**Bug:** `onDeleteTrade(trade)` passava objeto, `useTrades.deleteTrade` esperava string.
**Fix:** `onDeleteTrade={(trade) => deleteTrade(trade.id || trade)}`.

#### 4. StudentDashboard — Max Drawdown peak-to-trough
**Feature:** Algoritmo O(n) calcula pior vale histórico na série de PL cumulativo. Exibe Max DD %, valor absoluto e data do vale. Tooltip com data formatada.

#### 5. StudentDashboard — WR Planejado vs Clássico
**Feature:** `trades.filter(t => result > 0 AND rrRatio >= plan.rrTarget)` — mede disciplina vs "mão de alface". Inline no card Win Rate com gap indicator.

#### 6. StudentDashboard — Taxa de Conformidade
**Feature:** `trades sem redFlags / total`. Semáforo: ≥80% verde, 60-80% amarelo, <60% vermelho. Inline no card Profit Factor.

#### 7. StudentDashboard — Fontes sub-indicadores
**Fix visual:** Labels `text-[11px]`, valores `text-xs`, data Max DD `text-[11px]` (antes `text-[10px]`/`text-[9px]`).

#### 8. FeedbackPage — RO% removido, grid 3 colunas
**Fix:** RO% era redundante com RR (mesma informação em escala diferente). Grid passa de `cols-4` para `cols-3`. Tríade final: Stop Loss (pts), RR (ratio), % s/ PL.

#### 9. FeedbackPage — Red Flags com lista de violações
**Feature:** Seção com ícone AlertTriangle, contagem e lista de violações do trade.

#### 10. MentorDashboard — Horário na lista de trades
**Bug:** Lista "Aguardando Feedback" exibia só data e setup, sem horário.
**Fix:** Adicionado `HH:MM` (font-mono) ao lado da data.

#### 11. MentorDashboard — Sort ASC nos trades pendentes
**Bug:** `filteredPendingTrades` não tinha ordenação — herdava DESC do Firestore.
**Fix:** Sort ASC `date → entryTime → createdAt`.

#### 12. App.jsx — getPartials para FeedbackPage do mentor
**Bug:** Parciais não apareciam no feedback quando mentor acessava via MentorDashboard.
**Fix:** `getPartials` adicionado ao destructuring do `useTrades()` e passado como prop.

---

### Arquivos modificados (6)

| Arquivo | Mudanças |
|---------|----------|
| `src/components/TradesList.jsx` | Sort interno ASC |
| `src/components/AddTradeModal.jsx` | planId lock em edit mode |
| `src/pages/StudentDashboard.jsx` | Delete fix, Max DD, WR Planejado, Conformidade, fontes |
| `src/pages/FeedbackPage.jsx` | RO% removido, grid 3 cols, Red Flags |
| `src/pages/MentorDashboard.jsx` | Horário + sort ASC em filteredPendingTrades |
| `src/App.jsx` | getPartials destructured + prop FeedbackPage |

### Retrocompatibilidade

- Sort no TradesList é transparente para todos os callers
- planId lock só afeta modo edit — criação inalterada
- Métricas novas (Max DD, WR Planejado, Conformidade) são aditivas — sem dados, não renderizam
- RO% removido sem impacto funcional (RR cobre a mesma informação)
- getPartials é opcional na FeedbackPage — callers sem a prop continuam funcionando

### Teste

- [x] Calendário StudentDashboard: trades em ordem crescente
- [x] Edit trade: plano aparece desabilitado com Lock
- [x] Delete trade pelo calendário: funciona sem duplicar saldo
- [x] Max DD: mostra pior vale histórico com data
- [x] WR Planejado: aparece inline no card Win Rate
- [x] Conformidade: aparece inline no card Profit Factor com semáforo
- [x] FeedbackPage mentor: Stop/RR/%PL (sem RO%), Red Flags, parciais visíveis
- [x] MentorDashboard "Aguardando Feedback": trades com horário, ordem crescente
