### PR TITLE
Feature/v1.16.0 UI integration

### DIFF
--- a/src/components/PlanLedgerExtract.jsx
+++ b/src/components/PlanLedgerExtract.jsx
@@ -1,44 +1,41 @@
 /**
  * PlanLedgerExtract
- * @version 2.0.0 (v1.15.0)
- * @description Extrato Ledger emocional — combina auditoria financeira + perfil emocional + compliance.
- *   v2.0.0: Multi-moeda — recebe `currency` via prop, elimina fmt() hardcoded BRL.
- *   v1.1.0: Exibe RO_FORA, RR_FORA, NO_STOP na coluna Evento e no painel de eventos.
- * 
- * DIFERENÇA DO PlanExtractModal:
- * - PlanExtractModal: compliance financeiro puro (META/STOP)
- * - PlanLedgerExtract: compliance + camada emocional (emoção por trade, eventos, score)
- * 
+ * @version 3.0.0 (v1.16.0)
+ * @description Extrato Ledger emocional — orquestrador.
+ *   v3.0.0: Integra planStateMachine, seletor temporal, sub-componentes extraídos.
+ *   v2.0.0: Multi-moeda via currency prop.
+ *   v1.1.0: Compliance events (RO/RR/NO_STOP).
+ *
+ * ARQUITETURA:
+ *   PlanLedgerExtract (orquestrador)
+ *     ├─ ExtractPeriodSelector (seletor temporal)
+ *     ├─ ExtractSummary (resumo com estado + separação pré/pós)
+ *     ├─ ExtractTable (tabela com RO/RR/Emoção + marcação POST_GOAL/POST_STOP)
+ *     └─ ExtractEvents (painel de eventos)
+ *
  * USAGE:
- * <PlanLedgerExtract plan={plan} trades={planTrades} onClose={fn} currency="USD" />
+ *   <PlanLedgerExtract plan={plan} trades={planTrades} onClose={fn} currency="USD" />
  */
 
-import { useMemo } from 'react';
-import { 
-  X, ScrollText, Trophy, Skull, AlertTriangle, Flame, Zap, 
-  TrendingUp, TrendingDown, Brain, Shield, ShieldAlert, ShieldOff, Scale
-} from 'lucide-react';
+import { useState, useMemo } from 'react';
+import { X, ScrollText } from 'lucide-react';
 import { useMasterData } from '../hooks/useMasterData';
 import { useEmotionalProfile } from '../hooks/useEmotionalProfile';
 import { useComplianceRules } from '../hooks/useComplianceRules';
 import { formatCurrencyDynamic } from '../utils/currency';
-import DebugBadge from '../components/DebugBadge';
+import { computePlanState } from '../utils/planStateMachine';
+import DebugBadge from './DebugBadge';
 
-const fmtDate = (d) => { if (!d) return '-'; const [y, m, dd] = d.split('-'); return `${dd}/${m}`; };
-const fmtTime = (iso) => { if (!iso) return ''; try { return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }); } catch { return ''; } };
+// Sub-componentes extraídos
+import ExtractPeriodSelector from './extract/ExtractPeriodSelector';
+import ExtractSummary from './extract/ExtractSummary';
+import ExtractTable from './extract/ExtractTable';
+import ExtractEvents from './extract/ExtractEvents';
 
-const scoreColor = (score) => {
-  if (score >= 70) return 'text-emerald-400';
-  if (score >= 40) return 'text-amber-400';
-  return 'text-red-400';
-};
-
-const getEmotionColor = (category) => {
-  switch (category) {
-    case 'POSITIVE': return 'text-emerald-400';
-    case 'NEGATIVE': return 'text-red-400';
-    default: return 'text-slate-400';
-  }
+const fmtTime = (iso) => {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }); }
+  catch { return ''; }
 };
 
 const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
@@ -46,153 +43,149 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
   const { detectionConfig, statusThresholds } = useComplianceRules();
   const emotional = useEmotionalProfile({ trades, detectionConfig, statusThresholds });
 
-  // Wrapper de formatação com moeda do plano
+  // Seletor temporal: null = ciclo inteiro, string = periodKey
+  const [selectedPeriod, setSelectedPeriod] = useState(null);
+
+  // Currency formatter parcial
   const fmt = (v) => formatCurrencyDynamic(v, currency);
 
-  const { ledger, events, summary } = useMemo(() => {
-    if (!plan || !trades) return { ledger: [], events: [], summary: null };
+  // ==================== STATE MACHINE ====================
 
-    const sorted = [...trades].sort((a, b) => {
-      const da = a.entryTime || a.date;
-      const db = b.entryTime || b.date;
-      return new Date(da) - new Date(db);
+  const planState = useMemo(() => {
+    if (!plan || !trades || trades.length === 0) return null;
+
+    return computePlanState(trades, {
+      pl: Number(plan.pl) || 0,
+      periodGoal: Number(plan.periodGoal) || 0,
+      periodStop: Number(plan.periodStop) || 0,
+      cycleGoal: Number(plan.cycleGoal) || 0,
+      cycleStop: Number(plan.cycleStop) || 0,
+      operationPeriod: plan.operationPeriod || 'Diário',
+      adjustmentCycle: plan.adjustmentCycle || 'Mensal',
     });
+  }, [plan, trades]);
 
-    const startPL = Number(plan.pl) || 0;
-    const goalVal = startPL * ((plan.periodGoal || plan.goalPercent || 5) / 100);
-    const stopVal = startPL * ((plan.periodStop || plan.stopPercent || 3) / 100);
+  // ==================== DADOS DERIVADOS ====================
 
-    let balance = 0;
-    let goalHit = false;
-    let stopHit = false;
+  const currentPeriodState = useMemo(() => {
+    if (!planState) return null;
+    if (selectedPeriod === null) return null;
+    return planState.cycleState.periods.get(selectedPeriod) || null;
+  }, [planState, selectedPeriod]);
+
+  // Rows para a tabela
+  const tableRows = useMemo(() => {
+    if (!planState) return [];
+    if (selectedPeriod === null) {
+      // Ciclo inteiro: concatenar rows de todos os períodos
+      const allRows = [];
+      for (const periodKey of planState.availablePeriods) {
+        const period = planState.cycleState.periods.get(periodKey);
+        if (period) allRows.push(...period.rows);
+      }
+      return allRows;
+    }
+    return currentPeriodState?.rows || [];
+  }, [planState, selectedPeriod, currentPeriodState]);
+
+  // Eventos consolidados
+  const allEvents = useMemo(() => {
+    if (!planState) return [];
     const evts = [];
 
-    const rows = sorted.map((t, i) => {
-      const result = Number(t.result) || 0;
-      balance += result;
-      
-      const emotionCfg = getEmotionConfig ? getEmotionConfig(t.emotionEntry) : null;
-      const emoji = emotionCfg?.emoji || '❓';
-      const emotionName = emotionCfg?.name || t.emotionEntry || '-';
-      const category = emotionCfg?.analysisCategory || 'NEUTRAL';
-
-      let event = null;
-      if (!goalHit && !stopHit && balance >= goalVal && goalVal > 0) {
-        goalHit = true;
-        event = 'GOAL_HIT';
-        evts.push({ type: 'GOAL_HIT', date: t.date, time: fmtTime(t.entryTime), message: `META atingida: ${fmt(balance)}` });
-      } else if (!goalHit && !stopHit && balance <= -stopVal) {
-        stopHit = true;
-        event = 'STOP_HIT';
-        evts.push({ type: 'STOP_HIT', date: t.date, time: fmtTime(t.entryTime), message: `STOP atingido: ${fmt(balance)}` });
-      } else if (goalHit) {
-        event = 'POST_GOAL';
-      } else if (stopHit) {
-        event = 'POST_STOP';
+    // Eventos da state machine (por período)
+    for (const periodKey of planState.availablePeriods) {
+      const period = planState.cycleState.periods.get(periodKey);
+      if (period?.events) {
+        period.events.forEach(e => {
+          evts.push({
+            type: e.type,
+            date: e.timestamp?.split?.('T')?.[0] || periodKey,
+            time: fmtTime(e.timestamp),
+            message: e.type === 'GOAL_HIT'
+              ? `META atingida: ${fmt(e.cumPnL)}`
+              : `STOP atingido: ${fmt(e.cumPnL)}`
+          });
+        });
       }
+    }
 
-      // Compliance flags por trade (do Firestore, calculado pela CF)
-      const complianceFlags = [];
-      if (t.compliance?.roStatus === 'FORA_DO_PLANO') complianceFlags.push('RO_FORA');
-      if (t.compliance?.rrStatus === 'NAO_CONFORME') complianceFlags.push('RR_FORA');
-      const hasNoStop = Array.isArray(t.redFlags) && t.redFlags.some(f => 
-        (typeof f === 'string' ? f : f.type) === 'TRADE_SEM_STOP'
-      );
-      if (hasNoStop) complianceFlags.push('NO_STOP');
-
-      // Push compliance events
-      complianceFlags.forEach(flag => {
-        const msgs = {
-          RO_FORA: `RO fora do plano: ${t.ticker} (${(t.riskPercent || 0).toFixed(1)}%)`,
-          RR_FORA: `RR não conforme: ${t.ticker} (${(t.rrRatio || 0).toFixed(1)}x)`,
-          NO_STOP: `Trade sem stop: ${t.ticker}`
-        };
-        evts.push({ type: flag, date: t.date, time: fmtTime(t.entryTime), message: msgs[flag] });
+    // Eventos do ciclo
+    planState.cycleState.events?.forEach(e => {
+      evts.push({
+        type: e.type,
+        date: e.periodKey,
+        time: '',
+        message: e.type === 'CYCLE_GOAL_HIT'
+          ? `Meta do Ciclo atingida: ${fmt(e.cycleCumPnL)}`
+          : `Stop do Ciclo atingido: ${fmt(e.cycleCumPnL)}`
       });
-
-      return {
-        ...t,
-        idx: i + 1,
-        result,
-        runningBalance: balance,
-        emoji,
-        emotionName,
-        emotionCategory: category,
-        event,
-        complianceFlags
-      };
     });
 
-    // Adicionar eventos TILT/REVENGE dos alertas emocionais
+    // Compliance events
+    for (const row of tableRows) {
+      const trade = row.trade;
+      if (trade.compliance?.roStatus === 'FORA_DO_PLANO') {
+        evts.push({
+          type: 'RO_FORA', date: trade.date, time: fmtTime(trade.entryTime),
+          message: `RO fora do plano: ${trade.ticker} (${(trade.riskPercent || 0).toFixed(1)}%)`
+        });
+      }
+      if (trade.compliance?.rrStatus === 'NAO_CONFORME') {
+        evts.push({
+          type: 'RR_FORA', date: trade.date, time: fmtTime(trade.entryTime),
+          message: `RR não conforme: ${trade.ticker} (${(trade.rrRatio || 0).toFixed(1)}x)`
+        });
+      }
+      const hasNoStop = Array.isArray(trade.redFlags) && trade.redFlags.some(f =>
+        (typeof f === 'string' ? f : f.type) === 'TRADE_SEM_STOP'
+      );
+      if (hasNoStop) {
+        evts.push({
+          type: 'NO_STOP', date: trade.date, time: fmtTime(trade.entryTime),
+          message: `Trade sem stop: ${trade.ticker}`
+        });
+      }
+    }
+
+    // Alertas emocionais
     if (emotional.isReady && emotional.alerts) {
       emotional.alerts.forEach(a => {
-        if (a.type === 'TILT' || a.type === 'REVENGE' || a.type === 'STATUS_CRITICAL') {
-          const alertDate = a.date || a.tradeDate || (rows.length > 0 ? rows[rows.length - 1].date : null);
-          if (!alertDate) return;
+        if (['TILT_DETECTED', 'REVENGE_DETECTED', 'STATUS_CRITICAL'].includes(a.type)) {
           evts.push({
             type: a.type,
-            date: alertDate,
-            time: a.time || '',
+            date: a.timestamp?.split?.('T')?.[0] || '',
+            time: fmtTime(a.timestamp),
             message: a.message
           });
         }
       });
     }
 
-    // Sort events por data
     evts.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+    return evts;
+  }, [planState, tableRows, emotional, fmt]);
 
+  // Dados emocionais para o summary
+  const emotionalData = useMemo(() => {
+    if (!emotional.isReady) return null;
     return {
-      ledger: rows,
-      events: evts,
-      summary: {
-        startPL,
-        totalResult: balance,
-        currentPL: startPL + balance,
-        goalVal,
-        stopVal,
-        goalHit,
-        stopHit,
-        tradesCount: rows.length,
-        score: emotional.isReady ? emotional.metrics?.emotionalScore : null,
-        statusLabel: emotional.isReady ? emotional.status?.label : null
-      }
+      score: emotional.metrics?.score ?? null,
+      statusLabel: emotional.status?.label || '-'
     };
-  }, [plan, trades, getEmotionConfig, emotional]);
+  }, [emotional]);
+
+  // ==================== RENDER ====================
 
   if (!plan) return null;
 
-  const getEventIcon = (type) => {
-    switch (type) {
-      case 'GOAL_HIT': return <Trophy className="w-3.5 h-3.5 text-emerald-400" />;
-      case 'STOP_HIT': return <Skull className="w-3.5 h-3.5 text-red-400" />;
-      case 'TILT': return <Flame className="w-3.5 h-3.5 text-orange-400" />;
-      case 'REVENGE': return <Zap className="w-3.5 h-3.5 text-red-400" />;
-      case 'STATUS_CRITICAL': return <AlertTriangle className="w-3.5 h-3.5 text-red-400" />;
-      case 'RO_FORA': return <ShieldOff className="w-3.5 h-3.5 text-amber-400" />;
-      case 'RR_FORA': return <Scale className="w-3.5 h-3.5 text-amber-400" />;
-      case 'NO_STOP': return <ShieldAlert className="w-3.5 h-3.5 text-red-400" />;
-      default: return <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />;
-    }
-  };
-
-  const getEventStyle = (type) => {
-    switch (type) {
-      case 'GOAL_HIT': return 'bg-emerald-500/10 border-emerald-500/30';
-      case 'STOP_HIT': return 'bg-red-500/10 border-red-500/30';
-      case 'TILT': return 'bg-orange-500/10 border-orange-500/30';
-      case 'REVENGE': return 'bg-red-500/10 border-red-500/30';
-      case 'STATUS_CRITICAL': return 'bg-red-500/10 border-red-500/30';
-      case 'RO_FORA': case 'RR_FORA': return 'bg-amber-500/10 border-amber-500/30';
-      case 'NO_STOP': return 'bg-red-500/10 border-red-500/30';
-      default: return 'bg-yellow-500/10 border-yellow-500/30';
-    }
-  };
+  const startPL = Number(plan.pl) || 0;
+  const isCycleView = selectedPeriod === null;
 
   return (
     <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
       <div className="bg-slate-900 border border-slate-800 w-full max-w-6xl h-[90vh] rounded-xl flex flex-col shadow-2xl ring-1 ring-white/10">
-        
+
         {/* Header */}
         <div className="p-5 border-b border-slate-800 flex justify-between items-start">
           <div className="flex items-center gap-3">
@@ -201,7 +194,9 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
             </div>
             <div>
               <h2 className="text-lg font-bold text-white">Extrato Emocional: {plan.name}</h2>
-              <p className="text-xs text-slate-400">Auditoria Financeira + Perfil Emocional</p>
+              <p className="text-xs text-slate-400">
+                {plan.operationPeriod || 'Diário'} · {plan.adjustmentCycle || 'Mensal'} · {fmt(startPL)}
+              </p>
             </div>
           </div>
           <button onClick={onClose} className="p-2 hover:bg-slate-800 rounded-full text-slate-400 hover:text-white">
@@ -209,144 +204,37 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
           </button>
         </div>
 
-        {/* Resumo */}
-        {summary && (
-          <div className="px-5 py-4 bg-slate-800/30 border-b border-slate-800">
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-              <div>
-                <span className="text-[10px] text-slate-500 uppercase block">PL Inicial</span>
-                <span className="text-sm font-mono font-bold text-white">{fmt(summary.startPL)}</span>
-              </div>
-              <div>
-                <span className="text-[10px] text-slate-500 uppercase block">Resultado</span>
-                <span className={`text-sm font-mono font-bold ${summary.totalResult >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
-                  {summary.totalResult >= 0 ? '+' : ''}{fmt(summary.totalResult)}
-                </span>
-              </div>
-              <div>
-                <span className="text-[10px] text-slate-500 uppercase block">PL Atual</span>
-                <span className={`text-sm font-mono font-bold ${summary.currentPL >= summary.startPL ? 'text-emerald-400' : 'text-red-400'}`}>
-                  {fmt(summary.currentPL)}
-                </span>
-              </div>
-              <div>
-                <span className="text-[10px] text-slate-500 uppercase block">Status</span>
-                <span className={`text-sm font-bold ${summary.goalHit ? 'text-emerald-400' : summary.stopHit ? 'text-red-400' : 'text-blue-400'}`}>
-                  {summary.goalHit ? '🏆 Meta Batida' : summary.stopHit ? '🔴 Stop Atingido' : '📊 Em Andamento'}
-                </span>
-              </div>
-              <div>
-                <span className="text-[10px] text-slate-500 uppercase block flex items-center gap-1">
-                  <Brain className="w-3 h-3" /> Score Emocional
-                </span>
-                {summary.score !== null ? (
-                  <span className={`text-sm font-bold ${scoreColor(summary.score)}`}>
-                    {Math.round(summary.score)}/100 · {summary.statusLabel}
-                  </span>
-                ) : (
-                  <span className="text-sm text-slate-500">-</span>
-                )}
-              </div>
-            </div>
+        {/* Period Selector */}
+        {planState && (
+          <div className="px-5 py-3 border-b border-slate-800/50 bg-slate-800/10">
+            <ExtractPeriodSelector
+              availablePeriods={planState.availablePeriods}
+              selectedPeriod={selectedPeriod}
+              onSelectPeriod={setSelectedPeriod}
+              operationPeriod={plan.operationPeriod || 'Diário'}
+              currentPeriodKey={planState.currentPeriodKey}
+            />
           </div>
         )}
 
-        {/* Tabela */}
-        <div className="flex-1 overflow-auto">
-          <table className="w-full text-sm text-left border-collapse">
-            <thead className="bg-slate-800/80 text-[10px] uppercase text-slate-500 sticky top-0 z-10 font-bold tracking-wider">
-              <tr>
-                <th className="p-3 w-12 text-center">#</th>
-                <th className="p-3">Data</th>
-                <th className="p-3">Ativo</th>
-                <th className="p-3">Emoção</th>
-                <th className="p-3 text-right">Resultado</th>
-                <th className="p-3 text-right bg-slate-800/50">Acumulado</th>
-                <th className="p-3 text-center w-32">Evento</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-slate-800/50">
-              {ledger.map((row) => {
-                const isGhost = row.event === 'POST_GOAL' || row.event === 'POST_STOP';
-                const isEvent = row.event === 'GOAL_HIT' || row.event === 'STOP_HIT';
+        <ExtractSummary
+          periodState={currentPeriodState}
+          startPL={startPL}
+          fmt={fmt}
+          emotionalData={emotionalData}
+          isCycleView={isCycleView}
+          cycleSummary={planState?.cycleState?.summary || null}
+          cycleStatus={planState?.cycleState?.status || 'IN_PROGRESS'}
+        />
 
-                return (
-                  <tr key={row.id} className={`transition-all hover:bg-slate-800/40 ${
-                    isGhost ? 'opacity-40 hover:opacity-100' : ''
-                  } ${isEvent ? 'bg-slate-800/60' : ''}`}>
-                    <td className="p-3 text-center text-slate-600 font-mono text-xs">{row.idx}</td>
-                    <td className="p-3 text-slate-300">
-                      <span className="font-medium">{fmtDate(row.date)}</span>
-                      <span className="text-[10px] text-slate-500 ml-1">{fmtTime(row.entryTime)}</span>
-                    </td>
-                    <td className="p-3">
-                      <span className="text-white font-bold">{row.ticker}</span>
-                      <span className={`text-[10px] ml-1.5 px-1 py-0.5 rounded border ${
-                        row.side === 'LONG' ? 'border-emerald-500/30 text-emerald-500' : 'border-red-500/30 text-red-500'
-                      }`}>{row.side}</span>
-                    </td>
-                    <td className="p-3">
-                      <span className={`text-xs ${getEmotionColor(row.emotionCategory)}`}>
-                        {row.emoji} {row.emotionName}
-                      </span>
-                    </td>
-                    <td className={`p-3 text-right font-mono font-bold ${row.result >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
-                      {row.result > 0 ? '+' : ''}{fmt(row.result)}
-                    </td>
-                    <td className={`p-3 text-right font-mono font-bold bg-slate-800/30 border-l border-slate-800 ${
-                      row.runningBalance >= 0 ? 'text-emerald-300' : 'text-red-300'
-                    }`}>{fmt(row.runningBalance)}</td>
-                    <td className="p-3 text-center">
-                      <div className="flex flex-col items-center gap-0.5">
-                        {row.event === 'GOAL_HIT' && <span className="text-emerald-400 font-bold text-xs flex justify-center items-center gap-1"><Trophy className="w-3 h-3" /> META!</span>}
-                        {row.event === 'STOP_HIT' && <span className="text-red-400 font-bold text-xs flex justify-center items-center gap-1"><Skull className="w-3 h-3" /> STOP!</span>}
-                        {row.event === 'POST_GOAL' && <span className="text-yellow-500/70 text-[10px] uppercase font-bold">Pós-Meta</span>}
-                        {row.event === 'POST_STOP' && <span className="text-red-500/70 text-[10px] uppercase font-bold">Violação</span>}
-                        {row.complianceFlags?.includes('NO_STOP') && (
-                          <span className="text-red-400 text-[10px] font-bold flex items-center gap-0.5" title="Trade sem stop loss">
-                            <ShieldAlert className="w-3 h-3" /> S/STOP
-                          </span>
-                        )}
-                        {row.complianceFlags?.includes('RO_FORA') && (
-                          <span className="text-amber-400 text-[10px] font-bold flex items-center gap-0.5" title="Risco operacional fora do plano">
-                            <ShieldOff className="w-3 h-3" /> RO
-                          </span>
-                        )}
-                        {row.complianceFlags?.includes('RR_FORA') && (
-                          <span className="text-amber-400 text-[10px] font-bold flex items-center gap-0.5" title="Razão risco-retorno não conforme">
-                            <Scale className="w-3 h-3" /> RR
-                          </span>
-                        )}
-                        {!row.event && (!row.complianceFlags || row.complianceFlags.length === 0) && <span className="text-slate-600 text-xs">-</span>}
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-              {ledger.length === 0 && (
-                <tr><td colSpan="7" className="p-12 text-center text-slate-500">Nenhum trade neste plano.</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+        <ExtractTable
+          rows={tableRows}
+          fmt={fmt}
+          getEmotionConfig={getEmotionConfig}
+        />
 
-        {/* Eventos */}
-        {events.length > 0 && (
-          <div className="p-4 border-t border-slate-800 bg-slate-800/20 max-h-36 overflow-y-auto">
-            <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2 flex items-center gap-1.5">
-              <Shield className="w-3.5 h-3.5" /> Eventos ({events.length})
-            </h4>
-            <div className="space-y-1.5">
-              {events.map((evt, i) => (
-                <div key={i} className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs ${getEventStyle(evt.type)}`}>
-                  {getEventIcon(evt.type)}
-                  <span className="text-slate-500 font-mono">{fmtDate(evt.date)} {evt.time}</span>
-                  <span className="text-slate-300">{evt.message}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <ExtractEvents events={allEvents} />
+
       </div>
       <DebugBadge component="PlanLedgerExtract" />
     </div>

--- a/src/components/PlanLedgerExtract.jsx
+++ b/src/components/PlanLedgerExtract.jsx
@@ -73,19 +73,41 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
     return planState.cycleState.periods.get(selectedPeriod) || null;
   }, [planState, selectedPeriod]);
 
-  // Rows para a tabela
-  const tableRows = useMemo(() => {
-    if (!planState) return [];
+  // Rows para a tabela + saldo anterior (carry-over entre períodos)
+  const { tableRows, carryOver } = useMemo(() => {
+    if (!planState) return { tableRows: [], carryOver: 0 };
+
     if (selectedPeriod === null) {
-      // Ciclo inteiro: concatenar rows de todos os períodos
+      // Ciclo inteiro: concatenar rows com acumulado contínuo
       const allRows = [];
+      let runningTotal = 0;
       for (const periodKey of planState.availablePeriods) {
         const period = planState.cycleState.periods.get(periodKey);
-        if (period) allRows.push(...period.rows);
+        if (!period) continue;
+        for (const row of period.rows) {
+          runningTotal += row.result;
+          allRows.push({ ...row, cumPnL: runningTotal });
+        }
       }
-      return allRows;
+      return { tableRows: allRows, carryOver: 0 };
     }
-    return currentPeriodState?.rows || [];
+
+    // Período individual: calcular carry-over dos períodos anteriores
+    let carry = 0;
+    for (const periodKey of planState.availablePeriods) {
+      if (periodKey === selectedPeriod) break;
+      const period = planState.cycleState.periods.get(periodKey);
+      if (period) carry += period.summary.totalPnL;
+    }
+
+    // Ajustar cumPnL dos rows com o carry-over
+    const periodRows = currentPeriodState?.rows || [];
+    const adjustedRows = periodRows.map(row => ({
+      ...row,
+      cumPnL: carry + row.cumPnL,
+    }));
+
+    return { tableRows: adjustedRows, carryOver: carry };
   }, [planState, selectedPeriod, currentPeriodState]);
 
   // Eventos consolidados
@@ -231,6 +253,7 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
           rows={tableRows}
           fmt={fmt}
           getEmotionConfig={getEmotionConfig}
+          carryOver={carryOver}
         />
 
         <ExtractEvents events={allEvents} />

--- a/src/components/dashboard/PlanCardGrid.jsx
+++ b/src/components/dashboard/PlanCardGrid.jsx
@@ -1,62 +1,80 @@
 /**
  * PlanCardGrid
- * @version 1.0.0 (v1.15.0)
+ * @version 2.0.0 (v1.16.0)
  * @description Grid de cards de planos operacionais.
- *   Extraído do StudentDashboard para modularização.
- *   Inclui: MiniProgressBar, renderSentimentIcon, getComplianceBadge.
+ *   v2.0.0: Integra planStateMachine para badges e sentiment icons.
+ *   v1.0.0: Extraído do StudentDashboard (v1.15.0).
+ *
+ * MUDANÇAS v2:
+ * - getComplianceBadge() → classifyPeriodBadge() (da state machine)
+ * - renderSentimentIcon() → getSentimentFromState() (da state machine)
+ * - Novos badges: POST_GOAL_GAIN, POST_GOAL_LOSS, GOAL_TO_STOP, LOSS_TO_GOAL
+ * - Ícones evoluídos: Trophy, Skull em vez de apenas Smile/Frown/Meh
  */
 
-import { 
+import {
   PlusCircle, Check, Settings, Trash2, RefreshCw, Calendar, ScrollText,
-  Skull, Trophy, TrendingUp, TrendingDown, Smile, Frown, Meh
+  Skull, Trophy, TrendingUp, TrendingDown, Smile, Frown, Meh,
+  AlertTriangle, Activity
 } from 'lucide-react';
-import { filterTradesByPeriod, analyzePlanCompliance } from '../../utils/calculations';
 import { formatCurrencyDynamic } from '../../utils/currency';
 import { calculatePeriodPnL, calculateCyclePnL } from '../../utils/planCalculations';
+import { computePlanState, classifyPeriodBadge, getSentimentFromState } from '../../utils/planStateMachine';
 import DebugBadge from '../DebugBadge';
 
 const MiniProgressBar = ({ current, target, isLoss }) => {
   const percent = target > 0 ? Math.min(Math.abs(current) / target * 100, 100) : 0;
   return (
     <div className="w-full h-1.5 bg-slate-700 rounded-full overflow-hidden">
-      <div 
-        className={`h-full rounded-full transition-all duration-500 ${isLoss ? 'bg-red-500' : 'bg-emerald-500'}`} 
-        style={{ width: `${percent}%` }} 
+      <div
+        className={`h-full rounded-full transition-all duration-500 ${isLoss ? 'bg-red-500' : 'bg-emerald-500'}`}
+        style={{ width: `${percent}%` }}
       />
     </div>
   );
 };
 
-const renderSentimentIcon = (pnl) => {
-  if (pnl > 0) return <Smile className="w-5 h-5 text-emerald-400" />;
-  if (pnl < 0) return <Frown className="w-5 h-5 text-red-400" />;
-  return <Meh className="w-5 h-5 text-slate-400" />;
+// Icon map for dynamic rendering from state machine
+const ICON_MAP = {
+  Smile, Frown, Meh, Trophy, Skull, TrendingUp, TrendingDown, AlertTriangle, Activity, Check,
 };
 
-const getComplianceBadge = (compliance) => {
-  const { status } = compliance;
-  const baseClass = "flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-extrabold uppercase tracking-wide border backdrop-blur-sm shadow-sm";
-  if (status === 'LOSS_TO_GOAL') return <div className={`${baseClass} bg-amber-500/10 text-amber-400 border-amber-500/30`} title="Sorte"><Trophy className="w-3 h-3"/> Meta (Sorte)</div>;
-  if (status === 'GOAL_IMPROVED') return <div className={`${baseClass} bg-amber-500/10 text-amber-400 border-amber-500/30`} title="Risco"><TrendingUp className="w-3 h-3"/> Overtrading</div>;
-  if (status === 'GOAL_GAVE_BACK') return <div className={`${baseClass} bg-amber-500/10 text-amber-400 border-amber-500/30`} title="Ganância"><TrendingDown className="w-3 h-3"/> Devolveu Meta</div>;
-  if (status === 'GOAL_TO_STOP') return <div className={`${baseClass} bg-red-500/10 text-red-400 border-red-500/30 animate-pulse`} title="Catástrofe"><Skull className="w-3 h-3"/> Catástrofe</div>;
-  if (status === 'STOP_WORSENED' || status === 'STOP_RECOVERED') return <div className={`${baseClass} bg-red-500/10 text-red-400 border-red-500/30 animate-pulse`} title="Disciplina"><Skull className="w-3 h-3"/> Stop Violado</div>;
-  if (status === 'GOAL_DISCIPLINED') return <div className={`${baseClass} bg-emerald-500/10 text-emerald-400 border-emerald-500/30`} title="Parabéns"><Check className="w-3 h-3"/> Meta Batida</div>;
-  return null;
+const COLOR_MAP = {
+  emerald: { bg: 'bg-emerald-500/10', text: 'text-emerald-400', border: 'border-emerald-500/30' },
+  red: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/30' },
+  amber: { bg: 'bg-amber-500/10', text: 'text-amber-400', border: 'border-amber-500/30' },
+  slate: { bg: 'bg-slate-500/10', text: 'text-slate-400', border: 'border-slate-500/30' },
 };
 
 /**
- * @param {Array} availablePlans - Planos ativos filtrados
- * @param {Array} accounts - Todas as contas
- * @param {Array} trades - Todos os trades (não filtrados, para PnL por plano)
- * @param {string|null} selectedPlanId - ID do plano selecionado
- * @param {boolean} viewAs - Se é visualização de mentor
- * @param {Function} onSelectPlan - (planId) => void
- * @param {Function} onOpenLedger - (plan) => void
- * @param {Function} onEditPlan - (plan) => void
- * @param {Function} onDeletePlan - (e, planId) => void
- * @param {Function} onCreatePlan - () => void
+ * Renderiza badge de compliance baseado na state machine.
  */
+const renderStateBadge = (badge) => {
+  if (!badge || badge.badge === 'IN_PROGRESS' || badge.badge === 'UNKNOWN') return null;
+
+  const colors = COLOR_MAP[badge.colorClass] || COLOR_MAP.slate;
+  const Icon = ICON_MAP[badge.icon] || Activity;
+  const baseClass = "flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] font-extrabold uppercase tracking-wide border backdrop-blur-sm shadow-sm";
+
+  return (
+    <div
+      className={`${baseClass} ${colors.bg} ${colors.text} ${colors.border} ${badge.animate ? 'animate-pulse' : ''}`}
+      title={badge.label}
+    >
+      <Icon className="w-3 h-3" />
+      {badge.label}
+    </div>
+  );
+};
+
+/**
+ * Renderiza ícone de sentimento baseado na state machine.
+ */
+const renderSentimentFromState = (sentiment) => {
+  const Icon = ICON_MAP[sentiment.icon] || Meh;
+  return <Icon className={`w-5 h-5 ${sentiment.colorClass}`} />;
+};
+
 const PlanCardGrid = ({
   availablePlans,
   accounts,
@@ -93,12 +111,32 @@ const PlanCardGrid = ({
         const periodGoalVal = (plan.pl * (plan.periodGoal / 100));
         const cycleGoalVal = (plan.pl * (plan.cycleGoal / 100));
         const cycleStopVal = (plan.pl * (plan.cycleStop / 100));
-        const currentPeriodTrades = filterTradesByPeriod(planTrades, plan.operationPeriod);
-        const compliance = analyzePlanCompliance(currentPeriodTrades, periodStopVal, periodGoalVal);
+
+        // State machine: computar estado do período atual
+        const planState = computePlanState(planTrades, {
+          pl: planInitialPL,
+          periodGoal: Number(plan.periodGoal) || 0,
+          periodStop: Number(plan.periodStop) || 0,
+          cycleGoal: Number(plan.cycleGoal) || 0,
+          cycleStop: Number(plan.cycleStop) || 0,
+          operationPeriod: plan.operationPeriod || 'Diário',
+          adjustmentCycle: plan.adjustmentCycle || 'Mensal',
+        });
+
+        // Badge do período atual
+        const currentPeriodKey = planState?.currentPeriodKey;
+        const currentPeriodState = currentPeriodKey
+          ? planState.cycleState.periods.get(currentPeriodKey)
+          : null;
+        const badge = currentPeriodState ? classifyPeriodBadge(currentPeriodState) : null;
+
+        // Sentiment icon do período atual
+        const periodStatus = currentPeriodState?.status || null;
+        const sentiment = getSentimentFromState(periodStatus, periodPnL);
 
         return (
           <div key={plan.id} onClick={() => onSelectPlan(isSelected ? null : plan.id)} className={`relative cursor-pointer transition-all duration-300 overflow-hidden rounded-2xl border group ${isSelected ? 'bg-blue-600/10 border-blue-500 shadow-[0_0_20px_rgba(59,130,246,0.2)]' : 'bg-slate-800/40 border-slate-700/50 hover:bg-slate-800/60 hover:border-slate-600'}`}>
-            <div className="absolute top-2 left-2 z-30">{getComplianceBadge(compliance)}</div>
+            <div className="absolute top-2 left-2 z-30">{renderStateBadge(badge)}</div>
             <div className="absolute top-2 right-2 flex gap-1 z-20">
               <button onClick={(e) => { e.stopPropagation(); onOpenLedger(plan); }} className="p-1.5 rounded-lg text-slate-400 hover:text-purple-400 hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100" title="Extrato Emocional"><ScrollText className="w-4 h-4" /></button>
               {!viewAs && (
@@ -113,7 +151,7 @@ const PlanCardGrid = ({
               <div>
                 <div className="flex justify-between items-start mb-2 pl-8 mt-6">
                   <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-slate-700 to-slate-800 flex items-center justify-center border border-slate-600/50 shadow-inner ml-auto">
-                    <div className={!plan.active ? 'opacity-50 grayscale' : ''}>{renderSentimentIcon(periodPnL)}</div>
+                    <div className={!plan.active ? 'opacity-50 grayscale' : ''}>{renderSentimentFromState(sentiment)}</div>
                   </div>
                 </div>
                 <h3 className={`font-bold truncate mb-1 pr-6 ${isSelected ? 'text-white' : 'text-slate-300'}`}>{plan.name}</h3>

--- a/src/components/extract/ExtractEvents.jsx
+++ b/src/components/extract/ExtractEvents.jsx
@@ -1,0 +1,68 @@
+/**
+ * ExtractEvents
+ * @version 1.0.0 (v1.16.0)
+ * @description Painel de eventos do extrato — compliance, emocional, state machine.
+ *   Extraído do PlanLedgerExtract para modularização.
+ */
+
+import {
+  Trophy, Skull, AlertTriangle, Flame, Zap,
+  ShieldOff, ShieldAlert, Scale, Shield
+} from 'lucide-react';
+
+const fmtDate = (d) => { if (!d) return '-'; const [y, m, dd] = d.split('-'); return `${dd}/${m}`; };
+
+const getEventIcon = (type) => {
+  switch (type) {
+    case 'GOAL_HIT': return <Trophy className="w-3.5 h-3.5 text-emerald-400" />;
+    case 'STOP_HIT': return <Skull className="w-3.5 h-3.5 text-red-400" />;
+    case 'TILT_DETECTED': case 'TILT': return <Flame className="w-3.5 h-3.5 text-orange-400" />;
+    case 'REVENGE_DETECTED': case 'REVENGE': return <Zap className="w-3.5 h-3.5 text-red-400" />;
+    case 'STATUS_CRITICAL': return <AlertTriangle className="w-3.5 h-3.5 text-red-400" />;
+    case 'RO_FORA': return <ShieldOff className="w-3.5 h-3.5 text-amber-400" />;
+    case 'RR_FORA': return <Scale className="w-3.5 h-3.5 text-amber-400" />;
+    case 'NO_STOP': return <ShieldAlert className="w-3.5 h-3.5 text-red-400" />;
+    case 'CYCLE_GOAL_HIT': return <Trophy className="w-3.5 h-3.5 text-emerald-400" />;
+    case 'CYCLE_STOP_HIT': return <Skull className="w-3.5 h-3.5 text-red-400" />;
+    default: return <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />;
+  }
+};
+
+const getEventStyle = (type) => {
+  switch (type) {
+    case 'GOAL_HIT': case 'CYCLE_GOAL_HIT': return 'bg-emerald-500/10 border-emerald-500/30';
+    case 'STOP_HIT': case 'CYCLE_STOP_HIT': return 'bg-red-500/10 border-red-500/30';
+    case 'TILT_DETECTED': case 'TILT': return 'bg-orange-500/10 border-orange-500/30';
+    case 'REVENGE_DETECTED': case 'REVENGE': return 'bg-red-500/10 border-red-500/30';
+    case 'STATUS_CRITICAL': return 'bg-red-500/10 border-red-500/30';
+    case 'RO_FORA': case 'RR_FORA': return 'bg-amber-500/10 border-amber-500/30';
+    case 'NO_STOP': return 'bg-red-500/10 border-red-500/30';
+    default: return 'bg-yellow-500/10 border-yellow-500/30';
+  }
+};
+
+/**
+ * @param {Array} events - Eventos da state machine + compliance + emocional
+ */
+const ExtractEvents = ({ events }) => {
+  if (!events || events.length === 0) return null;
+
+  return (
+    <div className="p-4 border-t border-slate-800 bg-slate-800/20 max-h-36 overflow-y-auto">
+      <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+        <Shield className="w-3.5 h-3.5" /> Eventos ({events.length})
+      </h4>
+      <div className="space-y-1.5">
+        {events.map((evt, i) => (
+          <div key={i} className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs ${getEventStyle(evt.type)}`}>
+            {getEventIcon(evt.type)}
+            <span className="text-slate-500 font-mono">{fmtDate(evt.date)} {evt.time || ''}</span>
+            <span className="text-slate-300">{evt.message}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ExtractEvents;

--- a/src/components/extract/ExtractPeriodSelector.jsx
+++ b/src/components/extract/ExtractPeriodSelector.jsx
@@ -1,0 +1,73 @@
+/**
+ * ExtractPeriodSelector
+ * @version 1.0.0 (v1.16.0)
+ * @description Seletor temporal para o extrato do plano.
+ *   Toggle: Ciclo (consolidado) vs períodos individuais.
+ */
+
+import { Calendar, RefreshCw } from 'lucide-react';
+
+const fmtPeriodLabel = (periodKey, operationPeriod) => {
+  if (!periodKey) return '-';
+  const [y, m, d] = periodKey.split('-');
+  return operationPeriod === 'Semanal' ? `Sem. ${d}/${m}` : `${d}/${m}`;
+};
+
+/**
+ * @param {string[]} availablePeriods - Chaves dos períodos disponíveis
+ * @param {string|null} selectedPeriod - Período selecionado (null = visão ciclo)
+ * @param {Function} onSelectPeriod - (periodKey|null) => void
+ * @param {string} operationPeriod - 'Diário' | 'Semanal'
+ * @param {string} currentPeriodKey - Chave do período atual (highlight)
+ */
+const ExtractPeriodSelector = ({
+  availablePeriods,
+  selectedPeriod,
+  onSelectPeriod,
+  operationPeriod,
+  currentPeriodKey,
+}) => {
+  const isCycleView = selectedPeriod === null;
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <button
+        onClick={() => onSelectPeriod(null)}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold uppercase tracking-wider border transition-all ${
+          isCycleView
+            ? 'bg-purple-500/20 text-purple-400 border-purple-500/40'
+            : 'bg-slate-800/50 text-slate-500 border-slate-700/50 hover:text-slate-300 hover:border-slate-600'
+        }`}
+      >
+        <RefreshCw className="w-3 h-3" />
+        Ciclo
+      </button>
+      <span className="text-slate-700">|</span>
+      {availablePeriods.map(periodKey => {
+        const isSelected = selectedPeriod === periodKey;
+        const isCurrent = periodKey === currentPeriodKey;
+        return (
+          <button
+            key={periodKey}
+            onClick={() => onSelectPeriod(periodKey)}
+            className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-mono border transition-all ${
+              isSelected
+                ? 'bg-blue-500/20 text-blue-400 border-blue-500/40 font-bold'
+                : isCurrent
+                  ? 'bg-slate-800/50 text-slate-300 border-slate-600 hover:border-blue-500/40'
+                  : 'bg-slate-800/30 text-slate-500 border-slate-700/30 hover:text-slate-300 hover:border-slate-600'
+            }`}
+          >
+            <Calendar className="w-3 h-3" />
+            {fmtPeriodLabel(periodKey, operationPeriod)}
+          </button>
+        );
+      })}
+      {availablePeriods.length === 0 && (
+        <span className="text-xs text-slate-600 italic">Sem períodos com trades</span>
+      )}
+    </div>
+  );
+};
+
+export default ExtractPeriodSelector;

--- a/src/components/extract/ExtractSummary.jsx
+++ b/src/components/extract/ExtractSummary.jsx
@@ -17,6 +17,14 @@ const scoreColor = (score) => {
   return 'text-red-400';
 };
 
+/** Formato compacto: 1.6k, 20k, 1.2M */
+const fmtCompact = (val) => {
+  const abs = Math.abs(val || 0);
+  if (abs >= 1_000_000) return `${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(abs / 1_000).toFixed(abs % 1_000 === 0 ? 0 : 1)}k`;
+  return abs.toFixed(0);
+};
+
 const BADGE_ICONS = {
   Check, Trophy, TrendingUp, TrendingDown, Skull, AlertTriangle, Activity,
 };
@@ -114,10 +122,10 @@ const ExtractSummary = ({ periodState, cycleSummary, isCycleView, startPL, emoti
         </div>
         <div>
           <span className="text-[10px] text-slate-500 uppercase block">Meta / Stop</span>
-          <div className="flex items-center gap-2 text-xs font-mono">
-            <span className="text-emerald-400/70">{fmt(goalVal)}</span>
+          <div className="flex items-center gap-1 text-xs font-mono">
+            <span className="text-emerald-400/70">{fmtCompact(goalVal)}</span>
             <span className="text-slate-600">/</span>
-            <span className="text-red-400/70">-{fmt(stopVal)}</span>
+            <span className="text-red-400/70">-{fmtCompact(stopVal)}</span>
           </div>
         </div>
       </div>

--- a/src/components/extract/ExtractSummary.jsx
+++ b/src/components/extract/ExtractSummary.jsx
@@ -1,0 +1,147 @@
+/**
+ * ExtractSummary
+ * @version 1.0.0 (v1.16.0)
+ * @description Resumo executivo do extrato — PL, resultado, estado, score, breakdown pré/pós evento.
+ *   Sub-componente do PlanLedgerExtract (sem DebugBadge próprio).
+ */
+
+import {
+  Trophy, Skull, Check, TrendingUp, TrendingDown,
+  AlertTriangle, Activity, Brain
+} from 'lucide-react';
+import { classifyPeriodBadge, PERIOD_STATES } from '../../utils/planStateMachine';
+
+const scoreColor = (score) => {
+  if (score >= 70) return 'text-emerald-400';
+  if (score >= 40) return 'text-amber-400';
+  return 'text-red-400';
+};
+
+const BADGE_ICONS = {
+  Check, Trophy, TrendingUp, TrendingDown, Skull, AlertTriangle, Activity,
+};
+
+const COLOR_MAP = {
+  emerald: 'text-emerald-400',
+  red: 'text-red-400',
+  amber: 'text-amber-400',
+  slate: 'text-slate-400',
+  blue: 'text-blue-400',
+};
+
+/**
+ * @param {Object|null} periodState - Retorno de computePeriodState (visão período)
+ * @param {Object|null} cycleSummary - computePlanState().cycleState.summary (visão ciclo)
+ * @param {boolean} isCycleView - true = ciclo, false = período
+ * @param {number} startPL - PL inicial do plano
+ * @param {Object|null} emotionalData - { score, statusLabel } ou null
+ * @param {string} cycleStatus - Status do ciclo (PERIOD_STATES)
+ * @param {Function} fmt - Formatador de moeda
+ */
+const ExtractSummary = ({ periodState, cycleSummary, isCycleView, startPL, emotionalData, cycleStatus, fmt }) => {
+  const summary = periodState?.summary;
+  if (!summary && !cycleSummary) return null;
+
+  const activeSummary = isCycleView ? cycleSummary : summary;
+  const totalPnL = activeSummary?.totalPnL ?? 0;
+  const currentPL = startPL + totalPnL;
+  const resultPercent = startPL > 0 ? (totalPnL / startPL) * 100 : 0;
+  const goalVal = activeSummary?.goalVal ?? 0;
+  const stopVal = activeSummary?.stopVal ?? 0;
+
+  // Badge do estado (só para visão de período)
+  const badge = periodState && !isCycleView ? classifyPeriodBadge(periodState) : null;
+  const BadgeIcon = badge ? BADGE_ICONS[badge.icon] : null;
+  const statusColor = badge ? (COLOR_MAP[badge.colorClass] || 'text-blue-400') : 'text-blue-400';
+
+  // Status label
+  let statusLabel;
+  if (isCycleView) {
+    if (cycleStatus === PERIOD_STATES.GOAL_HIT) statusLabel = '🏆 Meta do Ciclo';
+    else if (cycleStatus === PERIOD_STATES.STOP_HIT) statusLabel = '🔴 Stop do Ciclo';
+    else statusLabel = '📊 Em Andamento';
+  } else {
+    statusLabel = badge?.label || 'Em Andamento';
+  }
+
+  // Separação pré/pós evento
+  const hasPostEvent = summary && (summary.postEventCount > 0) && !isCycleView;
+
+  return (
+    <div className="px-5 py-4 bg-slate-800/30 border-b border-slate-800">
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
+        <div>
+          <span className="text-[10px] text-slate-500 uppercase block">PL Inicial</span>
+          <span className="text-sm font-mono font-bold text-white">{fmt(startPL)}</span>
+        </div>
+        <div>
+          <span className="text-[10px] text-slate-500 uppercase block">Resultado</span>
+          <span className={`text-sm font-mono font-bold ${totalPnL >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+            {totalPnL >= 0 ? '+' : ''}{fmt(totalPnL)}
+          </span>
+          <span className={`text-[10px] font-mono ml-1 ${totalPnL >= 0 ? 'text-emerald-500/60' : 'text-red-500/60'}`}>
+            ({resultPercent >= 0 ? '+' : ''}{resultPercent.toFixed(1)}%)
+          </span>
+        </div>
+        <div>
+          <span className="text-[10px] text-slate-500 uppercase block">PL Atual</span>
+          <span className={`text-sm font-mono font-bold ${currentPL >= startPL ? 'text-emerald-400' : 'text-red-400'}`}>
+            {fmt(currentPL)}
+          </span>
+        </div>
+        <div>
+          <span className="text-[10px] text-slate-500 uppercase block">Estado</span>
+          <div className="flex items-center gap-1.5">
+            {BadgeIcon && <BadgeIcon className={`w-3.5 h-3.5 ${statusColor}`} />}
+            <span className={`text-sm font-bold ${isCycleView ? 'text-blue-400' : statusColor}`}>
+              {statusLabel}
+            </span>
+          </div>
+        </div>
+        <div>
+          <span className="text-[10px] text-slate-500 uppercase block flex items-center gap-1">
+            <Brain className="w-3 h-3" /> Score Emocional
+          </span>
+          {emotionalData?.score != null ? (
+            <span className={`text-sm font-bold ${scoreColor(emotionalData.score)}`}>
+              {Math.round(emotionalData.score)}/100 · {emotionalData.statusLabel}
+            </span>
+          ) : (
+            <span className="text-sm text-slate-500 italic">
+              Dados insuficientes
+            </span>
+          )}
+        </div>
+        <div>
+          <span className="text-[10px] text-slate-500 uppercase block">Meta / Stop</span>
+          <div className="flex items-center gap-2 text-xs font-mono">
+            <span className="text-emerald-400/70">{fmt(goalVal)}</span>
+            <span className="text-slate-600">/</span>
+            <span className="text-red-400/70">-{fmt(stopVal)}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Separação pré/pós evento */}
+      {hasPostEvent && (
+        <div className="mt-3 pt-3 border-t border-slate-700/50 flex items-center gap-6 text-xs">
+          <div className="flex items-center gap-2">
+            <span className="text-slate-500">Até evento:</span>
+            <span className={`font-mono font-bold ${summary.preEventPnL >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+              {summary.preEventPnL >= 0 ? '+' : ''}{fmt(summary.preEventPnL)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="w-3 h-3 text-amber-400" />
+            <span className="text-amber-400">Pós-evento ({summary.postEventCount} trade{summary.postEventCount !== 1 ? 's' : ''}):</span>
+            <span className={`font-mono font-bold ${summary.postEventPnL >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+              {summary.postEventPnL >= 0 ? '+' : ''}{fmt(summary.postEventPnL)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExtractSummary;

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -41,10 +41,11 @@ const getRowBg = (periodEvent, isEventTrade) => {
  * @param {Array} rows - Rows da state machine (cada row tem .trade, .periodEvent, .cumPnL, .result)
  * @param {Function} fmt - formatCurrencyDynamic parcial
  * @param {Function} getEmotionConfig - De useMasterData
+ * @param {number} carryOver - Saldo transportado de períodos anteriores (0 na visão ciclo)
  */
-const ExtractTable = ({ rows, fmt, getEmotionConfig }) => {
-  // Inverter para mais recentes no topo
-  const displayRows = [...rows].reverse();
+const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0 }) => {
+  // Ordem cronológica (mais antigo no topo) — acumulado funciona como saldo
+  const displayRows = rows;
 
   return (
     <div className="flex-1 overflow-auto">
@@ -63,6 +64,17 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig }) => {
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-800/50">
+          {/* Saldo anterior — primeira linha quando há carry-over */}
+          {carryOver !== 0 && displayRows.length > 0 && (
+            <tr className="bg-slate-800/20 border-b-2 border-slate-700 border-dashed">
+              <td className="p-3 text-center text-slate-600 font-mono text-xs">—</td>
+              <td colSpan="6" className="p-3 text-slate-500 italic text-xs">Saldo anterior (períodos anteriores)</td>
+              <td className={`p-3 text-right font-mono font-bold text-xs bg-slate-800/30 border-l border-slate-800 ${carryOver >= 0 ? 'text-emerald-400/60' : 'text-red-400/60'}`}>
+                {fmt(carryOver)}
+              </td>
+              <td className="p-3"></td>
+            </tr>
+          )}
           {displayRows.map((row) => {
             const trade = row.trade;
             const isGhost = row.periodEvent === PERIOD_STATES.POST_GOAL || row.periodEvent === PERIOD_STATES.POST_STOP;

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -1,0 +1,188 @@
+/**
+ * ExtractTable
+ * @version 1.0.0 (v1.16.0)
+ * @description Tabela do extrato com colunas de sanity check (RO, RR, Emoção)
+ *   e marcação visual para POST_GOAL/POST_STOP.
+ *   Ordem: mais recentes no topo (invertida).
+ */
+
+import {
+  Trophy, Skull, ShieldAlert, ShieldOff, Scale
+} from 'lucide-react';
+import { PERIOD_STATES } from '../../utils/planStateMachine';
+
+const fmtDate = (d) => { if (!d) return '-'; const [y, m, dd] = d.split('-'); return `${dd}/${m}`; };
+const fmtTime = (iso) => {
+  if (!iso) return '';
+  try { return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }); }
+  catch { return ''; }
+};
+
+const getEmotionColor = (category) => {
+  switch (category) {
+    case 'POSITIVE': return 'text-emerald-400';
+    case 'NEGATIVE': return 'text-red-400';
+    case 'CRITICAL': return 'text-red-500';
+    default: return 'text-slate-400';
+  }
+};
+
+/**
+ * Faixa de fundo para trades pós-evento.
+ */
+const getRowBg = (periodEvent, isEventTrade) => {
+  if (isEventTrade) return 'bg-slate-800/60';
+  if (periodEvent === PERIOD_STATES.POST_GOAL) return 'bg-amber-500/5 border-l-2 border-l-amber-500/40';
+  if (periodEvent === PERIOD_STATES.POST_STOP) return 'bg-red-500/5 border-l-2 border-l-red-500/40';
+  return '';
+};
+
+/**
+ * @param {Array} rows - Rows da state machine (cada row tem .trade, .periodEvent, .cumPnL, .result)
+ * @param {Function} fmt - formatCurrencyDynamic parcial
+ * @param {Function} getEmotionConfig - De useMasterData
+ */
+const ExtractTable = ({ rows, fmt, getEmotionConfig }) => {
+  // Inverter para mais recentes no topo
+  const displayRows = [...rows].reverse();
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <table className="w-full text-sm text-left border-collapse">
+        <thead className="bg-slate-800/80 text-[10px] uppercase text-slate-500 sticky top-0 z-10 font-bold tracking-wider">
+          <tr>
+            <th className="p-3 w-10 text-center">#</th>
+            <th className="p-3">Data</th>
+            <th className="p-3">Ativo</th>
+            <th className="p-3">Emoção</th>
+            <th className="p-3 text-right">RO %</th>
+            <th className="p-3 text-right">RR</th>
+            <th className="p-3 text-right">Resultado</th>
+            <th className="p-3 text-right bg-slate-800/50">Acumulado</th>
+            <th className="p-3 text-center w-28">Evento</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-800/50">
+          {displayRows.map((row) => {
+            const trade = row.trade;
+            const isGhost = row.periodEvent === PERIOD_STATES.POST_GOAL || row.periodEvent === PERIOD_STATES.POST_STOP;
+            const isEventTrade = row.periodEvent === PERIOD_STATES.GOAL_HIT || row.periodEvent === PERIOD_STATES.STOP_HIT;
+
+            // Emoção
+            const emotionCfg = getEmotionConfig ? getEmotionConfig(trade.emotionEntry) : null;
+            const emoji = emotionCfg?.emoji || '❓';
+            const emotionName = emotionCfg?.name || trade.emotionEntry || '-';
+            const emotionCategory = emotionCfg?.analysisCategory || 'NEUTRAL';
+
+            // Emoção de saída
+            const exitCfg = getEmotionConfig ? getEmotionConfig(trade.emotionExit) : null;
+            const exitEmoji = exitCfg?.emoji || '';
+
+            // Compliance
+            const riskPercent = trade.riskPercent != null ? `${Number(trade.riskPercent).toFixed(1)}%` : '-';
+            const rrRatio = trade.rrRatio != null ? `${Number(trade.rrRatio).toFixed(1)}:1` : '-';
+            const hasNoStop = Array.isArray(trade.redFlags) && trade.redFlags.some(f =>
+              (typeof f === 'string' ? f : f.type) === 'TRADE_SEM_STOP'
+            );
+            const roFora = trade.compliance?.roStatus === 'FORA_DO_PLANO';
+            const rrFora = trade.compliance?.rrStatus === 'NAO_CONFORME';
+
+            return (
+              <tr
+                key={trade.id}
+                className={`transition-all hover:bg-slate-800/40 ${getRowBg(row.periodEvent, isEventTrade)} ${
+                  isGhost ? 'opacity-50 hover:opacity-100' : ''
+                }`}
+              >
+                {/* # */}
+                <td className="p-3 text-center text-slate-600 font-mono text-xs">{row.tradeIndex + 1}</td>
+
+                {/* Data + Hora */}
+                <td className="p-3 text-slate-300">
+                  <span className="font-medium">{fmtDate(trade.date)}</span>
+                  <span className="text-[10px] text-slate-500 ml-1">{fmtTime(trade.entryTime)}</span>
+                </td>
+
+                {/* Ativo + Side */}
+                <td className="p-3">
+                  <span className="text-white font-bold">{trade.ticker}</span>
+                  <span className={`text-[10px] ml-1.5 px-1 py-0.5 rounded border ${
+                    trade.side === 'LONG' ? 'border-emerald-500/30 text-emerald-500' : 'border-red-500/30 text-red-500'
+                  }`}>{trade.side}</span>
+                </td>
+
+                {/* Emoção In → Out */}
+                <td className="p-3">
+                  <span className={`text-xs ${getEmotionColor(emotionCategory)}`}>
+                    {emoji} {emotionName}
+                  </span>
+                  {exitEmoji && (
+                    <span className="text-slate-500 text-[10px] ml-1">→ {exitEmoji}</span>
+                  )}
+                </td>
+
+                {/* RO % */}
+                <td className={`p-3 text-right font-mono text-xs ${roFora ? 'text-amber-400' : 'text-slate-400'}`}>
+                  <div className="flex items-center justify-end gap-1">
+                    {roFora && <ShieldOff className="w-3 h-3 text-amber-400" />}
+                    {hasNoStop ? (
+                      <span className="text-red-400 flex items-center gap-0.5"><ShieldAlert className="w-3 h-3" /> S/Stop</span>
+                    ) : riskPercent}
+                  </div>
+                </td>
+
+                {/* RR */}
+                <td className={`p-3 text-right font-mono text-xs ${rrFora ? 'text-amber-400' : 'text-slate-400'}`}>
+                  <div className="flex items-center justify-end gap-1">
+                    {rrFora && <Scale className="w-3 h-3 text-amber-400" />}
+                    {rrRatio}
+                  </div>
+                </td>
+
+                {/* Resultado */}
+                <td className={`p-3 text-right font-mono font-bold ${row.result >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                  {row.result > 0 ? '+' : ''}{fmt(row.result)}
+                </td>
+
+                {/* Acumulado */}
+                <td className={`p-3 text-right font-mono font-bold bg-slate-800/30 border-l border-slate-800 ${
+                  row.cumPnL >= 0 ? 'text-emerald-300' : 'text-red-300'
+                }`}>
+                  {fmt(row.cumPnL)}
+                </td>
+
+                {/* Evento */}
+                <td className="p-3 text-center">
+                  {row.periodEvent === PERIOD_STATES.GOAL_HIT && (
+                    <span className="text-emerald-400 font-bold text-xs flex justify-center items-center gap-1">
+                      <Trophy className="w-3 h-3" /> META!
+                    </span>
+                  )}
+                  {row.periodEvent === PERIOD_STATES.STOP_HIT && (
+                    <span className="text-red-400 font-bold text-xs flex justify-center items-center gap-1">
+                      <Skull className="w-3 h-3" /> STOP!
+                    </span>
+                  )}
+                  {row.periodEvent === PERIOD_STATES.POST_GOAL && (
+                    <span className="text-amber-500/70 text-[10px] uppercase font-bold">Pós-Meta</span>
+                  )}
+                  {row.periodEvent === PERIOD_STATES.POST_STOP && (
+                    <span className="text-red-500/70 text-[10px] uppercase font-bold">Violação</span>
+                  )}
+                  {row.periodEvent === PERIOD_STATES.IN_PROGRESS && (
+                    <span className="text-slate-600 text-xs">-</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+          {displayRows.length === 0 && (
+            <tr><td colSpan="9" className="p-12 text-center text-slate-500">Nenhum trade neste período.</td></tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ExtractTable;


### PR DESCRIPTION
## feat: state machine UI integration + extract refactor

### Resumo

Integra a `planStateMachine` (PR 1) nos componentes visuais. PlanLedgerExtract refatorado em sub-componentes. PlanCardGrid usa badges e sentiment icons da state machine.

**Closes #58** (state machine + UI integration)
**Partially closes #53** (extract refactor — Phase 1)

---

### Arquivos novos (4)

| Arquivo | Descrição |
|---------|-----------|
| `src/components/extract/ExtractPeriodSelector.jsx` | Seletor temporal: toggle Ciclo + botões por período (Diário/Semanal) |
| `src/components/extract/ExtractSummary.jsx` | Resumo: PL, resultado (%), PL atual, estado (badge), Meta/Stop (formato compacto), score emocional, breakdown pré/pós evento |
| `src/components/extract/ExtractTable.jsx` | Tabela cronológica (antigo→recente), colunas RO%, RR, Emoção In→Out, acumulado contínuo com carry-over entre períodos, faixa visual POST_GOAL (amarela) / POST_STOP (vermelha) |
| `src/components/extract/ExtractEvents.jsx` | Painel de eventos (GOAL/STOP, TILT/REVENGE, compliance, ciclo) |

### Arquivos modificados (2)

| Arquivo | Mudança |
|---------|---------|
| `src/components/PlanLedgerExtract.jsx` | **v3.0.0** — orquestrador. State machine inline removida, substituída por `computePlanState()`. Delega para 4 sub-componentes. Seletor de período. Acumulado contínuo com carry-over entre períodos. |
| `src/components/dashboard/PlanCardGrid.jsx` | **v2.0.0** — `getComplianceBadge()` e `renderSentimentIcon()` inline substituídos por `classifyPeriodBadge()` e `getSentimentFromState()` da state machine. Import de `analyzePlanCompliance` removido. |

### Comportamento novo

- **Seletor temporal**: Ciclo (todos os trades) ou período individual (dia/semana)
- **Acumulado contínuo**: na visão Ciclo, o saldo acumula sem reset entre períodos. Na visão de período, linha "Saldo anterior" aparece no topo quando há carry-over
- **Meta/Stop compacto**: valores exibidos como `1.6k / -1.2k` para não quebrar layout
- **Ordem cronológica**: tabela exibe do mais antigo (topo) ao mais recente (fundo), acumulado funciona como extrato bancário
- **Badges no card**: estado do período atual (GOAL_DISCIPLINED, POST_GOAL_GAIN, STOP_WORSENED, etc.) com ícone e cor
- **Sentiment evoluído**: Trophy (meta), Skull (stop), TrendingUp (pós-meta) nos cards

### Não incluído (roadmap v1.17.0)

- Navegação entre ciclos (histórico Fev/Mar)
- Dropdown para >7 períodos (diário com muitos dias úteis)
- Gauge charts (SVG semicircular)
- Sistema emocional v3 (em hold para discussão de design)

### Testes

- 182 testes passando (sem regressão)
- Sem testes novos neste PR (componentes visuais, lógica coberta no PR 1)

### Checklist

- [x] DebugBadge nos componentes de tela (PlanLedgerExtract, PlanCardGrid)
- [x] DebugBadge ausente nos sub-componentes (correto)
- [x] Imports verificados contra App.jsx e StudentDashboard.jsx
- [x] PlanExtractModal (financeiro puro) não tocado
- [x] CI green (182 tests)
