### PR TITLE
Feature/issue 60 feedback image

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,7 +78,8 @@ const AppContent = () => {
     allTrades,
     addFeedbackComment,
     updateTradeStatus,
-    getPartials
+    getPartials,
+    uploadFeedbackImage
   } = useTrades();
   const { plans } = usePlans();
 
@@ -155,8 +156,8 @@ const AppContent = () => {
   };
 
   // Handler para adicionar comentário no FeedbackPage
-  const handleAddFeedbackComment = async (tradeId, content, isQuestion) => {
-    const updatedTrade = await addFeedbackComment(tradeId, content, isQuestion);
+  const handleAddFeedbackComment = async (tradeId, content, isQuestion, imageUrl = null) => {
+    const updatedTrade = await addFeedbackComment(tradeId, content, isQuestion, imageUrl);
     // Atualiza o trade local para refletir mudanças imediatas
     setFeedbackTrade(prev => ({
       ...prev,
@@ -201,6 +202,7 @@ const AppContent = () => {
           onAddComment={handleAddFeedbackComment}
           onUpdateStatus={handleUpdateTradeStatus}
           getPartials={getPartials}
+          uploadFeedbackImage={uploadFeedbackImage}
         />
       );
     }

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -424,7 +424,7 @@ export const useTrades = (overrideStudentId = null) => {
   /**
    * Adiciona comentário ao histórico com transição de status automática
    */
-  const addFeedbackComment = useCallback(async (tradeId, content, isQuestion = false) => {
+  const addFeedbackComment = useCallback(async (tradeId, content, isQuestion = false, imageUrl = null) => {
     if (!user) throw new Error('Auth required');
     
     const tradeRef = doc(db, 'trades', tradeId);
@@ -457,6 +457,11 @@ export const useTrades = (overrideStudentId = null) => {
       isQuestion,
       createdAt: new Date().toISOString(),
     };
+
+    // Inclui imageUrl no comment se presente
+    if (imageUrl) {
+      comment.imageUrl = imageUrl;
+    }
     
     const updateData = {
       feedbackHistory: arrayUnion(comment),
@@ -471,7 +476,7 @@ export const useTrades = (overrideStudentId = null) => {
     }
     
     await updateDoc(tradeRef, updateData);
-    console.log(`[useTrades] Feedback: ${trade.status} → ${newStatus}`);
+    console.log(`[useTrades] Feedback: ${trade.status} → ${newStatus}${imageUrl ? ' (com imagem)' : ''}`);
     
     return { 
       ...trade, id: tradeId, ...updateData, 
@@ -530,6 +535,25 @@ export const useTrades = (overrideStudentId = null) => {
     console.log(`[useTrades] Bulk feedback: ${tradeIds.length} trades → REVIEWED`);
     return { success: true, count: tradeIds.length };
   }, [user, isMentor]);
+
+  /**
+   * Faz upload de imagem de feedback para Firebase Storage
+   * @param {File} file - Arquivo de imagem
+   * @param {string} tradeId - ID do trade para organizar no Storage
+   * @returns {Promise<string>} URL da imagem
+   */
+  const uploadFeedbackImage = useCallback(async (file, tradeId) => {
+    if (!user) throw new Error('Auth required');
+    if (!file) throw new Error('Arquivo obrigatório');
+
+    const ext = file.name?.split('.').pop() || 'png';
+    const path = `feedback/${tradeId}/${Date.now()}_${Math.random().toString(36).substr(2, 6)}.${ext}`;
+    const storageRef = ref(storage, path);
+    const snap = await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(snap.ref);
+    console.log(`[useTrades] Feedback image uploaded: ${path}`);
+    return url;
+  }, [user]);
 
   // ============================================
   // SISTEMA DE PARCIAIS v1.6.0
@@ -736,7 +760,7 @@ export const useTrades = (overrideStudentId = null) => {
   return { 
     trades, allTrades, loading, error, 
     addTrade, updateTrade, deleteTrade, 
-    addFeedback, addFeedbackComment, updateTradeStatus, addBulkFeedback,
+    addFeedback, addFeedbackComment, updateTradeStatus, addBulkFeedback, uploadFeedbackImage,
     // Parciais
     addPartial, updatePartial, deletePartial, getPartials, recalculateFromPartials,
     // Helpers

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -5,6 +5,12 @@
  * @see version.js para versão do produto
  * 
  * CHANGELOG:
+ * - 1.13.0: Issue #60 — Imagem no feedback via copy/paste (mentor only)
+ *   - Paste handler no textarea intercepta imagem do clipboard
+ *   - Preview inline com botão remover
+ *   - Upload para Firebase Storage (feedback/{tradeId}/)
+ *   - imageUrl salvo no comment do feedbackHistory
+ *   - ChatMessage renderiza imagem inline com fullscreen
  * - 1.10.2: TradeInfoCard exibe Stop Loss, RR, Resultado % sobre PL, Red Flags (RO% removido — redundante com RR)
  * - 1.4.0: Prop embedded para uso dentro de StudentFeedbackPage master-detail
  *   - embedded=true: sem padding, sem header, sem botão voltar, grid 2 colunas (info + chat)
@@ -24,7 +30,7 @@ import {
   ChevronLeft, Send, HelpCircle, Lock, User, GraduationCap,
   Calendar, TrendingUp, TrendingDown, Clock, AlertCircle, AlertTriangle,
   BarChart3, Brain, Maximize2, X, CheckCircle, MessageSquare, Loader2,
-  Layers, ArrowDownRight, ArrowUpRight
+  Layers, ArrowDownRight, ArrowUpRight, ImageIcon
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import DebugBadge from '../components/DebugBadge';
@@ -273,7 +279,7 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
   );
 };
 
-const ChatMessage = ({ message }) => {
+const ChatMessage = ({ message, onImageClick }) => {
   const isFromMentor = message.authorRole === 'mentor';
   const formatTime = (timestamp) => {
     if (!timestamp) return '';
@@ -290,8 +296,17 @@ const ChatMessage = ({ message }) => {
           {isFromMentor ? <GraduationCap className="w-4 h-4 text-purple-400" /> : <User className="w-4 h-4 text-blue-400" />}
           <span className={`text-sm font-medium ${isFromMentor ? 'text-purple-400' : 'text-blue-400'}`}>{message.authorName || (isFromMentor ? 'Mentor' : 'Aluno')}</span>
           {message.isQuestion && <span className="px-2 py-0.5 bg-amber-500/20 text-amber-400 text-xs rounded-full">Dúvida</span>}
+          {message.isBulk && <span className="px-2 py-0.5 bg-slate-700 text-slate-400 text-xs rounded-full">Em massa</span>}
         </div>
-        <p className="text-slate-200 whitespace-pre-wrap">{message.content}</p>
+        {message.content && <p className="text-slate-200 whitespace-pre-wrap">{message.content}</p>}
+        {message.imageUrl && (
+          <div className="mt-2 relative rounded-xl overflow-hidden border border-slate-700/50 cursor-pointer group" onClick={() => onImageClick?.(message.imageUrl)}>
+            <img src={message.imageUrl} alt="Feedback" className="max-w-full max-h-64 object-contain rounded-xl" />
+            <div className="absolute inset-0 bg-slate-950/60 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+              <Maximize2 className="w-6 h-6 text-white" />
+            </div>
+          </div>
+        )}
         <span className="text-xs text-slate-500 mt-2 block">{formatTime(message.createdAt)}</span>
       </div>
     </div>
@@ -302,12 +317,16 @@ const ChatMessage = ({ message }) => {
 // MAIN COMPONENT
 // ============================================
 
-const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = false, embedded = false, getPartials }) => {
+const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = false, embedded = false, getPartials, uploadFeedbackImage }) => {
   const { user, isMentor } = useAuth();
   const [comment, setComment] = useState('');
   const [fullscreenImage, setFullscreenImage] = useState(null);
   const [sending, setSending] = useState(false);
   const messagesEndRef = useRef(null);
+
+  // === Image Paste State (mentor only) ===
+  const [pastedImage, setPastedImage] = useState(null); // { file: File, preview: string }
+  const textareaRef = useRef(null);
 
   // Fetch parciais quando trade muda
   const [tradeWithPartials, setTradeWithPartials] = useState(null);
@@ -372,13 +391,49 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
 
   // ========== HANDLERS ==========
 
-  // Mentor envia feedback/resposta
+  // Paste handler — intercepta imagem colada no textarea (mentor only)
+  const handlePaste = (e) => {
+    if (!isMentor()) return;
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (!file) return;
+        
+        // Limite 5MB
+        if (file.size > 5 * 1024 * 1024) {
+          alert('Imagem muito grande. Máximo 5MB.');
+          return;
+        }
+
+        const preview = URL.createObjectURL(file);
+        setPastedImage({ file, preview });
+        return;
+      }
+    }
+  };
+
+  // Limpa preview ao descartar
+  const handleRemoveImage = () => {
+    if (pastedImage?.preview) URL.revokeObjectURL(pastedImage.preview);
+    setPastedImage(null);
+  };
+
+  // Mentor envia feedback/resposta (com imagem opcional)
   const handleMentorSend = async () => {
-    if (!comment.trim() || sending) return;
+    if ((!comment.trim() && !pastedImage) || sending) return;
     setSending(true);
     try {
-      await onAddComment(trade.id, comment, false);
+      let imageUrl = null;
+      if (pastedImage?.file && uploadFeedbackImage) {
+        imageUrl = await uploadFeedbackImage(pastedImage.file, trade.id);
+      }
+      await onAddComment(trade.id, comment || '', false, imageUrl);
       setComment('');
+      handleRemoveImage();
     } catch (err) {
       console.error('Erro:', err);
     } finally {
@@ -492,7 +547,7 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                   <h3 className="text-slate-400 font-medium">Aguardando primeiro feedback</h3>
                 </div>
               ) : (
-                messages.map((msg, idx) => <ChatMessage key={msg.id || idx} message={msg} />)
+                messages.map((msg, idx) => <ChatMessage key={msg.id || idx} message={msg} onImageClick={setFullscreenImage} />)
               )}
               <div ref={messagesEndRef} />
             </div>
@@ -506,10 +561,21 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
               </div>
             ) : (
               <div className="flex-none p-3 border-t border-slate-800">
+                {/* Image Preview (mentor only, embedded) */}
+                {pastedImage && canMentorComment && (
+                  <div className="mb-2 relative inline-block">
+                    <img src={pastedImage.preview} alt="Preview" className="max-h-24 rounded-lg border border-slate-700" />
+                    <button onClick={handleRemoveImage} className="absolute -top-2 -right-2 p-1 bg-red-500 hover:bg-red-600 text-white rounded-full transition-colors">
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                )}
+
                 <textarea 
                   value={comment} 
                   onChange={(e) => setComment(e.target.value)} 
-                  placeholder={getPlaceholder()} 
+                  onPaste={handlePaste}
+                  placeholder={canMentorComment ? `${getPlaceholder()} (Ctrl+V para colar imagem)` : getPlaceholder()} 
                   disabled={(!canMentorComment && !canStudentAct) || sending} 
                   rows={2}
                   className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-white placeholder-slate-500 resize-none focus:border-blue-500 focus:outline-none disabled:opacity-50 text-sm mb-2"
@@ -519,11 +585,12 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                   <div className="flex justify-end">
                     <button 
                       onClick={handleMentorSend}
-                      disabled={!comment.trim() || sending}
+                      disabled={(!comment.trim() && !pastedImage) || sending}
                       className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium disabled:opacity-50 transition-colors flex items-center gap-2 text-sm"
                     >
-                      {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+                      {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : pastedImage ? <ImageIcon className="w-4 h-4" /> : <Send className="w-4 h-4" />}
                       {status === STATUS.OPEN ? 'Enviar Feedback' : 'Responder'}
+                      {pastedImage && ' + Img'}
                     </button>
                   </div>
                 )}
@@ -630,7 +697,7 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                 <h3 className="text-slate-400 font-medium">Aguardando primeiro feedback</h3>
               </div>
             ) : (
-              messages.map((msg, idx) => <ChatMessage key={msg.id || idx} message={msg} />)
+              messages.map((msg, idx) => <ChatMessage key={msg.id || idx} message={msg} onImageClick={setFullscreenImage} />)
             )}
             <div ref={messagesEndRef} />
           </div>
@@ -644,11 +711,23 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
             </div>
           ) : (
             <div className="flex-none p-4 border-t border-slate-800">
+              {/* Image Preview (mentor only) */}
+              {pastedImage && canMentorComment && (
+                <div className="mb-3 relative inline-block">
+                  <img src={pastedImage.preview} alt="Preview" className="max-h-32 rounded-lg border border-slate-700" />
+                  <button onClick={handleRemoveImage} className="absolute -top-2 -right-2 p-1 bg-red-500 hover:bg-red-600 text-white rounded-full transition-colors">
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+              )}
+
               {/* Textarea */}
               <textarea 
+                ref={textareaRef}
                 value={comment} 
                 onChange={(e) => setComment(e.target.value)} 
-                placeholder={getPlaceholder()} 
+                onPaste={handlePaste}
+                placeholder={canMentorComment ? `${getPlaceholder()} (Ctrl+V para colar imagem)` : getPlaceholder()} 
                 disabled={(!canMentorComment && !canStudentAct) || sending} 
                 rows={2}
                 className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-3 text-white placeholder-slate-500 resize-none focus:border-blue-500 focus:outline-none disabled:opacity-50 mb-3"
@@ -659,11 +738,12 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                 <div className="flex justify-end">
                   <button 
                     onClick={handleMentorSend}
-                    disabled={!comment.trim() || sending}
+                    disabled={(!comment.trim() && !pastedImage) || sending}
                     className="px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium disabled:opacity-50 transition-colors flex items-center gap-2"
                   >
-                    {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Send className="w-4 h-4" />}
+                    {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : pastedImage ? <ImageIcon className="w-4 h-4" /> : <Send className="w-4 h-4" />}
                     {status === STATUS.OPEN ? 'Enviar Feedback' : 'Responder Dúvida'}
+                    {pastedImage && ' + Imagem'}
                   </button>
                 </div>
               )}

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -424,18 +424,28 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
 
   // Mentor envia feedback/resposta (com imagem opcional)
   const handleMentorSend = async () => {
-    if ((!comment.trim() && !pastedImage) || sending) return;
+    const hasText = comment.trim().length > 0;
+    const hasImage = !!pastedImage?.file;
+    if ((!hasText && !hasImage) || sending) return;
+    
     setSending(true);
     try {
       let imageUrl = null;
-      if (pastedImage?.file && uploadFeedbackImage) {
-        imageUrl = await uploadFeedbackImage(pastedImage.file, trade.id);
+      if (hasImage && uploadFeedbackImage) {
+        try {
+          imageUrl = await uploadFeedbackImage(pastedImage.file, trade.id);
+        } catch (uploadErr) {
+          console.error('[FeedbackPage] Upload error:', uploadErr);
+          alert('Erro ao enviar imagem. Tente novamente.');
+          setSending(false);
+          return;
+        }
       }
       await onAddComment(trade.id, comment || '', false, imageUrl);
       setComment('');
       handleRemoveImage();
     } catch (err) {
-      console.error('Erro:', err);
+      console.error('[FeedbackPage] Send error:', err);
     } finally {
       setSending(false);
     }
@@ -585,7 +595,7 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                   <div className="flex justify-end">
                     <button 
                       onClick={handleMentorSend}
-                      disabled={(!comment.trim() && !pastedImage) || sending}
+                      disabled={(!comment.trim() && !pastedImage?.file) || sending}
                       className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium disabled:opacity-50 transition-colors flex items-center gap-2 text-sm"
                     >
                       {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : pastedImage ? <ImageIcon className="w-4 h-4" /> : <Send className="w-4 h-4" />}
@@ -738,7 +748,7 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                 <div className="flex justify-end">
                   <button 
                     onClick={handleMentorSend}
-                    disabled={(!comment.trim() && !pastedImage) || sending}
+                    disabled={(!comment.trim() && !pastedImage?.file) || sending}
                     className="px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium disabled:opacity-50 transition-colors flex items-center gap-2"
                   >
                     {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : pastedImage ? <ImageIcon className="w-4 h-4" /> : <Send className="w-4 h-4" />}

--- a/src/pages/MentorDashboard.jsx
+++ b/src/pages/MentorDashboard.jsx
@@ -98,17 +98,17 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
   const filteredPendingTrades = useMemo(() => {
     if (!pendingFilter) return [];
     const trades = getTradesByStudentAndStatus(pendingFilter.studentEmail, pendingFilter.status);
-    // Sort crescente: mais antigo primeiro (date → entryTime → createdAt)
+    // Sort decrescente: mais recente primeiro (date → entryTime → createdAt)
     return [...trades].sort((a, b) => {
       const dateA = a.date || '';
       const dateB = b.date || '';
-      if (dateA !== dateB) return dateA.localeCompare(dateB);
+      if (dateA !== dateB) return dateB.localeCompare(dateA);
       const timeA = a.entryTime || '';
       const timeB = b.entryTime || '';
-      if (timeA && timeB) return timeA.localeCompare(timeB);
+      if (timeA && timeB) return timeB.localeCompare(timeA);
       const tsA = a.createdAt?.seconds || 0;
       const tsB = b.createdAt?.seconds || 0;
-      return tsA - tsB;
+      return tsB - tsA;
     });
   }, [pendingFilter, getTradesByStudentAndStatus]);
 
@@ -437,7 +437,11 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
                         <div className="max-h-32 overflow-y-auto space-y-1 bg-slate-800/30 rounded-xl p-3">
                           {filteredPendingTrades.filter(t => selectedTradeIds.has(t.id)).map(t => (
                             <div key={t.id} className="flex items-center justify-between text-sm">
-                              <span className="text-slate-300">{t.ticker} <span className="text-slate-500">{t.date?.split('-').reverse().join('/')}</span></span>
+                              <span className="text-slate-300">
+                                {t.ticker}
+                                {' '}<span className="text-slate-500">{t.date?.split('-').reverse().join('/')}</span>
+                                {t.entryTime && <span className="text-slate-600 font-mono ml-1">{(() => { try { return t.entryTime.split('T')[1]?.substring(0, 5); } catch { return ''; } })()}</span>}
+                              </span>
                               <span className={t.result >= 0 ? 'text-emerald-400' : 'text-red-400'}>{t.result >= 0 ? '+' : ''}{formatCurrency(t.result)}</span>
                             </div>
                           ))}
@@ -454,17 +458,17 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
                         />
 
                         {/* Confirmação */}
-                        <label className="flex items-start gap-3 cursor-pointer group">
-                          <button onClick={() => setBulkConfirmed(!bulkConfirmed)} className="flex-shrink-0 mt-0.5">
+                        <div className="flex items-start gap-3 cursor-pointer group" onClick={() => setBulkConfirmed(!bulkConfirmed)}>
+                          <div className="flex-shrink-0 mt-0.5">
                             {bulkConfirmed
                               ? <CheckSquare className="w-5 h-5 text-blue-400" />
                               : <Square className="w-5 h-5 text-slate-500 group-hover:text-slate-300" />
                             }
-                          </button>
+                          </div>
                           <span className="text-sm text-slate-400">
                             Confirmo aplicar este feedback para <strong className="text-white">{selectedTradeIds.size} trade{selectedTradeIds.size > 1 ? 's' : ''}</strong>. O texto será adicionado ao histórico de cada trade.
                           </span>
-                        </label>
+                        </div>
 
                         {/* Botões */}
                         <div className="flex gap-3 justify-end">

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,12 @@
  * @description SemVer 2.0.0 — MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
  * 
  * CHANGELOG:
+ * - 1.13.0: Issue #60 — Imagem no feedback via copy/paste (mentor only)
+ *   - Paste handler no textarea do FeedbackPage
+ *   - Upload para Firebase Storage (feedback/{tradeId}/)
+ *   - imageUrl no feedbackHistory comment
+ *   - ChatMessage renderiza imagem inline com fullscreen
+ *   - uploadFeedbackImage no useTrades
  * - 1.12.0: Issue #9 — Feedback em massa para múltiplos trades
  *   - addBulkFeedback no useTrades (Firestore writeBatch)
  *   - UI de seleção múltipla no MentorDashboard (checkboxes, select all)
@@ -31,7 +37,7 @@
  */
 export const VERSION = {
   major: 1,
-  minor: 12,
+  minor: 13,
   patch: 0,
   prerelease: null,
   build: '20260302',

--- a/storage.rules
+++ b/storage.rules
@@ -18,5 +18,10 @@ service firebase.storage {
       allow read: if request.auth != null;
       allow write: if request.auth != null;
     }
+    // Documentos gerais
+    match /feedback/{tradeId}/{allPaths=**} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null;
+    }
   }
 }


### PR DESCRIPTION
## feat: Imagem no Feedback via Copy/Paste (Issue #60)

Closes #60

### O que foi feito

- **FeedbackPage.jsx**: Ctrl+V no textarea intercepta imagem do clipboard (mentor only)
  - Preview inline com botão remover, limite 5MB
  - Suporta envio de texto + imagem juntos ou só imagem
  - ChatMessage renderiza imagem inline, clicável para fullscreen
  - Funciona em modo standalone e embedded
- **useTrades.js**: `uploadFeedbackImage(file, tradeId)` → Firebase Storage `feedback/{tradeId}/`
  - `addFeedbackComment` aceita `imageUrl` opcional → salva no comment do feedbackHistory
- **App.jsx**: Passa `uploadFeedbackImage` e `imageUrl` no handler

### Como testar
1. Login como mentor → abrir feedback de qualquer trade
2. Copiar imagem (screenshot ou Ctrl+C em imagem)
3. Ctrl+V no textarea → preview aparece
4. Enviar → imagem aparece no chat, clicável para fullscreen
5. Verificar no Firebase Storage: pasta `feedback/{tradeId}/`