### PR TITLE
feat: plan state machine foundation + tech debt fixes (#58 partial)

### DIFF
--- a/src/__tests__/utils/planStateMachine.test.js
+++ b/src/__tests__/utils/planStateMachine.test.js
@@ -1,0 +1,472 @@
+/**
+ * planStateMachine.test.js
+ * @version 1.0.0 (v1.16.0)
+ * @description Testes da máquina de estados do plano.
+ *   Cobre: períodos, ciclos, transições, POST_GOAL/POST_STOP,
+ *   agrupamento diário/semanal, boundary de ciclo, badges.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PERIOD_STATES,
+  computePeriodState,
+  computePlanState,
+  getPeriodKey,
+  getCycleStartDate,
+  getCycleEndDate,
+  classifyPeriodBadge,
+  getSentimentFromState,
+} from '../../utils/planStateMachine';
+
+// ============================================
+// HELPERS — Factory de trades para testes
+// ============================================
+
+const makeTrade = (overrides = {}) => ({
+  id: `trade_${Math.random().toString(36).slice(2, 8)}`,
+  date: '2026-03-04',
+  entryTime: '2026-03-04T10:00:00',
+  result: 0,
+  planId: 'plan_test',
+  ...overrides,
+});
+
+const makePlanConfig = (overrides = {}) => ({
+  pl: 20000,
+  periodGoal: 2,       // 2% = R$ 400
+  periodStop: 2,       // 2% = R$ 400
+  cycleGoal: 8,        // 8% = R$ 1600
+  cycleStop: 6,        // 6% = R$ 1200
+  operationPeriod: 'Diário',
+  adjustmentCycle: 'Mensal',
+  ...overrides,
+});
+
+// ============================================
+// computePeriodState
+// ============================================
+
+describe('computePeriodState', () => {
+  it('período vazio → IN_PROGRESS, sem eventos', () => {
+    const state = computePeriodState([], 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.rows).toHaveLength(0);
+    expect(state.events).toHaveLength(0);
+    expect(state.summary.tradesCount).toBe(0);
+    expect(state.summary.totalPnL).toBe(0);
+  });
+
+  it('1 trade lucrativo abaixo da meta → IN_PROGRESS', () => {
+    const trades = [makeTrade({ result: 200 })];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.rows[0].periodEvent).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.summary.totalPnL).toBe(200);
+    expect(state.summary.goalPercent).toBe(50); // 200/400
+  });
+
+  it('acumulado atinge meta → GOAL_HIT no trade correto', () => {
+    const trades = [
+      makeTrade({ result: 150, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: 100, entryTime: '2026-03-04T10:30:00' }),
+      makeTrade({ result: 200, entryTime: '2026-03-04T11:00:00' }), // acum = 450 >= 400
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.GOAL_HIT);
+    expect(state.rows[0].periodEvent).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.rows[1].periodEvent).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.rows[2].periodEvent).toBe(PERIOD_STATES.GOAL_HIT);
+    expect(state.events).toHaveLength(1);
+    expect(state.events[0].type).toBe('GOAL_HIT');
+    expect(state.events[0].tradeIndex).toBe(2);
+  });
+
+  it('trade após GOAL_HIT → POST_GOAL', () => {
+    const trades = [
+      makeTrade({ result: 500, entryTime: '2026-03-04T10:00:00' }), // GOAL_HIT
+      makeTrade({ result: -100, entryTime: '2026-03-04T11:00:00' }), // POST_GOAL
+      makeTrade({ result: 50, entryTime: '2026-03-04T11:30:00' }),   // POST_GOAL
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.POST_GOAL);
+    expect(state.rows[0].periodEvent).toBe(PERIOD_STATES.GOAL_HIT);
+    expect(state.rows[1].periodEvent).toBe(PERIOD_STATES.POST_GOAL);
+    expect(state.rows[2].periodEvent).toBe(PERIOD_STATES.POST_GOAL);
+    expect(state.summary.preEventPnL).toBe(500);
+    expect(state.summary.postEventPnL).toBe(-50); // -100 + 50
+    expect(state.summary.postEventCount).toBe(2);
+  });
+
+  it('acumulado atinge stop → STOP_HIT', () => {
+    const trades = [
+      makeTrade({ result: -200, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: -250, entryTime: '2026-03-04T10:30:00' }), // acum = -450 <= -400
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.STOP_HIT);
+    expect(state.rows[1].periodEvent).toBe(PERIOD_STATES.STOP_HIT);
+    expect(state.events[0].type).toBe('STOP_HIT');
+    expect(state.summary.stopPercent).toBeCloseTo(112.5); // 450/400 * 100
+  });
+
+  it('trade após STOP_HIT → POST_STOP', () => {
+    const trades = [
+      makeTrade({ result: -500, entryTime: '2026-03-04T10:00:00' }), // STOP_HIT
+      makeTrade({ result: 200, entryTime: '2026-03-04T11:00:00' }),   // POST_STOP
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.POST_STOP);
+    expect(state.rows[0].periodEvent).toBe(PERIOD_STATES.STOP_HIT);
+    expect(state.rows[1].periodEvent).toBe(PERIOD_STATES.POST_STOP);
+  });
+
+  it('meta atingida, depois devolveu → POST_GOAL com pnl negativo pós-evento', () => {
+    const trades = [
+      makeTrade({ result: 450, entryTime: '2026-03-04T10:00:00' }),  // GOAL_HIT
+      makeTrade({ result: -300, entryTime: '2026-03-04T11:00:00' }), // POST_GOAL, devolveu
+      makeTrade({ result: -200, entryTime: '2026-03-04T11:30:00' }), // POST_GOAL, devolveu mais
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.POST_GOAL);
+    expect(state.summary.totalPnL).toBe(-50); // 450 - 300 - 200
+    expect(state.summary.preEventPnL).toBe(450);
+    expect(state.summary.postEventPnL).toBe(-500);
+  });
+
+  it('goalVal = 0 → nunca atinge meta', () => {
+    const trades = [makeTrade({ result: 10000 })];
+    const state = computePeriodState(trades, 0, 400);
+    expect(state.status).toBe(PERIOD_STATES.IN_PROGRESS);
+  });
+
+  it('stopVal = 0 → nunca atinge stop', () => {
+    const trades = [makeTrade({ result: -10000 })];
+    const state = computePeriodState(trades, 400, 0);
+    expect(state.status).toBe(PERIOD_STATES.IN_PROGRESS);
+  });
+
+  it('trade com result = 0 → não muda estado', () => {
+    const trades = [
+      makeTrade({ result: 0, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: 0, entryTime: '2026-03-04T10:30:00' }),
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    expect(state.status).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.summary.totalPnL).toBe(0);
+  });
+});
+
+// ============================================
+// computePlanState — Agrupamento Diário
+// ============================================
+
+describe('computePlanState — Diário', () => {
+  it('trades no mesmo dia ficam no mesmo período', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-04', result: 100, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ date: '2026-03-04', result: 200, entryTime: '2026-03-04T11:00:00' }),
+    ];
+    const config = makePlanConfig();
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-04T12:00:00') });
+
+    expect(state.availablePeriods).toHaveLength(1);
+    expect(state.availablePeriods[0]).toBe('2026-03-04');
+    expect(state.cycleState.periods.get('2026-03-04').summary.tradesCount).toBe(2);
+  });
+
+  it('trades em dias diferentes → períodos separados', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-03', result: 100 }),
+      makeTrade({ date: '2026-03-04', result: -50 }),
+      makeTrade({ date: '2026-03-05', result: 200 }),
+    ];
+    const config = makePlanConfig();
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-05T12:00:00') });
+
+    expect(state.availablePeriods).toHaveLength(3);
+    expect(state.cycleState.summary.totalPnL).toBe(250);
+  });
+
+  it('filtra trades fora do ciclo', () => {
+    const trades = [
+      makeTrade({ date: '2026-02-28', result: 999 }), // Fevereiro — fora do ciclo de março
+      makeTrade({ date: '2026-03-04', result: 100 }),
+    ];
+    const config = makePlanConfig();
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-04T12:00:00') });
+
+    expect(state.cycleState.summary.tradesCount).toBe(1);
+    expect(state.cycleState.summary.totalPnL).toBe(100);
+  });
+});
+
+// ============================================
+// computePlanState — Agrupamento Semanal
+// ============================================
+
+describe('computePlanState — Semanal', () => {
+  it('trades de segunda a sexta ficam na mesma semana', () => {
+    // 2026-03-02 = segunda, 2026-03-06 = sexta
+    const trades = [
+      makeTrade({ date: '2026-03-02', result: 100 }),
+      makeTrade({ date: '2026-03-04', result: 200 }),
+      makeTrade({ date: '2026-03-06', result: -50 }),
+    ];
+    const config = makePlanConfig({ operationPeriod: 'Semanal' });
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-06T12:00:00') });
+
+    expect(state.availablePeriods).toHaveLength(1);
+    // Chave da semana = segunda-feira
+    expect(state.availablePeriods[0]).toBe('2026-03-02');
+  });
+
+  it('semana que cruza mês se divide no boundary do ciclo', () => {
+    // 2026-03-30 = segunda, 2026-03-31 = terça (fim do mês), 2026-04-01 = quarta (novo ciclo)
+    const trades = [
+      makeTrade({ date: '2026-03-30', result: 100 }),
+      makeTrade({ date: '2026-03-31', result: 200 }),
+      makeTrade({ date: '2026-04-01', result: 300 }), // Novo ciclo
+    ];
+    const config = makePlanConfig({ operationPeriod: 'Semanal' });
+
+    // Ciclo de março — usar T12:00:00 para evitar problema de TZ (UTC midnight = dia anterior em BRT)
+    const stateMar = computePlanState(trades, config, { targetDate: new Date('2026-03-31T12:00:00') });
+    expect(stateMar.cycleState.summary.totalPnL).toBe(300); // Apenas março
+    expect(stateMar.cycleState.summary.tradesCount).toBe(2);
+
+    // Ciclo de abril
+    const stateApr = computePlanState(trades, config, { targetDate: new Date('2026-04-01T12:00:00') });
+    expect(stateApr.cycleState.summary.totalPnL).toBe(300); // Apenas abril
+    expect(stateApr.cycleState.summary.tradesCount).toBe(1);
+  });
+});
+
+// ============================================
+// computePlanState — Ciclo State Machine
+// ============================================
+
+describe('computePlanState — Cycle states', () => {
+  it('ciclo com 3 períodos calcula estado do ciclo corretamente', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-03', result: 500 }),
+      makeTrade({ date: '2026-03-04', result: 500 }),
+      makeTrade({ date: '2026-03-05', result: 500 }),
+    ];
+    const config = makePlanConfig(); // cycleGoal = 8% = R$ 1600
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-05T12:00:00') });
+
+    expect(state.cycleState.summary.totalPnL).toBe(1500);
+    expect(state.cycleState.status).toBe(PERIOD_STATES.IN_PROGRESS);
+    expect(state.cycleState.summary.periodsCount).toBe(3);
+  });
+
+  it('ciclo atinge goal', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-03', result: 800 }),
+      makeTrade({ date: '2026-03-04', result: 900 }), // acum = 1700 >= 1600
+    ];
+    const config = makePlanConfig();
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-04T12:00:00') });
+
+    expect(state.cycleState.status).toBe(PERIOD_STATES.GOAL_HIT);
+    expect(state.cycleState.events).toHaveLength(1);
+    expect(state.cycleState.events[0].type).toBe('CYCLE_GOAL_HIT');
+  });
+
+  it('ciclo atinge stop', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-03', result: -700 }),
+      makeTrade({ date: '2026-03-04', result: -600 }), // acum = -1300 <= -1200
+    ];
+    const config = makePlanConfig();
+    const state = computePlanState(trades, config, { targetDate: new Date('2026-03-04T12:00:00') });
+
+    expect(state.cycleState.status).toBe(PERIOD_STATES.STOP_HIT);
+    expect(state.cycleState.events[0].type).toBe('CYCLE_STOP_HIT');
+  });
+});
+
+// ============================================
+// getCycleStartDate / getCycleEndDate
+// ============================================
+
+describe('Cycle date helpers', () => {
+  it('Mensal: março 2026', () => {
+    const ref = new Date('2026-03-15T12:00:00');
+    const start = getCycleStartDate('Mensal', ref);
+    const end = getCycleEndDate('Mensal', ref);
+    expect(start.getFullYear()).toBe(2026);
+    expect(start.getMonth()).toBe(2); // março = 2
+    expect(start.getDate()).toBe(1);
+    expect(end.getMonth()).toBe(2);
+    expect(end.getDate()).toBe(31);
+  });
+
+  it('Trimestral: Q1 2026 (jan-mar)', () => {
+    const ref = new Date('2026-02-10T12:00:00');
+    const start = getCycleStartDate('Trimestral', ref);
+    const end = getCycleEndDate('Trimestral', ref);
+    expect(start.getMonth()).toBe(0); // janeiro
+    expect(start.getDate()).toBe(1);
+    expect(end.getMonth()).toBe(2); // março
+    expect(end.getDate()).toBe(31);
+  });
+
+  it('Trimestral: Q2 2026 (abr-jun)', () => {
+    const ref = new Date('2026-05-20T12:00:00');
+    const start = getCycleStartDate('Trimestral', ref);
+    const end = getCycleEndDate('Trimestral', ref);
+    expect(start.getMonth()).toBe(3); // abril
+    expect(end.getMonth()).toBe(5);   // junho
+    expect(end.getDate()).toBe(30);
+  });
+});
+
+// ============================================
+// getPeriodKey
+// ============================================
+
+describe('getPeriodKey', () => {
+  const cycleStart = new Date('2026-03-01T00:00:00');
+  const cycleEnd = new Date('2026-03-31T23:59:59.999');
+
+  it('Diário retorna a data do trade', () => {
+    expect(getPeriodKey('2026-03-04', 'Diário', cycleStart, cycleEnd)).toBe('2026-03-04');
+  });
+
+  it('Semanal retorna a segunda-feira', () => {
+    // 2026-03-04 = quarta → segunda = 2026-03-02
+    expect(getPeriodKey('2026-03-04', 'Semanal', cycleStart, cycleEnd)).toBe('2026-03-02');
+  });
+
+  it('Semanal trunca no início do ciclo se segunda é do mês anterior', () => {
+    // 2026-03-01 = domingo. Segunda da semana ISO = 2026-02-23 (fev)
+    // Como cycleStart = 01/mar, deve usar 01/mar como chave
+    expect(getPeriodKey('2026-03-01', 'Semanal', cycleStart, cycleEnd)).toBe('2026-03-01');
+  });
+});
+
+// ============================================
+// classifyPeriodBadge
+// ============================================
+
+describe('classifyPeriodBadge', () => {
+  it('IN_PROGRESS → Em Andamento', () => {
+    const state = computePeriodState([makeTrade({ result: 100 })], 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('IN_PROGRESS');
+    expect(badge.colorClass).toBe('slate');
+  });
+
+  it('GOAL_HIT sem POST → GOAL_DISCIPLINED', () => {
+    const state = computePeriodState([makeTrade({ result: 500 })], 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('GOAL_DISCIPLINED');
+    expect(badge.icon).toBe('Check');
+    expect(badge.colorClass).toBe('emerald');
+  });
+
+  it('POST_GOAL com gain → POST_GOAL_GAIN', () => {
+    const trades = [
+      makeTrade({ result: 500, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: 50, entryTime: '2026-03-04T11:00:00' }),
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('POST_GOAL_GAIN');
+  });
+
+  it('POST_GOAL que devolveu meta → POST_GOAL_LOSS', () => {
+    const trades = [
+      makeTrade({ result: 500, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: -400, entryTime: '2026-03-04T11:00:00' }),
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('POST_GOAL_LOSS');
+    expect(badge.label).toBe('Devolveu Meta');
+  });
+
+  it('POST_GOAL que foi ao stop → GOAL_TO_STOP (Catástrofe)', () => {
+    const trades = [
+      makeTrade({ result: 500, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: -600, entryTime: '2026-03-04T11:00:00' }),
+      makeTrade({ result: -400, entryTime: '2026-03-04T11:30:00' }),
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('GOAL_TO_STOP');
+    expect(badge.animate).toBe(true);
+  });
+
+  it('STOP_HIT → Stop Atingido', () => {
+    const state = computePeriodState([makeTrade({ result: -500 })], 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('STOP_HIT');
+    expect(badge.colorClass).toBe('red');
+  });
+
+  it('POST_STOP que recuperou → LOSS_TO_GOAL', () => {
+    const trades = [
+      makeTrade({ result: -500, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: 600, entryTime: '2026-03-04T11:00:00' }),
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('LOSS_TO_GOAL');
+    expect(badge.label).toBe('Recuperação');
+  });
+
+  it('POST_STOP que piorou → STOP_WORSENED', () => {
+    const trades = [
+      makeTrade({ result: -500, entryTime: '2026-03-04T10:00:00' }),
+      makeTrade({ result: -100, entryTime: '2026-03-04T11:00:00' }),
+    ];
+    const state = computePeriodState(trades, 400, 400);
+    const badge = classifyPeriodBadge(state);
+    expect(badge.badge).toBe('STOP_WORSENED');
+    expect(badge.animate).toBe(true);
+  });
+});
+
+// ============================================
+// getSentimentFromState
+// ============================================
+
+describe('getSentimentFromState', () => {
+  it('GOAL_HIT → Trophy dourado', () => {
+    const s = getSentimentFromState(PERIOD_STATES.GOAL_HIT, 500);
+    expect(s.icon).toBe('Trophy');
+    expect(s.colorClass).toContain('yellow');
+  });
+
+  it('STOP_HIT → Skull vermelho', () => {
+    const s = getSentimentFromState(PERIOD_STATES.STOP_HIT, -500);
+    expect(s.icon).toBe('Skull');
+    expect(s.colorClass).toContain('red');
+  });
+
+  it('IN_PROGRESS positivo → Smile verde', () => {
+    const s = getSentimentFromState(PERIOD_STATES.IN_PROGRESS, 100);
+    expect(s.icon).toBe('Smile');
+    expect(s.colorClass).toContain('emerald');
+  });
+
+  it('IN_PROGRESS negativo → Frown vermelho', () => {
+    const s = getSentimentFromState(PERIOD_STATES.IN_PROGRESS, -100);
+    expect(s.icon).toBe('Frown');
+    expect(s.colorClass).toContain('red');
+  });
+
+  it('IN_PROGRESS zero → Meh cinza', () => {
+    const s = getSentimentFromState(PERIOD_STATES.IN_PROGRESS, 0);
+    expect(s.icon).toBe('Meh');
+    expect(s.colorClass).toContain('slate');
+  });
+
+  it('null status (fallback legacy) → comportamento por pnl', () => {
+    expect(getSentimentFromState(null, 100).icon).toBe('Smile');
+    expect(getSentimentFromState(null, -100).icon).toBe('Frown');
+    expect(getSentimentFromState(null, 0).icon).toBe('Meh');
+  });
+});

--- a/src/components/TradesList.jsx
+++ b/src/components/TradesList.jsx
@@ -30,9 +30,11 @@ import {
 /**
  * Formatadores Visuais (Helpers)
  */
-const formatCurrency = (value) => {
+const formatCurrency = (value, currency = 'BRL') => {
   const safeValue = Number(value) || 0;
-  return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(safeValue);
+  const localeMap = { BRL: 'pt-BR', USD: 'en-US', EUR: 'de-DE', GBP: 'en-GB', ARS: 'es-AR' };
+  const locale = localeMap[currency] || 'pt-BR';
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(safeValue);
 };
 
 const formatPercent = (value) => {
@@ -227,7 +229,7 @@ const TradesList = ({
                         />
                       )}
                       <span>
-                        {result > 0 ? '+' : ''}{formatCurrency(result)}
+                        {result > 0 ? '+' : ''}{formatCurrency(result, trade.currency)}
                       </span>
                     </div>
                     <div className={`text-xs ${getResultColor(result)} opacity-80`}>

--- a/src/components/dashboard/DashboardHeader.jsx
+++ b/src/components/dashboard/DashboardHeader.jsx
@@ -9,6 +9,7 @@ import { PlusCircle, Filter, Wallet } from 'lucide-react';
 import AccountFilterBar from '../AccountFilterBar';
 import { formatCurrencyDynamic } from '../../utils/currency';
 import { isRealAccount } from '../../utils/planCalculations';
+import DebugBadge from '../DebugBadge';
 
 /**
  * @param {Object} props
@@ -97,6 +98,7 @@ const DashboardHeader = ({
           </span>
         </div>
       )}
+      <DebugBadge component="DashboardHeader" />
     </div>
   );
 };

--- a/src/components/dashboard/MetricsCards.jsx
+++ b/src/components/dashboard/MetricsCards.jsx
@@ -9,6 +9,7 @@
 import { DollarSign, Target, TrendingDown, Wallet, Activity } from 'lucide-react';
 import { formatPercent } from '../../utils/calculations';
 import { formatCurrencyDynamic } from '../../utils/currency';
+import DebugBadge from '../DebugBadge';
 
 /**
  * @param {Object} stats - Retorno de calculateStats
@@ -112,6 +113,7 @@ const MetricsCards = ({
           </div>
         )}
       </div>
+      <DebugBadge component="MetricsCards" />
     </div>
   );
 };

--- a/src/components/dashboard/PlanCardGrid.jsx
+++ b/src/components/dashboard/PlanCardGrid.jsx
@@ -13,6 +13,7 @@ import {
 import { filterTradesByPeriod, analyzePlanCompliance } from '../../utils/calculations';
 import { formatCurrencyDynamic } from '../../utils/currency';
 import { calculatePeriodPnL, calculateCyclePnL } from '../../utils/planCalculations';
+import DebugBadge from '../DebugBadge';
 
 const MiniProgressBar = ({ current, target, isLoss }) => {
   const percent = target > 0 ? Math.min(Math.abs(current) / target * 100, 100) : 0;
@@ -145,6 +146,7 @@ const PlanCardGrid = ({
           </div>
         );
       })}
+      <DebugBadge component="PlanCardGrid" />
     </div>
   );
 };

--- a/src/hooks/useDashboardMetrics.js
+++ b/src/hooks/useDashboardMetrics.js
@@ -69,14 +69,14 @@ const useDashboardMetrics = ({
       const plan = plans.find(p => p.id === selectedPlanId);
       if (plan) {
         const acc = accounts.find(a => a.id === plan.accountId);
-        return acc ? (acc.initialBalance || 0) : 0;
+        return acc ? (acc.initialBalance ?? 0) : 0;
       }
     }
     if (filters.accountId !== 'all') {
       const acc = accounts.find(a => a.id === filters.accountId);
-      return acc ? (acc.initialBalance || 0) : 0;
+      return acc ? (acc.initialBalance ?? 0) : 0;
     }
-    return filteredAccountsByType.reduce((sum, acc) => sum + (acc.initialBalance || 0), 0);
+    return filteredAccountsByType.reduce((sum, acc) => sum + (acc.initialBalance ?? 0), 0);
   }, [filteredAccountsByType, filters.accountId, accounts, selectedPlanId, plans]);
 
   const aggregatedCurrentBalance = useMemo(() => {

--- a/src/pages/ComplianceConfigPage.jsx
+++ b/src/pages/ComplianceConfigPage.jsx
@@ -456,7 +456,7 @@ const ComplianceConfigPage = ({ embedded = false }) => {
         </div>
       </div>
 
-      <DebugBadge component="ComplianceConfigPage" />
+      {!embedded && <DebugBadge component="ComplianceConfigPage" />}
     </div>
   );
 };

--- a/src/utils/planStateMachine.js
+++ b/src/utils/planStateMachine.js
@@ -1,0 +1,509 @@
+/**
+ * planStateMachine.js
+ * @version 1.0.0 (v1.16.0)
+ * @description Máquina de estados do plano operacional — função pura.
+ *   Recebe trades + config → retorna estado completo de períodos e ciclo.
+ *   Shape do retorno é compatível com futuro doc `cycleClosures` no Firestore.
+ *
+ * HIERARQUIA:
+ *   Ciclo (Mensal/Trimestral)
+ *     └─ Período 1 (Diário/Semanal)
+ *     │    └─ Trade A → IN_PROGRESS
+ *     │    └─ Trade B → GOAL_HIT (acum >= meta)
+ *     │    └─ Trade C → POST_GOAL (violação pós-meta)
+ *     └─ Período 2
+ *          └─ Trade D → STOP_HIT
+ *          └─ Trade E → POST_STOP
+ *
+ * REGRAS DE NEGÓCIO:
+ *   - Períodos só existem quando há trades (sem geração de dias/semanas vazios)
+ *   - Semana se divide no boundary do ciclo (mês/trimestre)
+ *   - trade.date é source of truth para agrupamento
+ *   - O sistema não bloqueia — apenas classifica (POST_GOAL/POST_STOP)
+ *   - goalVal/stopVal = 0 → nunca atinge (desabilitado)
+ */
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+export const PERIOD_STATES = {
+  IN_PROGRESS: 'IN_PROGRESS',
+  GOAL_HIT: 'GOAL_HIT',
+  STOP_HIT: 'STOP_HIT',
+  POST_GOAL: 'POST_GOAL',
+  POST_STOP: 'POST_STOP',
+};
+
+// ============================================
+// HELPERS — Date / Period Grouping
+// ============================================
+
+/**
+ * Retorna o último dia do mês (Date object, 23:59:59.999)
+ */
+const getMonthEnd = (year, month) => new Date(year, month + 1, 0, 23, 59, 59, 999);
+
+/**
+ * Retorna o último dia do trimestre
+ */
+const getQuarterEnd = (year, month) => {
+  const quarterEndMonth = Math.floor(month / 3) * 3 + 2;
+  return getMonthEnd(year, quarterEndMonth);
+};
+
+/**
+ * Retorna o último dia do ciclo que contém a data fornecida.
+ * @param {string} adjustmentCycle - 'Mensal' | 'Trimestral'
+ * @param {Date} date
+ * @returns {Date}
+ */
+export const getCycleEndDate = (adjustmentCycle, date) => {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  switch (adjustmentCycle) {
+    case 'Trimestral':
+      return getQuarterEnd(y, m);
+    case 'Mensal':
+    default:
+      return getMonthEnd(y, m);
+  }
+};
+
+/**
+ * Retorna o primeiro dia do ciclo que contém a data fornecida.
+ * @param {string} adjustmentCycle - 'Mensal' | 'Trimestral'
+ * @param {Date} date
+ * @returns {Date}
+ */
+export const getCycleStartDate = (adjustmentCycle, date) => {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  switch (adjustmentCycle) {
+    case 'Trimestral':
+      return new Date(y, Math.floor(m / 3) * 3, 1);
+    case 'Mensal':
+    default:
+      return new Date(y, m, 1);
+  }
+};
+
+/**
+ * Retorna a segunda-feira da semana ISO de uma data.
+ */
+const getISOWeekMonday = (date) => {
+  const d = new Date(date);
+  const day = d.getDay(); // 0=Sun, 1=Mon, ...
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  d.setDate(diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+/**
+ * Gera a chave de período para um trade.
+ * - Diário: 'YYYY-MM-DD'
+ * - Semanal: 'YYYY-MM-DD' (segunda-feira da semana, truncada no boundary do ciclo)
+ *
+ * @param {string} tradeDate - 'YYYY-MM-DD'
+ * @param {string} operationPeriod - 'Diário' | 'Semanal'
+ * @param {Date} cycleStart - Início do ciclo (para truncar semanas no boundary)
+ * @param {Date} cycleEnd - Fim do ciclo (para truncar semanas no boundary)
+ * @returns {string} periodKey
+ */
+export const getPeriodKey = (tradeDate, operationPeriod, cycleStart, cycleEnd) => {
+  if (operationPeriod === 'Diário') {
+    return tradeDate; // 'YYYY-MM-DD'
+  }
+
+  // Semanal: agrupar por segunda-feira, mas truncar no boundary do ciclo
+  const tradeDateObj = new Date(tradeDate + 'T12:00:00'); // noon to avoid TZ issues
+  const monday = getISOWeekMonday(tradeDateObj);
+
+  // Se a segunda-feira é anterior ao início do ciclo, usar o início do ciclo como chave
+  if (monday < cycleStart) {
+    return formatDateKey(cycleStart);
+  }
+
+  return formatDateKey(monday);
+};
+
+/**
+ * Formata Date como 'YYYY-MM-DD'
+ */
+const formatDateKey = (date) => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+};
+
+/**
+ * Verifica se um trade pertence a um ciclo específico.
+ */
+const isTradeInCycle = (tradeDate, cycleStart, cycleEnd) => {
+  const d = new Date(tradeDate + 'T12:00:00');
+  return d >= cycleStart && d <= cycleEnd;
+};
+
+// ============================================
+// CORE — Period State Machine
+// ============================================
+
+/**
+ * Processa trades de um período e retorna estado + classificação por trade.
+ *
+ * @param {Array} trades - Trades do período, já ordenados ASC (date → entryTime)
+ * @param {number} goalVal - Valor absoluto da meta do período (R$)
+ * @param {number} stopVal - Valor absoluto do stop do período (R$)
+ * @returns {Object} { status, rows[], events[], summary }
+ */
+export const computePeriodState = (trades, goalVal, stopVal) => {
+  const rows = [];
+  const events = [];
+  let cumPnL = 0;
+  let currentStatus = PERIOD_STATES.IN_PROGRESS;
+
+  for (let i = 0; i < trades.length; i++) {
+    const trade = trades[i];
+    const result = Number(trade.result) || 0;
+    const prevCumPnL = cumPnL;
+    cumPnL += result;
+
+    let tradeEvent = null;
+
+    // Classificação do trade
+    if (currentStatus === PERIOD_STATES.GOAL_HIT || currentStatus === PERIOD_STATES.POST_GOAL) {
+      // Qualquer trade após GOAL_HIT é POST_GOAL
+      tradeEvent = PERIOD_STATES.POST_GOAL;
+      currentStatus = PERIOD_STATES.POST_GOAL;
+    } else if (currentStatus === PERIOD_STATES.STOP_HIT || currentStatus === PERIOD_STATES.POST_STOP) {
+      // Qualquer trade após STOP_HIT é POST_STOP
+      tradeEvent = PERIOD_STATES.POST_STOP;
+      currentStatus = PERIOD_STATES.POST_STOP;
+    } else {
+      // IN_PROGRESS — checar transições
+      if (goalVal > 0 && cumPnL >= goalVal) {
+        tradeEvent = PERIOD_STATES.GOAL_HIT;
+        currentStatus = PERIOD_STATES.GOAL_HIT;
+        events.push({
+          type: 'GOAL_HIT',
+          tradeIndex: i,
+          tradeId: trade.id,
+          cumPnL,
+          timestamp: trade.entryTime || trade.date,
+        });
+      } else if (stopVal > 0 && cumPnL <= -stopVal) {
+        tradeEvent = PERIOD_STATES.STOP_HIT;
+        currentStatus = PERIOD_STATES.STOP_HIT;
+        events.push({
+          type: 'STOP_HIT',
+          tradeIndex: i,
+          tradeId: trade.id,
+          cumPnL,
+          timestamp: trade.entryTime || trade.date,
+        });
+      } else {
+        tradeEvent = PERIOD_STATES.IN_PROGRESS;
+      }
+    }
+
+    rows.push({
+      tradeId: trade.id,
+      tradeIndex: i,
+      result,
+      cumPnL,
+      prevCumPnL,
+      periodEvent: tradeEvent,
+      trade, // referência completa para UI
+    });
+  }
+
+  // Resultado pré-evento e pós-evento
+  const eventIndex = events.length > 0 ? events[0].tradeIndex : -1;
+  const preEventPnL = eventIndex >= 0
+    ? rows.slice(0, eventIndex + 1).reduce((s, r) => s + r.result, 0)
+    : cumPnL;
+  const postEventPnL = eventIndex >= 0
+    ? rows.slice(eventIndex + 1).reduce((s, r) => s + r.result, 0)
+    : 0;
+  const postEventCount = eventIndex >= 0
+    ? rows.length - (eventIndex + 1)
+    : 0;
+
+  return {
+    status: currentStatus,
+    rows,
+    events,
+    summary: {
+      tradesCount: trades.length,
+      totalPnL: cumPnL,
+      preEventPnL,
+      postEventPnL,
+      postEventCount,
+      goalVal,
+      stopVal,
+      goalPercent: goalVal > 0 ? (cumPnL / goalVal) * 100 : 0,
+      stopPercent: stopVal > 0 && cumPnL < 0 ? (Math.abs(cumPnL) / stopVal) * 100 : 0,
+    },
+  };
+};
+
+// ============================================
+// CORE — Cycle Aggregator
+// ============================================
+
+/**
+ * Função principal: computa estado completo do plano.
+ *
+ * @param {Array} trades - Todos os trades do plano (qualquer ordem)
+ * @param {Object} planConfig - {
+ *   pl, periodGoal, periodStop, cycleGoal, cycleStop,
+ *   operationPeriod ('Diário'|'Semanal'),
+ *   adjustmentCycle ('Mensal'|'Trimestral')
+ * }
+ * @param {Object} [options] - {
+ *   targetDate?: Date - data de referência (default: now),
+ *   targetCycle?: { start: Date, end: Date } - ciclo específico
+ * }
+ *
+ * @returns {Object} Estado completo (shape compatível com futuro cycleClosures doc)
+ * {
+ *   cycleKey: string,
+ *   cycleStart: string (ISO),
+ *   cycleEnd: string (ISO),
+ *   cycleState: { status, periods: Map<periodKey, periodState>, summary },
+ *   currentPeriodKey: string | null,
+ *   availablePeriods: string[],
+ *   planConfig: { ...snapshot },
+ *   computedAt: string (ISO),
+ *   // Futuro (Épico Kelly/Monte Carlo): kelly, monteCarlo, reallocation
+ * }
+ */
+export const computePlanState = (trades, planConfig, options = {}) => {
+  const {
+    pl = 0,
+    periodGoal = 0,
+    periodStop = 0,
+    cycleGoal = 0,
+    cycleStop = 0,
+    operationPeriod = 'Diário',
+    adjustmentCycle = 'Mensal',
+  } = planConfig;
+
+  // Valores absolutos (R$) das metas/stops
+  const periodGoalVal = pl * (periodGoal / 100);
+  const periodStopVal = pl * (periodStop / 100);
+  const cycleGoalVal = pl * (cycleGoal / 100);
+  const cycleStopVal = pl * (cycleStop / 100);
+
+  // Determinar ciclo alvo
+  const refDate = options.targetDate || new Date();
+  const cycleStart = options.targetCycle?.start || getCycleStartDate(adjustmentCycle, refDate);
+  const cycleEnd = options.targetCycle?.end || getCycleEndDate(adjustmentCycle, refDate);
+
+  // Filtrar trades do ciclo
+  const cycleTrades = trades
+    .filter(t => t.date && isTradeInCycle(t.date, cycleStart, cycleEnd))
+    .sort((a, b) => {
+      // Sort ASC: date → entryTime → createdAt
+      const dateA = a.date || '';
+      const dateB = b.date || '';
+      if (dateA !== dateB) return dateA.localeCompare(dateB);
+      const timeA = a.entryTime || '';
+      const timeB = b.entryTime || '';
+      if (timeA && timeB) return timeA.localeCompare(timeB);
+      const caA = a.createdAt?.toDate?.()?.toISOString?.() || a.createdAt || '';
+      const caB = b.createdAt?.toDate?.()?.toISOString?.() || b.createdAt || '';
+      return caA.toString().localeCompare(caB.toString());
+    });
+
+  // Agrupar trades por período
+  const periodMap = new Map(); // periodKey → trades[]
+
+  for (const trade of cycleTrades) {
+    const key = getPeriodKey(trade.date, operationPeriod, cycleStart, cycleEnd);
+    if (!periodMap.has(key)) {
+      periodMap.set(key, []);
+    }
+    periodMap.get(key).push(trade);
+  }
+
+  // Computar estado de cada período
+  const periods = new Map(); // periodKey → periodState
+  let cycleCumPnL = 0;
+  let cycleStatus = PERIOD_STATES.IN_PROGRESS;
+  const cycleEvents = [];
+
+  // Iterar períodos em ordem cronológica
+  const sortedPeriodKeys = [...periodMap.keys()].sort();
+
+  for (const periodKey of sortedPeriodKeys) {
+    const periodTrades = periodMap.get(periodKey);
+    const periodState = computePeriodState(periodTrades, periodGoalVal, periodStopVal);
+    periods.set(periodKey, periodState);
+
+    // Acumular para o ciclo
+    const periodPnL = periodState.summary.totalPnL;
+    const prevCycleCumPnL = cycleCumPnL;
+    cycleCumPnL += periodPnL;
+
+    // Checar transições do ciclo
+    if (cycleStatus === PERIOD_STATES.IN_PROGRESS) {
+      if (cycleGoalVal > 0 && cycleCumPnL >= cycleGoalVal) {
+        cycleStatus = PERIOD_STATES.GOAL_HIT;
+        cycleEvents.push({
+          type: 'CYCLE_GOAL_HIT',
+          periodKey,
+          cycleCumPnL,
+        });
+      } else if (cycleStopVal > 0 && cycleCumPnL <= -cycleStopVal) {
+        cycleStatus = PERIOD_STATES.STOP_HIT;
+        cycleEvents.push({
+          type: 'CYCLE_STOP_HIT',
+          periodKey,
+          cycleCumPnL,
+        });
+      }
+    }
+    // Nota: ciclo não tem POST_GOAL/POST_STOP por período — isso é granularidade do período
+  }
+
+  // Determinar período atual
+  const today = formatDateKey(refDate);
+  const currentPeriodKey = sortedPeriodKeys.includes(today)
+    ? today
+    : operationPeriod === 'Semanal'
+      ? sortedPeriodKeys.find(k => {
+          // Para semanal, verificar se hoje está dentro da semana do período
+          const periodStart = new Date(k + 'T00:00:00');
+          const periodEnd = new Date(periodStart);
+          periodEnd.setDate(periodEnd.getDate() + 6);
+          return refDate >= periodStart && refDate <= periodEnd;
+        }) || sortedPeriodKeys[sortedPeriodKeys.length - 1] || null
+      : sortedPeriodKeys[sortedPeriodKeys.length - 1] || null;
+
+  // Cycle summary
+  const cycleSummary = {
+    tradesCount: cycleTrades.length,
+    periodsCount: sortedPeriodKeys.length,
+    totalPnL: cycleCumPnL,
+    goalVal: cycleGoalVal,
+    stopVal: cycleStopVal,
+    goalPercent: cycleGoalVal > 0 ? (cycleCumPnL / cycleGoalVal) * 100 : 0,
+    stopPercent: cycleStopVal > 0 && cycleCumPnL < 0 ? (Math.abs(cycleCumPnL) / cycleStopVal) * 100 : 0,
+    pl,
+  };
+
+  return {
+    cycleKey: formatDateKey(cycleStart),
+    cycleStart: cycleStart.toISOString(),
+    cycleEnd: cycleEnd.toISOString(),
+    cycleState: {
+      status: cycleStatus,
+      periods,
+      events: cycleEvents,
+      summary: cycleSummary,
+    },
+    currentPeriodKey,
+    availablePeriods: sortedPeriodKeys,
+    planConfig: {
+      pl,
+      periodGoal,
+      periodStop,
+      cycleGoal,
+      cycleStop,
+      operationPeriod,
+      adjustmentCycle,
+    },
+    computedAt: new Date().toISOString(),
+    // Reservado para Épico Kelly/Monte Carlo:
+    // kelly: null,
+    // monteCarlo: null,
+    // reallocation: null,
+  };
+};
+
+// ============================================
+// HELPERS — Badge Classification
+// ============================================
+
+/**
+ * Classifica o estado final de um período para badge visual.
+ * Lógica extraída do PlanCardGrid para reuso e testabilidade.
+ *
+ * @param {Object} periodState - Retorno de computePeriodState
+ * @returns {Object} { badge, label, icon, colorClass, animate }
+ */
+export const classifyPeriodBadge = (periodState) => {
+  const { status, summary } = periodState;
+  const { totalPnL, postEventPnL, postEventCount } = summary;
+
+  switch (status) {
+    case PERIOD_STATES.IN_PROGRESS:
+      return { badge: 'IN_PROGRESS', label: 'Em Andamento', icon: 'Activity', colorClass: 'slate', animate: false };
+
+    case PERIOD_STATES.GOAL_HIT:
+      // Meta batida, sem trades pós-meta
+      return { badge: 'GOAL_DISCIPLINED', label: 'Meta Batida', icon: 'Check', colorClass: 'emerald', animate: false };
+
+    case PERIOD_STATES.POST_GOAL:
+      if (totalPnL >= summary.goalVal) {
+        // Pós-meta mas ainda em gain
+        return { badge: 'POST_GOAL_GAIN', label: 'Pós-Meta (Gain)', icon: 'TrendingUp', colorClass: 'amber', animate: false };
+      }
+      if (totalPnL <= 0 && summary.stopVal > 0 && Math.abs(totalPnL) >= summary.stopVal) {
+        // Devolveu tudo e atingiu stop — catástrofe
+        return { badge: 'GOAL_TO_STOP', label: 'Catástrofe', icon: 'Skull', colorClass: 'red', animate: true };
+      }
+      // Devolveu parcial ou total da meta
+      return { badge: 'POST_GOAL_LOSS', label: 'Devolveu Meta', icon: 'TrendingDown', colorClass: 'amber', animate: false };
+
+    case PERIOD_STATES.STOP_HIT:
+      // Stop atingido, sem trades pós-stop
+      return { badge: 'STOP_HIT', label: 'Stop Atingido', icon: 'AlertTriangle', colorClass: 'red', animate: true };
+
+    case PERIOD_STATES.POST_STOP:
+      if (totalPnL >= 0) {
+        // Recuperou do stop — sorte/habilidade
+        return { badge: 'LOSS_TO_GOAL', label: 'Recuperação', icon: 'Trophy', colorClass: 'amber', animate: false };
+      }
+      // Piorou após stop
+      return { badge: 'STOP_WORSENED', label: 'Stop Violado', icon: 'Skull', colorClass: 'red', animate: true };
+
+    default:
+      return { badge: 'UNKNOWN', label: '-', icon: 'Meh', colorClass: 'slate', animate: false };
+  }
+};
+
+/**
+ * Retorna o ícone de sentimento baseado no estado da máquina + P&L.
+ * Evolui a caretinha simples (Smile/Frown/Meh) para usar estados.
+ *
+ * @param {string|null} periodStatus - Estado do período (da state machine), ou null se não calculado
+ * @param {number} pnl - P&L do período
+ * @returns {Object} { icon: string, colorClass: string }
+ */
+export const getSentimentFromState = (periodStatus, pnl) => {
+  if (!periodStatus) {
+    // Fallback: comportamento legacy
+    if (pnl > 0) return { icon: 'Smile', colorClass: 'text-emerald-400' };
+    if (pnl < 0) return { icon: 'Frown', colorClass: 'text-red-400' };
+    return { icon: 'Meh', colorClass: 'text-slate-400' };
+  }
+
+  switch (periodStatus) {
+    case PERIOD_STATES.GOAL_HIT:
+      return { icon: 'Trophy', colorClass: 'text-yellow-400' };
+    case PERIOD_STATES.POST_GOAL:
+      return { icon: 'TrendingUp', colorClass: 'text-amber-400' };
+    case PERIOD_STATES.STOP_HIT:
+    case PERIOD_STATES.POST_STOP:
+      return { icon: 'Skull', colorClass: 'text-red-400' };
+    case PERIOD_STATES.IN_PROGRESS:
+    default:
+      if (pnl > 0) return { icon: 'Smile', colorClass: 'text-emerald-400' };
+      if (pnl < 0) return { icon: 'Frown', colorClass: 'text-red-400' };
+      return { icon: 'Meh', colorClass: 'text-slate-400' };
+  }
+};

--- a/src/version.js
+++ b/src/version.js
@@ -1,10 +1,16 @@
 /**
  * version.js — Single Source of Truth
  * @description Versão do produto Acompanhamento 2.0
+ *
+ * CHANGELOG:
+ * - 1.16.0: State machine plano (#58), badge reclassification, quick fixes dívida técnica
+ * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.15.0',
-  build: '20260303',
+  version: '1.16.0',
+  build: '20260304',
+  display: 'v1.16.0',
+  full: '1.16.0+20260304',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## feat: plan state machine foundation + tech debt fixes

### Resumo

PR de fundação para a v1.16.0. Introduz a máquina de estados do plano como função pura (`planStateMachine.js`) com 30 testes, e resolve 6 itens de dívida técnica acumulada.

**Não fecha issues** — a integração visual (#58, #53) vem no PR 2.

---

### Novos arquivos

| Arquivo | Descrição |
|---------|-----------|
| `src/utils/planStateMachine.js` | Máquina de estados pura: `computePeriodState`, `computePlanState`, `classifyPeriodBadge`, `getSentimentFromState`. Hierarquia Ciclo → Período → Trade. Estados: IN_PROGRESS, GOAL_HIT, STOP_HIT, POST_GOAL, POST_STOP. Shape do retorno futuro-proof para `cycleClosures`. |
| `src/__tests__/utils/planStateMachine.test.js` | 30 testes: transições de período (9), agrupamento diário/semanal (6), ciclo (3), date helpers (4), getPeriodKey (2), badges (8), sentiment (6). TZ-safe (`T12:00:00`). |

### Dívida técnica resolvida

| Fix | Arquivo | Detalhe |
|-----|---------|---------|
| `\|\|` → `??` em `initialBalance` | `useDashboardMetrics.js` | 3 ocorrências (linhas 72, 77, 79). `\|\|` tratava `0` como falsy → fallback indevido para `initialBalance`. |
| Double DebugBadge | `ComplianceConfigPage.jsx` | `{!embedded && <DebugBadge>}` — badge só renderiza em standalone. |
| DebugBadge em sub-componentes | `DashboardHeader.jsx`, `MetricsCards.jsx`, `PlanCardGrid.jsx` | Adicionado conforme regra de desenvolvimento. |
| TradesList formatCurrency hardcoded R$ | `TradesList.jsx` | `formatCurrency(value, currency)` agora aceita moeda, usa `trade.currency` com fallback BRL. |
| version.js campos faltantes | `version.js` | Adicionados `display` e `full` para DebugBadge (bug pré-existente desde v1.15.0). |

### Version bump

`src/version.js` → v1.16.0, build 20260304

### Testes

- **Antes:** 144 passando
- **Depois:** 182 passando (+30 novos, +8 do currency bump anterior)
- Zero falhas

### Checklist

- [x] DebugBadge em componentes novos/modificados
- [x] Testes para nova business logic (planStateMachine)
- [x] SemVer bump em version.js
- [x] CI green (182 tests)
- [x] Sem breaking changes
