### PR TITLE
Feature/issue 43 mentor plans

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+*.jsx text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.md text eol=lf

--- a/src/__tests__/utils/mentorPlanAudit.test.js
+++ b/src/__tests__/utils/mentorPlanAudit.test.js
@@ -1,0 +1,114 @@
+/**
+ * Tests: mentorPlanAudit
+ * @description Testa lógica de auditoria quando mentor edita plano do aluno
+ * 
+ * Cenários:
+ * - Detecção de campos alterados
+ * - Geração de auditInfo correta
+ * - Edge cases: nenhum campo alterado, todos alterados
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectChangedFields, buildAuditInfo } from '../../utils/mentorPlanAudit';
+
+describe('detectChangedFields', () => {
+
+  const basePlan = {
+    name: 'MFF Sobrevivência 1k',
+    pl: 1000,
+    riskPerOperation: 6,
+    rrTarget: 2,
+    periodGoal: 20,
+    periodStop: 12,
+    cycleGoal: 75,
+    cycleStop: 50,
+    adjustmentCycle: 'Semanal',
+    operationPeriod: 'Diário',
+  };
+
+  it('nenhum campo alterado → array vazio', () => {
+    const result = detectChangedFields(basePlan, { ...basePlan });
+    expect(result).toHaveLength(0);
+  });
+
+  it('1 campo alterado (riskPerOperation)', () => {
+    const newData = { ...basePlan, riskPerOperation: 4 };
+    const result = detectChangedFields(basePlan, newData);
+    expect(result).toEqual(['riskPerOperation']);
+  });
+
+  it('múltiplos campos alterados', () => {
+    const newData = { ...basePlan, pl: 2000, cycleStop: 30, name: 'Novo Nome' };
+    const result = detectChangedFields(basePlan, newData);
+    expect(result).toContain('pl');
+    expect(result).toContain('cycleStop');
+    expect(result).toContain('name');
+    expect(result).toHaveLength(3);
+  });
+
+  it('todos os campos alterados', () => {
+    const newData = {
+      name: 'Outro',
+      pl: 999,
+      riskPerOperation: 1,
+      rrTarget: 3,
+      periodGoal: 10,
+      periodStop: 5,
+      cycleGoal: 50,
+      cycleStop: 25,
+      adjustmentCycle: 'Mensal',
+      operationPeriod: 'Semanal',
+    };
+    const result = detectChangedFields(basePlan, newData);
+    expect(result).toHaveLength(10);
+  });
+
+  it('comparação string vs number (pl: 1000 vs "1000") → sem mudança', () => {
+    const newData = { ...basePlan, pl: '1000' };
+    const result = detectChangedFields(basePlan, newData);
+    expect(result).toHaveLength(0);
+  });
+
+  it('valor zero vs string vazia → detecta mudança', () => {
+    const planWithZero = { ...basePlan, periodGoal: 0 };
+    const newData = { ...basePlan, periodGoal: '' };
+    const result = detectChangedFields(planWithZero, newData);
+    expect(result).toContain('periodGoal');
+  });
+});
+
+describe('buildAuditInfo', () => {
+
+  const basePlan = {
+    name: 'Plano A',
+    pl: 1000,
+    riskPerOperation: 6,
+    rrTarget: 2,
+    periodGoal: 20,
+    periodStop: 12,
+    cycleGoal: 75,
+    cycleStop: 50,
+    adjustmentCycle: 'Semanal',
+    operationPeriod: 'Diário',
+  };
+
+  it('gera auditInfo com editedBy mentor', () => {
+    const newData = { ...basePlan, riskPerOperation: 3 };
+    const audit = buildAuditInfo('mentor@test.com', basePlan, newData);
+
+    expect(audit.editedBy).toBe('mentor');
+    expect(audit.email).toBe('mentor@test.com');
+    expect(audit.changedFields).toEqual(['riskPerOperation']);
+  });
+
+  it('sem alterações → changedFields vazio', () => {
+    const audit = buildAuditInfo('mentor@test.com', basePlan, { ...basePlan });
+    expect(audit.changedFields).toHaveLength(0);
+  });
+
+  it('preserva email do mentor', () => {
+    const audit = buildAuditInfo('marcio.portes@me.com', basePlan, { ...basePlan, pl: 5000 });
+    expect(audit.email).toBe('marcio.portes@me.com');
+    expect(audit.changedFields).toContain('pl');
+  });
+});

--- a/src/hooks/usePlans.js
+++ b/src/hooks/usePlans.js
@@ -21,7 +21,8 @@ import {
   doc,
   getDocs,
   serverTimestamp,
-  orderBy
+  orderBy,
+  arrayUnion
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
@@ -149,14 +150,43 @@ export const usePlans = (overrideStudentId = null) => {
 
   /**
    * Atualizar plano
+   * @param {string} planId
+   * @param {object} planData
+   * @param {object} [auditInfo] - { editedBy: 'mentor'|'student', email, changedFields }
    */
-  const updatePlan = useCallback(async (planId, planData) => {
+  const updatePlan = useCallback(async (planId, planData, auditInfo = null) => {
     try {
       const planRef = doc(db, 'plans', planId);
-      await updateDoc(planRef, {
+      const updateData = {
         ...planData,
         updatedAt: serverTimestamp()
-      });
+      };
+
+      // Audit trail para edições do mentor
+      if (auditInfo && auditInfo.editedBy === 'mentor') {
+        updateData.lastEditedBy = 'mentor';
+        updateData.lastEditedByEmail = auditInfo.email;
+        updateData.lastEditedAt = serverTimestamp();
+
+        // Append no editHistory (arrayUnion não funciona com objetos complexos no mesmo update,
+        // então usamos merge approach — o campo é gerenciado no caller via arrayUnion separado)
+      }
+
+      await updateDoc(planRef, updateData);
+
+      // Se mentor, registra no editHistory via arrayUnion separado
+      if (auditInfo && auditInfo.editedBy === 'mentor') {
+        const historyEntry = {
+          by: 'mentor',
+          email: auditInfo.email,
+          fields: auditInfo.changedFields || [],
+          timestamp: new Date().toISOString()
+        };
+        await updateDoc(planRef, {
+          editHistory: arrayUnion(historyEntry)
+        });
+        console.log(`[usePlans] Mentor edit audit: ${auditInfo.email} → ${planId}`);
+      }
     } catch (err) {
       console.error('[usePlans] Erro atualizar:', err);
       throw err;

--- a/src/hooks/usePlans.js
+++ b/src/hooks/usePlans.js
@@ -1,3 +1,4 @@
+// v1.14.0 — Issue #43: mentor audit trail
 /**
  * usePlans
  * @see version.js para versão do produto

--- a/src/pages/AccountDetailPage.jsx
+++ b/src/pages/AccountDetailPage.jsx
@@ -22,6 +22,7 @@ import { useMovements } from '../hooks/useMovements';
 import { useAuth } from '../contexts/AuthContext';
 import PlanManagementModal from '../components/PlanManagementModal';
 import DebugBadge from '../components/DebugBadge';
+import { buildAuditInfo } from '../utils/mentorPlanAudit';
 
 // --- Helpers de Formatação ---
 
@@ -193,18 +194,7 @@ const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubm
   const handleMentorSavePlan = async (planData) => {
     if (!editingPlan || !onUpdatePlan) return;
     
-    // Detecta quais campos mudaram
-    const changedFields = [];
-    const compareFields = ['pl', 'riskPerOperation', 'rrTarget', 'periodGoal', 'periodStop', 'cycleGoal', 'cycleStop', 'adjustmentCycle', 'operationPeriod', 'name'];
-    compareFields.forEach(f => {
-      if (String(editingPlan[f]) !== String(planData[f])) changedFields.push(f);
-    });
-
-    const auditInfo = {
-      editedBy: 'mentor',
-      email: user?.email,
-      changedFields
-    };
+    const auditInfo = buildAuditInfo(user?.email, editingPlan, planData);
 
     try {
       await onUpdatePlan(editingPlan.id, planData, auditInfo);

--- a/src/pages/AccountDetailPage.jsx
+++ b/src/pages/AccountDetailPage.jsx
@@ -1,19 +1,27 @@
 /**
  * AccountDetailPage
- * @version 6.1.1 (UI Tweaks)
- * @description Extrato com cálculo reverso (Reverse Ledger).
- * * CHANGE LOG 6.1.1:
- * - UI: Aumentado espaçamento da coluna 'Tipo' (w-32 -> w-40) para evitar quebra de linha em 'Resultado Trade'.
- * - MANUTENÇÃO: Mantida toda a lógica de cálculo reverso, tradução e formatação da v6.1.0.
+ * @version 7.0.0 (Plans View + Mentor Edit)
+ * @description Extrato com cálculo reverso (Reverse Ledger) + Planos vinculados.
+ * 
+ * CHANGELOG:
+ * - 7.0.0: Issue #43 — Seção "Planos Vinculados" com indicadores estratégicos
+ *   - Mentor vê e edita planos do aluno
+ *   - Indicadores: PL, RO, Stop Período, Stop Ciclo, Meta
+ *   - Audit trail: edições do mentor registradas no editHistory
+ * - 6.1.1: UI: Aumentado espaçamento da coluna 'Tipo' (w-32 -> w-40)
  */
 
 import { useState, useMemo } from 'react';
 import {
   ArrowLeft, Plus, Minus, Calendar,
   TrendingUp, TrendingDown, ArrowDownCircle, ArrowUpCircle,
-  Wallet, Loader2, X, History, Filter
+  Wallet, Loader2, X, History, Filter,
+  Target, ShieldAlert, Settings, AlertTriangle, GraduationCap
 } from 'lucide-react';
 import { useMovements } from '../hooks/useMovements';
+import { useAuth } from '../contexts/AuthContext';
+import PlanManagementModal from '../components/PlanManagementModal';
+import DebugBadge from '../components/DebugBadge';
 
 // --- Helpers de Formatação ---
 
@@ -39,8 +47,9 @@ const translateType = (type) => {
   return map[type] || type;
 };
 
-const AccountDetailPage = ({ account, onBack }) => {
+const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubmitting = false }) => {
   const { movements, loading, addDeposit, addWithdrawal } = useMovements(account?.id);
+  const { user, isMentor } = useAuth();
   
   // Filtros
   const [period, setPeriod] = useState('month');
@@ -55,6 +64,15 @@ const AccountDetailPage = ({ account, onBack }) => {
   const [txAmount, setTxAmount] = useState('');
   const [txDesc, setTxDesc] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+
+  // Modal Plano (mentor edit)
+  const [showPlanModal, setShowPlanModal] = useState(false);
+  const [editingPlan, setEditingPlan] = useState(null);
+
+  // Planos desta conta
+  const accountPlans = useMemo(() => {
+    return plans.filter(p => p.accountId === account?.id);
+  }, [plans, account]);
 
   /**
    * 1. ENGINE DE CÁLCULO REVERSO (Reverse Ledger)
@@ -171,6 +189,32 @@ const AccountDetailPage = ({ account, onBack }) => {
     return amount >= 0 ? <TrendingUp className="w-4 h-4 text-emerald-400" /> : <TrendingDown className="w-4 h-4 text-red-400" />;
   };
 
+  // Handler: Mentor salva edição do plano com audit trail
+  const handleMentorSavePlan = async (planData) => {
+    if (!editingPlan || !onUpdatePlan) return;
+    
+    // Detecta quais campos mudaram
+    const changedFields = [];
+    const compareFields = ['pl', 'riskPerOperation', 'rrTarget', 'periodGoal', 'periodStop', 'cycleGoal', 'cycleStop', 'adjustmentCycle', 'operationPeriod', 'name'];
+    compareFields.forEach(f => {
+      if (String(editingPlan[f]) !== String(planData[f])) changedFields.push(f);
+    });
+
+    const auditInfo = {
+      editedBy: 'mentor',
+      email: user?.email,
+      changedFields
+    };
+
+    try {
+      await onUpdatePlan(editingPlan.id, planData, auditInfo);
+      setShowPlanModal(false);
+      setEditingPlan(null);
+    } catch (err) {
+      alert('Erro ao salvar plano: ' + err.message);
+    }
+  };
+
   if (!account) return null;
 
   return (
@@ -193,6 +237,77 @@ const AccountDetailPage = ({ account, onBack }) => {
           </div>
         </div>
       </div>
+
+      {/* === PLANOS VINCULADOS (Issue #43) === */}
+      {accountPlans.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-bold text-white flex items-center gap-2 mb-4">
+            <Target className="w-5 h-5 text-blue-400" /> Planos Vinculados
+            <span className="text-sm font-normal text-slate-500">({accountPlans.length})</span>
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {accountPlans.map(plan => {
+              const plInitial = plan.pl || 0;
+              const plCurrent = plan.currentPl ?? plInitial;
+              const plPnL = plCurrent - plInitial;
+              const plPnLPercent = plInitial > 0 ? ((plPnL / plInitial) * 100) : 0;
+              const roValue = plInitial > 0 ? (plInitial * (plan.riskPerOperation || 0) / 100) : 0;
+              const periodStopValue = plInitial > 0 ? (plInitial * (plan.periodStop || 0) / 100) : 0;
+              const cycleStopValue = plInitial > 0 ? (plInitial * (plan.cycleStop || 0) / 100) : 0;
+              const periodGoalValue = plInitial > 0 ? (plInitial * (plan.periodGoal || 0) / 100) : 0;
+              const cycleGoalValue = plInitial > 0 ? (plInitial * (plan.cycleGoal || 0) / 100) : 0;
+              const isPositive = plPnL >= 0;
+              const wasMentorEdited = plan.lastEditedBy === 'mentor';
+
+              return (
+                <div key={plan.id} className="glass-card p-5 relative group">
+                  <div className="flex items-start justify-between mb-4">
+                    <div>
+                      <h3 className="font-bold text-white text-base">{plan.name}</h3>
+                      <p className="text-xs text-slate-500">{plan.type || plan.description} • {plan.operationPeriod}</p>
+                      {wasMentorEdited && (
+                        <span className="inline-flex items-center gap-1 mt-1 text-[10px] text-purple-400 bg-purple-500/10 border border-purple-500/20 px-2 py-0.5 rounded">
+                          <GraduationCap className="w-3 h-3" /> Ajustado pelo Mentor
+                        </span>
+                      )}
+                    </div>
+                    {isMentor() && onUpdatePlan && (
+                      <button
+                        onClick={() => { setEditingPlan(plan); setShowPlanModal(true); }}
+                        className="p-2 rounded-lg text-slate-500 hover:text-blue-400 hover:bg-blue-500/10 opacity-0 group-hover:opacity-100 transition-all"
+                        title="Editar plano"
+                      >
+                        <Settings className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="bg-slate-800/50 rounded-xl p-3 mb-4 border border-slate-700/30">
+                    <span className="text-[9px] text-slate-500 uppercase tracking-wider font-bold block mb-1">Saldo do Plano (PL)</span>
+                    <div className="flex items-baseline gap-2">
+                      <span className={`text-xl font-mono font-bold ${plCurrent >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                        {formatCurrency(plCurrent, account.currency)}
+                      </span>
+                      <span className={`text-xs font-mono ${isPositive ? 'text-emerald-500/70' : 'text-red-500/70'}`}>
+                        {isPositive ? '+' : ''}{plPnLPercent.toFixed(1)}%
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                    <div className="flex justify-between"><span className="text-slate-500 text-xs">RO/Trade</span><span className="text-white font-mono text-xs font-medium">{plan.riskPerOperation}% ({formatCurrency(roValue, account.currency)})</span></div>
+                    <div className="flex justify-between"><span className="text-slate-500 text-xs">RR Alvo</span><span className="text-blue-400 font-mono text-xs font-medium">1:{plan.rrTarget}</span></div>
+                    <div className="flex justify-between"><span className="text-slate-500 text-xs">Stop {plan.operationPeriod}</span><span className="text-red-400 font-mono text-xs font-medium">-{plan.periodStop}% ({formatCurrency(periodStopValue, account.currency)})</span></div>
+                    <div className="flex justify-between"><span className="text-slate-500 text-xs">Meta {plan.operationPeriod}</span><span className="text-emerald-400 font-mono text-xs font-medium">+{plan.periodGoal}% ({formatCurrency(periodGoalValue, account.currency)})</span></div>
+                    <div className="flex justify-between"><span className="text-slate-500 text-xs">Stop {plan.adjustmentCycle}</span><span className="text-red-400 font-mono text-xs font-medium">-{plan.cycleStop}% ({formatCurrency(cycleStopValue, account.currency)})</span></div>
+                    <div className="flex justify-between"><span className="text-slate-500 text-xs">Meta {plan.adjustmentCycle}</span><span className="text-emerald-400 font-mono text-xs font-medium">+{plan.cycleGoal}% ({formatCurrency(cycleGoalValue, account.currency)})</span></div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* EXTRATO CARD */}
       <div className="glass-card">
@@ -361,6 +476,17 @@ const AccountDetailPage = ({ account, onBack }) => {
           </div>
         </div>
       )}
+      {/* MODAL PLANO (Mentor Edit) */}
+      {isMentor() && (
+        <PlanManagementModal
+          isOpen={showPlanModal}
+          onClose={() => { setShowPlanModal(false); setEditingPlan(null); }}
+          onSubmit={handleMentorSavePlan}
+          editingPlan={editingPlan}
+          isSubmitting={planSubmitting}
+        />
+      )}
+      <DebugBadge component="AccountDetailPage" />
     </div>
   );
 };

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -468,4 +468,4 @@ const AccountsPage = () => {
   );
 };
 
-export default AccountsPage;
+export default AccountsPage;

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -17,6 +17,7 @@ import {
 import { useAccounts } from '../hooks/useAccounts';
 import { useMasterData } from '../hooks/useMasterData';
 import { useAuth } from '../contexts/AuthContext';
+import { usePlans } from '../hooks/usePlans';
 import AccountDetailPage from './AccountDetailPage';
 import StudentAccountGroup from '../components/StudentAccountGroup';
 import DebugBadge from '../components/DebugBadge';
@@ -76,12 +77,14 @@ const AccountsPage = () => {
   const { accounts, loading, addAccount, updateAccount, deleteAccount } = useAccounts();
   const { brokers } = useMasterData();
   const { isMentor } = useAuth();
+  const { plans, updatePlan } = usePlans();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingAccount, setEditingAccount] = useState(null);
   const [showBrokerSuggestions, setShowBrokerSuggestions] = useState(false);
   const [selectedAccount, setSelectedAccount] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [planSubmitting, setPlanSubmitting] = useState(false);
   
   const [auditState, setAuditState] = useState({ status: 'idle', message: '', issueType: null, ledgerBalance: 0, suggestion: null });
   const [isFixing, setIsFixing] = useState(false);
@@ -345,6 +348,16 @@ const AccountsPage = () => {
     if (window.confirm("Deseja excluir esta conta? O histórico será perdido.")) await deleteAccount(id);
   };
 
+  // Handler: Mentor atualiza plano do aluno (com audit trail)
+  const handleMentorUpdatePlan = async (planId, planData, auditInfo) => {
+    setPlanSubmitting(true);
+    try {
+      await updatePlan(planId, planData, auditInfo);
+    } finally {
+      setPlanSubmitting(false);
+    }
+  };
+
   const getAccountBadge = (acc) => {
     const type = acc.type || (acc.isReal ? 'REAL' : 'DEMO');
     switch (type) {
@@ -358,7 +371,7 @@ const AccountsPage = () => {
 
   if (selectedAccount) {
     const mergedAccount = { ...selectedAccount, currentBalance: balancesByAccountId[selectedAccount.id] ?? selectedAccount.currentBalance ?? 0 };
-    return <AccountDetailPage account={mergedAccount} onBack={() => setSelectedAccount(null)} />;
+    return <AccountDetailPage account={mergedAccount} onBack={() => setSelectedAccount(null)} plans={plans} onUpdatePlan={handleMentorUpdatePlan} planSubmitting={planSubmitting} />;
   }
 
   return (

--- a/src/utils/mentorPlanAudit.js
+++ b/src/utils/mentorPlanAudit.js
@@ -1,0 +1,40 @@
+/**
+ * Mentor Plan Audit — Utilitários
+ * @version 1.0.0
+ * 
+ * Lógica de detecção de campos alterados e geração de audit info
+ * para quando mentor edita plano do aluno.
+ */
+
+const PLAN_COMPARE_FIELDS = [
+  'pl', 'riskPerOperation', 'rrTarget',
+  'periodGoal', 'periodStop', 'cycleGoal', 'cycleStop',
+  'adjustmentCycle', 'operationPeriod', 'name'
+];
+
+/**
+ * Detecta quais campos mudaram entre o plano original e os novos dados
+ * @param {object} originalPlan - Plano antes da edição
+ * @param {object} newPlanData - Dados do formulário
+ * @returns {string[]} Lista de nomes dos campos alterados
+ */
+export const detectChangedFields = (originalPlan, newPlanData) => {
+  return PLAN_COMPARE_FIELDS.filter(f => String(originalPlan[f]) !== String(newPlanData[f]));
+};
+
+/**
+ * Gera objeto de auditoria para edição do mentor
+ * @param {string} mentorEmail
+ * @param {object} originalPlan
+ * @param {object} newPlanData
+ * @returns {{ editedBy: 'mentor', email: string, changedFields: string[] }}
+ */
+export const buildAuditInfo = (mentorEmail, originalPlan, newPlanData) => {
+  return {
+    editedBy: 'mentor',
+    email: mentorEmail,
+    changedFields: detectChangedFields(originalPlan, newPlanData)
+  };
+};
+
+export default { detectChangedFields, buildAuditInfo };

--- a/src/version.js
+++ b/src/version.js
@@ -3,44 +3,34 @@
  * @description SemVer 2.0.0 — MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
  * 
  * CHANGELOG:
+ * - 1.14.0: Issue #43 — Mentor visualiza e edita planos do aluno
+ *   - AccountDetailPage: seção "Planos Vinculados" com indicadores estratégicos
+ *   - PL atual, RO, Stop Período/Ciclo, Meta Período/Ciclo — tudo calculado
+ *   - Mentor edita via PlanManagementModal com audit trail
+ *   - usePlans.updatePlan: registra lastEditedBy, lastEditedByEmail, editHistory[]
+ *   - Badge "Ajustado pelo Mentor" nos planos editados
+ *   - AccountsPage passa plans e handler para AccountDetailPage
  * - 1.13.0: Issue #60 — Imagem no feedback via copy/paste (mentor only)
- *   - Paste handler no textarea do FeedbackPage
- *   - Upload para Firebase Storage (feedback/{tradeId}/)
- *   - imageUrl no feedbackHistory comment
- *   - ChatMessage renderiza imagem inline com fullscreen
- *   - uploadFeedbackImage no useTrades
  * - 1.12.0: Issue #9 — Feedback em massa para múltiplos trades
- *   - addBulkFeedback no useTrades (Firestore writeBatch)
- *   - UI de seleção múltipla no MentorDashboard (checkboxes, select all)
- *   - Modal de confirmação com resumo dos trades
- *   - Barra flutuante de ação
- *   - Flag isBulk no comment para auditoria
- *   - Validação: validateBulkFeedback (src/utils/bulkFeedback.js)
  * - 1.11.0: Issue #22 Phase 1 — Testes automatizados + CI/CD pipeline
- *   - vitest.config.js, setup, mocks, GitHub Actions CI
- *   - Extração: compliance.js, movements.js, dashboardMetrics.js
- *   - 74 testes unitários (compliance, maxDD, WR planejado, movements)
- *   - Cleanup: removida pasta tests/ legada
- * - 1.10.2: Hotfix — TradesList sort ASC, planId lock em edit, delete trade fix,
- *   Max Drawdown peak-to-trough, WR Planejado vs Clássico, Taxa de Conformidade,
- *   FeedbackPage tríade risco (RO% removido), Red Flags lista, MentorDashboard horário+sort
- * - 1.10.1: Hotfix — RO/RR com tickSize, validação HH:MM:SS range, data+hora em listas, risco pts vs %
- * - 1.10.0: Issue #41 — Campo Stop Loss, HH:MM:SS parciais, red flag NO_STOP, compliance RR via resultado
- * - 1.9.0: Sistema Emocional v2 — Fase 1.5.0 (UI Completa: Extrato Ledger + Alertas Mentor)
- * - 1.8.0: Sistema Emocional v2 — Fase 1.4.0 (Perfil Emocional do Aluno)
- * - 1.7.1: Hotfix: Filtro master de conta no dashboard aluno (AccountFilterBar)
- * - 1.7.0: Sistema Emocional v2 — Fase 1.3.1 (engine + hooks) + Fase 1.3.2 (ComplianceConfig)
- * - 1.6.0: Trade Partials, Auditoria Saldo, Feedback Parciais, Mentor Accounts UX
+ * - 1.10.2: Hotfix — TradesList sort ASC, planId lock em edit, delete trade fix
+ * - 1.10.1: Hotfix — RO/RR com tickSize, validação HH:MM:SS range
+ * - 1.10.0: Issue #41 — Campo Stop Loss, HH:MM:SS parciais, red flag NO_STOP
+ * - 1.9.0: Sistema Emocional v2 — Fase 1.5.0
+ * - 1.8.0: Sistema Emocional v2 — Fase 1.4.0
+ * - 1.7.1: Hotfix: Filtro master de conta no dashboard aluno
+ * - 1.7.0: Sistema Emocional v2 — Fase 1.3.1 + 1.3.2
+ * - 1.6.0: Trade Partials, Auditoria Saldo, Feedback Parciais
  * - 1.5.0: Plan-centric ledger
  * - 1.4.1: StudentFeedbackPage master-detail
  * - 1.4.0: State machine, dashboard mirror
  */
 export const VERSION = {
   major: 1,
-  minor: 13,
+  minor: 14,
   patch: 0,
   prerelease: null,
-  build: '20260302',
+  build: '20260303',
 
   get number() {
     return `${this.major}.${this.minor}.${this.patch}`;
@@ -63,7 +53,7 @@ export const VERSION = {
   },
 
   get date() {
-    return '2026-03-02';
+    return '2026-03-03';
   }
 };
 


### PR DESCRIPTION
## feat: Mentor visualiza e edita planos do aluno (Issue #43)

Closes #43
Closes #54

### O que foi feito
- AccountDetailPage: seção "Planos Vinculados" com indicadores estratégicos
- Mentor edita planos via PlanManagementModal com audit trail completo
- usePlans.updatePlan: registra lastEditedBy, editHistory[]
- Badge "Ajustado pelo Mentor" para planos tocados

### Como testar
1. Login mentor → Contas dos Alunos → clica numa conta
2. Seção "Planos Vinculados" aparece acima do extrato
3. Hover no card → engrenagem → edita → salva
4. Verifica no Firestore: lastEditedBy='mentor', editHistory com campos