### PR TITLE
feat(#53-F2): cycle navigation, gauge charts, period dropdown, cycle …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "firebase": "^12.8.0",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
+        "react-d3-speedometer": "^2.2.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.13.0",
         "recharts": "^2.10.0"
@@ -3718,6 +3719,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -3773,6 +3783,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -3816,6 +3835,25 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
       }
     },
     "node_modules/data-urls": {
@@ -6110,6 +6148,12 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6237,6 +6281,12 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -7196,6 +7246,34 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-d3-speedometer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-d3-speedometer/-/react-d3-speedometer-2.2.1.tgz",
+      "integrity": "sha512-Uk/f6qD9ds+lEI0ynnmfjIz8IE6Gh6PssFS++MoVX22DDI2OCYuKghWe+o6jXPHnVh6qPdMHOGki/k4+i6VyTA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^3.1.4",
+        "d3-color": "^3.1.0",
+        "d3-ease": "^3.0.1",
+        "d3-format": "^3.1.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-shape": "^3.1.0",
+        "d3-transition": "^3.0.1",
+        "lodash-es": "^4.17.21",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "firebase": "^12.8.0",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
+    "react-d3-speedometer": "^2.2.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.13.0",
     "recharts": "^2.10.0"

--- a/src/__tests__/utils/planStateMachine.test.js
+++ b/src/__tests__/utils/planStateMachine.test.js
@@ -1,9 +1,10 @@
 /**
  * planStateMachine.test.js
- * @version 1.0.0 (v1.16.0)
+ * @version 2.0.0 (v1.17.0)
  * @description Testes da máquina de estados do plano.
  *   Cobre: períodos, ciclos, transições, POST_GOAL/POST_STOP,
- *   agrupamento diário/semanal, boundary de ciclo, badges.
+ *   agrupamento diário/semanal, boundary de ciclo, badges,
+ *   cycle navigation, getAvailableCycles.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -16,6 +17,7 @@ import {
   getCycleEndDate,
   classifyPeriodBadge,
   getSentimentFromState,
+  getAvailableCycles,
 } from '../../utils/planStateMachine';
 
 // ============================================
@@ -406,7 +408,7 @@ describe('classifyPeriodBadge', () => {
     expect(badge.colorClass).toBe('red');
   });
 
-  it('POST_STOP que recuperou → LOSS_TO_GOAL', () => {
+  it('POST_STOP que recuperou → LOSS_TO_GOAL (Violação)', () => {
     const trades = [
       makeTrade({ result: -500, entryTime: '2026-03-04T10:00:00' }),
       makeTrade({ result: 600, entryTime: '2026-03-04T11:00:00' }),
@@ -414,7 +416,8 @@ describe('classifyPeriodBadge', () => {
     const state = computePeriodState(trades, 400, 400);
     const badge = classifyPeriodBadge(state);
     expect(badge.badge).toBe('LOSS_TO_GOAL');
-    expect(badge.label).toBe('Recuperação');
+    expect(badge.label).toBe('Violação (Recuperou)');
+    expect(badge.animate).toBe(true);
   });
 
   it('POST_STOP que piorou → STOP_WORSENED', () => {
@@ -468,5 +471,106 @@ describe('getSentimentFromState', () => {
     expect(getSentimentFromState(null, 100).icon).toBe('Smile');
     expect(getSentimentFromState(null, -100).icon).toBe('Frown');
     expect(getSentimentFromState(null, 0).icon).toBe('Meh');
+  });
+});
+
+// ============================================
+// getAvailableCycles (v1.17.0)
+// ============================================
+
+describe('getAvailableCycles', () => {
+  it('retorna vazio para array vazio', () => {
+    expect(getAvailableCycles([], 'Mensal')).toHaveLength(0);
+  });
+
+  it('retorna 1 ciclo quando todos trades são do mesmo mês', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-03' }),
+      makeTrade({ date: '2026-03-15' }),
+      makeTrade({ date: '2026-03-28' }),
+    ];
+    const cycles = getAvailableCycles(trades, 'Mensal');
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].key).toBe('2026-03-01');
+    expect(cycles[0].label).toBe('Mar/2026');
+    expect(cycles[0].tradesCount).toBe(3);
+  });
+
+  it('retorna múltiplos ciclos mensais em ordem cronológica', () => {
+    const trades = [
+      makeTrade({ date: '2026-01-10' }),
+      makeTrade({ date: '2026-03-05' }),
+      makeTrade({ date: '2026-02-20' }),
+      makeTrade({ date: '2026-03-15' }),
+    ];
+    const cycles = getAvailableCycles(trades, 'Mensal');
+    expect(cycles).toHaveLength(3);
+    expect(cycles[0].label).toBe('Jan/2026');
+    expect(cycles[0].tradesCount).toBe(1);
+    expect(cycles[1].label).toBe('Fev/2026');
+    expect(cycles[2].label).toBe('Mar/2026');
+    expect(cycles[2].tradesCount).toBe(2);
+  });
+
+  it('agrupa trimestralmente', () => {
+    const trades = [
+      makeTrade({ date: '2026-01-10' }),
+      makeTrade({ date: '2026-02-15' }),
+      makeTrade({ date: '2026-04-05' }),
+    ];
+    const cycles = getAvailableCycles(trades, 'Trimestral');
+    expect(cycles).toHaveLength(2);
+    expect(cycles[0].label).toBe('Q1/2026');
+    expect(cycles[0].tradesCount).toBe(2);
+    expect(cycles[1].label).toBe('Q2/2026');
+    expect(cycles[1].tradesCount).toBe(1);
+  });
+
+  it('ignora trades sem date', () => {
+    const trades = [
+      makeTrade({ date: '2026-03-04' }),
+      makeTrade({ date: undefined }),
+      makeTrade({ date: '' }),
+    ];
+    const cycles = getAvailableCycles(trades, 'Mensal');
+    expect(cycles).toHaveLength(1);
+    expect(cycles[0].tradesCount).toBe(1);
+  });
+});
+
+// ============================================
+// computePlanState — targetCycle option (v1.17.0)
+// ============================================
+
+describe('computePlanState — targetCycle navigation', () => {
+  it('filtra trades para ciclo específico passado via targetCycle', () => {
+    const trades = [
+      makeTrade({ date: '2026-02-10', result: 100 }),
+      makeTrade({ date: '2026-02-20', result: 200 }),
+      makeTrade({ date: '2026-03-05', result: 500 }),
+    ];
+    const config = makePlanConfig();
+
+    // Ciclo de fevereiro
+    const febState = computePlanState(trades, config, {
+      targetDate: new Date('2026-02-15T12:00:00'),
+      targetCycle: {
+        start: new Date('2026-02-01'),
+        end: new Date('2026-02-28T23:59:59.999'),
+      },
+    });
+    expect(febState.cycleState.summary.tradesCount).toBe(2);
+    expect(febState.cycleState.summary.totalPnL).toBe(300);
+
+    // Ciclo de março
+    const marState = computePlanState(trades, config, {
+      targetDate: new Date('2026-03-05T12:00:00'),
+      targetCycle: {
+        start: new Date('2026-03-01'),
+        end: new Date('2026-03-31T23:59:59.999'),
+      },
+    });
+    expect(marState.cycleState.summary.tradesCount).toBe(1);
+    expect(marState.cycleState.summary.totalPnL).toBe(500);
   });
 });

--- a/src/components/GaugeChart.jsx
+++ b/src/components/GaugeChart.jsx
@@ -1,0 +1,98 @@
+/**
+ * GaugeChart
+ * @version 7.0.0 (v1.17.0)
+ * @description Wrapper do react-d3-speedometer para progresso bidirecional.
+ *   Escala: [-stopVal ... 0 ... +goalVal]
+ *   Segmentos: vermelho (loss) → verde (gain)
+ *   Needle aponta para o P&L atual.
+ *
+ * DEPENDÊNCIA: npm install react-d3-speedometer
+ *
+ * USAGE:
+ *   <GaugeChart pnl={463} goalVal={1600} stopVal={1200} fmt={fmt} />
+ */
+
+import ReactSpeedometer from 'react-d3-speedometer';
+
+const fmtK = (v) => {
+  const a = Math.abs(v || 0);
+  if (a >= 1e6) return `${(a / 1e6).toFixed(1)}M`;
+  if (a >= 1e3) return `${(a / 1e3).toFixed(a % 1e3 === 0 ? 0 : 1)}k`;
+  return a.toFixed(0);
+};
+
+/**
+ * @param {number} pnl - P&L atual
+ * @param {number} goalVal - Meta absoluta
+ * @param {number} stopVal - Stop absoluto
+ * @param {Function} [fmt] - Currency formatter
+ * @param {string} [className]
+ */
+const GaugeChart = ({
+  pnl = 0,
+  goalVal = 0,
+  stopVal = 0,
+  fmt,
+  className = '',
+}) => {
+  // Garantir valores mínimos para a escala
+  const safeStop = Math.max(stopVal, 1);
+  const safeGoal = Math.max(goalVal, 1);
+
+  // Escala: de -stopVal até +goalVal
+  const minVal = -safeStop;
+  const maxVal = safeGoal;
+
+  // Clamp o valor dentro da escala (com margem de 10%)
+  const clampedValue = Math.max(minVal * 1.1, Math.min(maxVal * 1.1, pnl));
+
+  // Segmentos: vermelho escuro → vermelho → amarelo → verde → verde escuro
+  // Com parada customizada no zero
+  const segmentStops = [minVal, minVal * 0.5, 0, maxVal * 0.5, maxVal];
+  const segmentColors = ['#dc2626', '#f97316', '#eab308', '#84cc16', '#10b981'];
+
+  // Labels customizadas — 4 segmentos (stops.length - 1)
+  const segmentLabels = [
+    { text: `-${fmtK(safeStop)}`, position: 'OUTSIDE', color: '#ef4444', fontSize: '10px' },
+    { text: '0', position: 'OUTSIDE', color: '#64748b', fontSize: '10px' },
+    { text: '', position: 'OUTSIDE', color: 'transparent' },
+    { text: `+${fmtK(safeGoal)}`, position: 'OUTSIDE', color: '#10b981', fontSize: '10px' },
+  ];
+
+  // Texto central: valor formatado + percentual
+  const pct = pnl >= 0
+    ? (safeGoal > 0 ? Math.round((pnl / safeGoal) * 100) : 0)
+    : (safeStop > 0 ? Math.round((Math.abs(pnl) / safeStop) * 100) : 0);
+  const pnlText = fmt ? fmt(pnl) : `${pnl >= 0 ? '+' : ''}${fmtK(pnl)}`;
+  const valueText = `${pnlText}  (${pct}% ${pnl >= 0 ? 'meta' : 'stop'})`;
+
+  return (
+    <div className={`w-full flex justify-center ${className}`}>
+      <ReactSpeedometer
+        forceRender={true}
+        minValue={minVal}
+        maxValue={maxVal}
+        value={clampedValue}
+        customSegmentStops={segmentStops}
+        segmentColors={segmentColors}
+        customSegmentLabels={segmentLabels}
+        currentValueText={valueText}
+        needleColor="#e2e8f0"
+        needleTransitionDuration={800}
+        needleTransition="easeElastic"
+        needleHeightRatio={0.7}
+        ringWidth={20}
+        textColor="#94a3b8"
+        valueTextFontSize="11px"
+        valueTextFontWeight="bold"
+        labelFontSize="9px"
+        width={220}
+        height={140}
+        paddingHorizontal={5}
+        paddingVertical={5}
+      />
+    </div>
+  );
+};
+
+export default GaugeChart;

--- a/src/components/PlanLedgerExtract.jsx
+++ b/src/components/PlanLedgerExtract.jsx
@@ -1,42 +1,37 @@
 /**
  * PlanLedgerExtract
- * @version 3.0.0 (v1.16.0)
+ * @version 4.0.0 (v1.17.0)
  * @description Extrato Ledger emocional — orquestrador.
+ *   v4.0.0: Navegação entre ciclos, ExtractCycleCard com gauges, click-to-filter.
  *   v3.0.0: Integra planStateMachine, seletor temporal, sub-componentes extraídos.
  *   v2.0.0: Multi-moeda via currency prop.
  *   v1.1.0: Compliance events (RO/RR/NO_STOP).
  *
  * ARQUITETURA:
  *   PlanLedgerExtract (orquestrador)
- *     ├─ ExtractPeriodSelector (seletor temporal)
+ *     ├─ ExtractPeriodSelector (seletor temporal + navegação ciclos)
+ *     ├─ ExtractCycleCard (barra progresso + breakdown por período — lateral)
  *     ├─ ExtractSummary (resumo com estado + separação pré/pós)
- *     ├─ ExtractTable (tabela com RO/RR/Emoção + marcação POST_GOAL/POST_STOP)
- *     └─ ExtractEvents (painel de eventos)
+ *     └─ ExtractTable (tabela com RO/RR/Emoção + eventos inline)
  *
  * USAGE:
  *   <PlanLedgerExtract plan={plan} trades={planTrades} onClose={fn} currency="USD" />
  */
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { X, ScrollText } from 'lucide-react';
 import { useMasterData } from '../hooks/useMasterData';
 import { useEmotionalProfile } from '../hooks/useEmotionalProfile';
 import { useComplianceRules } from '../hooks/useComplianceRules';
 import { formatCurrencyDynamic } from '../utils/currency';
-import { computePlanState } from '../utils/planStateMachine';
+import { computePlanState, getAvailableCycles, getCycleStartDate, getCycleEndDate } from '../utils/planStateMachine';
 import DebugBadge from './DebugBadge';
 
-// Sub-componentes extraídos
+// Sub-componentes
 import ExtractPeriodSelector from './extract/ExtractPeriodSelector';
+import ExtractCycleCard from './extract/ExtractCycleCard';
 import ExtractSummary from './extract/ExtractSummary';
 import ExtractTable from './extract/ExtractTable';
-import ExtractEvents from './extract/ExtractEvents';
-
-const fmtTime = (iso) => {
-  if (!iso) return '';
-  try { return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }); }
-  catch { return ''; }
-};
 
 const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
   const { getEmotionConfig } = useMasterData();
@@ -47,12 +42,53 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
   const [selectedPeriod, setSelectedPeriod] = useState(null);
 
   // Currency formatter parcial
-  const fmt = (v) => formatCurrencyDynamic(v, currency);
+  const fmt = useCallback((v) => formatCurrencyDynamic(v, currency), [currency]);
+
+  // ==================== CYCLE NAVIGATION ====================
+
+  const adjustmentCycle = plan?.adjustmentCycle || 'Mensal';
+
+  const availableCycles = useMemo(() => {
+    if (!trades || trades.length === 0) return [];
+    return getAvailableCycles(trades, adjustmentCycle);
+  }, [trades, adjustmentCycle]);
+
+  // Ciclo selecionado (default = ciclo atual)
+  const [selectedCycleKey, setSelectedCycleKey] = useState(() => {
+    if (!trades || trades.length === 0) return null;
+    const now = new Date();
+    const currentCycleStart = getCycleStartDate(adjustmentCycle, now);
+    const currentKey = `${currentCycleStart.getFullYear()}-${String(currentCycleStart.getMonth() + 1).padStart(2, '0')}-${String(currentCycleStart.getDate()).padStart(2, '0')}`;
+    // Se o ciclo atual tem trades, usar ele. Senão, usar o último com trades.
+    const cycles = getAvailableCycles(trades, adjustmentCycle);
+    const hasCurrent = cycles.some(c => c.key === currentKey);
+    if (hasCurrent) return currentKey;
+    return cycles.length > 0 ? cycles[cycles.length - 1].key : null;
+  });
+
+  const handleSelectCycle = useCallback((cycleKey) => {
+    setSelectedCycleKey(cycleKey);
+    setSelectedPeriod(null); // Reset período ao trocar ciclo
+  }, []);
+
+  // Resolver start/end do ciclo selecionado
+  const selectedCycleRange = useMemo(() => {
+    if (!selectedCycleKey) return null;
+    const d = new Date(selectedCycleKey + 'T12:00:00');
+    return {
+      start: getCycleStartDate(adjustmentCycle, d),
+      end: getCycleEndDate(adjustmentCycle, d),
+    };
+  }, [selectedCycleKey, adjustmentCycle]);
 
   // ==================== STATE MACHINE ====================
 
   const planState = useMemo(() => {
     if (!plan || !trades || trades.length === 0) return null;
+
+    const options = selectedCycleRange
+      ? { targetCycle: selectedCycleRange, targetDate: selectedCycleRange.start }
+      : {};
 
     return computePlanState(trades, {
       pl: Number(plan.pl) || 0,
@@ -61,9 +97,9 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
       cycleGoal: Number(plan.cycleGoal) || 0,
       cycleStop: Number(plan.cycleStop) || 0,
       operationPeriod: plan.operationPeriod || 'Diário',
-      adjustmentCycle: plan.adjustmentCycle || 'Mensal',
-    });
-  }, [plan, trades]);
+      adjustmentCycle: adjustmentCycle,
+    }, options);
+  }, [plan, trades, selectedCycleRange, adjustmentCycle]);
 
   // ==================== DADOS DERIVADOS ====================
 
@@ -74,25 +110,47 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
   }, [planState, selectedPeriod]);
 
   // Rows para a tabela + saldo anterior (carry-over entre períodos)
+  // Também marca cycleEvent quando um trade causa CYCLE_GOAL_HIT ou CYCLE_STOP_HIT
   const { tableRows, carryOver } = useMemo(() => {
     if (!planState) return { tableRows: [], carryOver: 0 };
 
+    // Pré-computar: qual periodKey causou cycle event
+    const cycleEventByPeriod = {};
+    planState.cycleState.events?.forEach(e => {
+      cycleEventByPeriod[e.periodKey] = e.type;
+    });
+
+    // Computar acumulado do ciclo para cada trade (para detectar exatamente qual trade cruzou)
+    const cycleGoalVal = planState.cycleState.summary.goalVal;
+    const cycleStopVal = planState.cycleState.summary.stopVal;
+
     if (selectedPeriod === null) {
-      // Ciclo inteiro: concatenar rows com acumulado contínuo
+      // Ciclo inteiro
       const allRows = [];
       let runningTotal = 0;
+      let cycleTriggered = false;
       for (const periodKey of planState.availablePeriods) {
         const period = planState.cycleState.periods.get(periodKey);
         if (!period) continue;
         for (const row of period.rows) {
           runningTotal += row.result;
-          allRows.push({ ...row, cumPnL: runningTotal });
+          let cycleEvent = null;
+          if (!cycleTriggered) {
+            if (cycleGoalVal > 0 && runningTotal >= cycleGoalVal) {
+              cycleEvent = 'CYCLE_GOAL_HIT';
+              cycleTriggered = true;
+            } else if (cycleStopVal > 0 && runningTotal <= -cycleStopVal) {
+              cycleEvent = 'CYCLE_STOP_HIT';
+              cycleTriggered = true;
+            }
+          }
+          allRows.push({ ...row, cumPnL: runningTotal, cycleEvent });
         }
       }
       return { tableRows: allRows, carryOver: 0 };
     }
 
-    // Período individual: calcular carry-over dos períodos anteriores
+    // Período individual
     let carry = 0;
     for (const periodKey of planState.availablePeriods) {
       if (periodKey === selectedPeriod) break;
@@ -100,93 +158,15 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
       if (period) carry += period.summary.totalPnL;
     }
 
-    // Ajustar cumPnL dos rows com o carry-over
     const periodRows = currentPeriodState?.rows || [];
     const adjustedRows = periodRows.map(row => ({
       ...row,
       cumPnL: carry + row.cumPnL,
+      cycleEvent: null,
     }));
 
     return { tableRows: adjustedRows, carryOver: carry };
   }, [planState, selectedPeriod, currentPeriodState]);
-
-  // Eventos consolidados
-  const allEvents = useMemo(() => {
-    if (!planState) return [];
-    const evts = [];
-
-    // Eventos da state machine (por período)
-    for (const periodKey of planState.availablePeriods) {
-      const period = planState.cycleState.periods.get(periodKey);
-      if (period?.events) {
-        period.events.forEach(e => {
-          evts.push({
-            type: e.type,
-            date: e.timestamp?.split?.('T')?.[0] || periodKey,
-            time: fmtTime(e.timestamp),
-            message: e.type === 'GOAL_HIT'
-              ? `META atingida: ${fmt(e.cumPnL)}`
-              : `STOP atingido: ${fmt(e.cumPnL)}`
-          });
-        });
-      }
-    }
-
-    // Eventos do ciclo
-    planState.cycleState.events?.forEach(e => {
-      evts.push({
-        type: e.type,
-        date: e.periodKey,
-        time: '',
-        message: e.type === 'CYCLE_GOAL_HIT'
-          ? `Meta do Ciclo atingida: ${fmt(e.cycleCumPnL)}`
-          : `Stop do Ciclo atingido: ${fmt(e.cycleCumPnL)}`
-      });
-    });
-
-    // Compliance events
-    for (const row of tableRows) {
-      const trade = row.trade;
-      if (trade.compliance?.roStatus === 'FORA_DO_PLANO') {
-        evts.push({
-          type: 'RO_FORA', date: trade.date, time: fmtTime(trade.entryTime),
-          message: `RO fora do plano: ${trade.ticker} (${(trade.riskPercent || 0).toFixed(1)}%)`
-        });
-      }
-      if (trade.compliance?.rrStatus === 'NAO_CONFORME') {
-        evts.push({
-          type: 'RR_FORA', date: trade.date, time: fmtTime(trade.entryTime),
-          message: `RR não conforme: ${trade.ticker} (${(trade.rrRatio || 0).toFixed(1)}x)`
-        });
-      }
-      const hasNoStop = Array.isArray(trade.redFlags) && trade.redFlags.some(f =>
-        (typeof f === 'string' ? f : f.type) === 'TRADE_SEM_STOP'
-      );
-      if (hasNoStop) {
-        evts.push({
-          type: 'NO_STOP', date: trade.date, time: fmtTime(trade.entryTime),
-          message: `Trade sem stop: ${trade.ticker}`
-        });
-      }
-    }
-
-    // Alertas emocionais
-    if (emotional.isReady && emotional.alerts) {
-      emotional.alerts.forEach(a => {
-        if (['TILT_DETECTED', 'REVENGE_DETECTED', 'STATUS_CRITICAL'].includes(a.type)) {
-          evts.push({
-            type: a.type,
-            date: a.timestamp?.split?.('T')?.[0] || '',
-            time: fmtTime(a.timestamp),
-            message: a.message
-          });
-        }
-      });
-    }
-
-    evts.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
-    return evts;
-  }, [planState, tableRows, emotional, fmt]);
 
   // Dados emocionais para o summary
   const emotionalData = useMemo(() => {
@@ -195,6 +175,19 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
       score: emotional.metrics?.score ?? null,
       statusLabel: emotional.status?.label || '-'
     };
+  }, [emotional]);
+
+  // Eventos emocionais para matching inline na tabela
+  const emotionalEvents = useMemo(() => {
+    if (!emotional.isReady || !emotional.alerts) return [];
+    return emotional.alerts
+      .filter(a => ['TILT_DETECTED', 'REVENGE_DETECTED', 'STATUS_CRITICAL'].includes(a.type))
+      .map(a => ({
+        type: a.type,
+        date: a.timestamp?.split?.('T')?.[0] || '',
+        tradeId: a.tradeId || null,
+        message: a.message,
+      }));
   }, [emotional]);
 
   // ==================== RENDER ====================
@@ -206,7 +199,7 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
 
   return (
     <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-slate-900 border border-slate-800 w-full max-w-6xl h-[90vh] rounded-xl flex flex-col shadow-2xl ring-1 ring-white/10">
+      <div className="bg-slate-900 border border-slate-800 w-full max-w-7xl h-[90vh] rounded-xl flex flex-col shadow-2xl ring-1 ring-white/10">
 
         {/* Header */}
         <div className="p-5 border-b border-slate-800 flex justify-between items-start">
@@ -226,7 +219,7 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
           </button>
         </div>
 
-        {/* Period Selector */}
+        {/* Period Selector + Cycle Navigation */}
         {planState && (
           <div className="px-5 py-3 border-b border-slate-800/50 bg-slate-800/10">
             <ExtractPeriodSelector
@@ -235,28 +228,51 @@ const PlanLedgerExtract = ({ plan, trades, onClose, currency = 'BRL' }) => {
               onSelectPeriod={setSelectedPeriod}
               operationPeriod={plan.operationPeriod || 'Diário'}
               currentPeriodKey={planState.currentPeriodKey}
+              availableCycles={availableCycles}
+              selectedCycleKey={selectedCycleKey}
+              onSelectCycle={handleSelectCycle}
             />
           </div>
         )}
 
-        <ExtractSummary
-          periodState={currentPeriodState}
-          startPL={startPL}
-          fmt={fmt}
-          emotionalData={emotionalData}
-          isCycleView={isCycleView}
-          cycleSummary={planState?.cycleState?.summary || null}
-          cycleStatus={planState?.cycleState?.status || 'IN_PROGRESS'}
-        />
+        {/* Main content: Cycle Card (lateral) + Summary + Table */}
+        <div className="flex-1 flex overflow-hidden">
 
-        <ExtractTable
-          rows={tableRows}
-          fmt={fmt}
-          getEmotionConfig={getEmotionConfig}
-          carryOver={carryOver}
-        />
+          {/* Cycle Card — lateral esquerda */}
+          {planState && (
+            <div className="w-72 min-w-[288px] border-r border-slate-800/50 bg-slate-900/50 overflow-y-auto hidden lg:flex lg:flex-col">
+              <ExtractCycleCard
+                planState={planState}
+                startPL={startPL}
+                fmt={fmt}
+                selectedPeriod={selectedPeriod}
+                onSelectPeriod={setSelectedPeriod}
+                operationPeriod={plan.operationPeriod || 'Diário'}
+              />
+            </div>
+          )}
 
-        <ExtractEvents events={allEvents} />
+          {/* Conteúdo principal */}
+          <div className="flex-1 flex flex-col overflow-hidden">
+            <ExtractSummary
+              periodState={currentPeriodState}
+              startPL={startPL}
+              fmt={fmt}
+              emotionalData={emotionalData}
+              isCycleView={isCycleView}
+              cycleSummary={planState?.cycleState?.summary || null}
+              cycleStatus={planState?.cycleState?.status || 'IN_PROGRESS'}
+            />
+
+            <ExtractTable
+              rows={tableRows}
+              fmt={fmt}
+              getEmotionConfig={getEmotionConfig}
+              carryOver={carryOver}
+              emotionalEvents={emotionalEvents}
+            />
+          </div>
+        </div>
 
       </div>
       <DebugBadge component="PlanLedgerExtract" />

--- a/src/components/PlanManagementModal.jsx
+++ b/src/components/PlanManagementModal.jsx
@@ -346,10 +346,51 @@ const PlanManagementModal = ({
                   </div>
                 </div>
                 <div className="mt-8 pt-6 border-t border-slate-800">
-                  <h4 className="text-xs uppercase tracking-widest text-slate-500 mb-4 font-bold">Resumo</h4>
-                  <div className="grid grid-cols-2 gap-4 text-sm bg-slate-800/30 p-4 rounded-lg">
-                    <div className="flex justify-between"><span className="text-slate-400">Capital:</span><span className="text-white font-mono font-bold">{formatCurrency(formData.pl)}</span></div>
-                    <div className="flex justify-between"><span className="text-slate-400">Stop Ciclo:</span><span className="text-red-400 font-mono font-bold">-{formatCurrency(calcValue(formData.cycleStop))}</span></div>
+                  <h4 className="text-xs uppercase tracking-widest text-slate-500 mb-4 font-bold">Resumo do Plano</h4>
+                  <div className="space-y-3 text-sm bg-slate-800/30 p-4 rounded-lg">
+                    <div className="flex justify-between">
+                      <span className="text-slate-400">Capital (PL):</span>
+                      <span className="text-white font-mono font-bold">{formatCurrency(formData.pl)}</span>
+                    </div>
+                    <div className="border-t border-slate-700/50 pt-2 mt-2">
+                      <p className="text-[10px] text-slate-500 uppercase tracking-wider font-bold mb-2">Período ({formData.operationPeriod})</p>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div className="flex justify-between">
+                          <span className="text-emerald-400/70 text-xs">Meta:</span>
+                          <span className="text-emerald-400 font-mono text-xs">{formData.periodGoal}% · {formatCurrency(calcValue(formData.periodGoal))}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-red-400/70 text-xs">Stop:</span>
+                          <span className="text-red-400 font-mono text-xs">{formData.periodStop}% · -{formatCurrency(calcValue(formData.periodStop))}</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="border-t border-slate-700/50 pt-2">
+                      <p className="text-[10px] text-slate-500 uppercase tracking-wider font-bold mb-2">Ciclo ({formData.adjustmentCycle})</p>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div className="flex justify-between">
+                          <span className="text-emerald-400/70 text-xs">Meta:</span>
+                          <span className="text-emerald-400 font-mono text-xs">{formData.cycleGoal}% · {formatCurrency(calcValue(formData.cycleGoal))}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-red-400/70 text-xs">Stop:</span>
+                          <span className="text-red-400 font-mono text-xs">{formData.cycleStop}% · -{formatCurrency(calcValue(formData.cycleStop))}</span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="border-t border-slate-700/50 pt-2">
+                      <p className="text-[10px] text-slate-500 uppercase tracking-wider font-bold mb-2">Risco por Trade</p>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div className="flex justify-between">
+                          <span className="text-amber-400/70 text-xs">RO Máx:</span>
+                          <span className="text-amber-400 font-mono text-xs">{formData.riskPerOperation}% · {formatCurrency(calcValue(formData.riskPerOperation))}</span>
+                        </div>
+                        <div className="flex justify-between">
+                          <span className="text-blue-400/70 text-xs">RR Mín:</span>
+                          <span className="text-blue-400 font-mono text-xs">1:{formData.rrTarget}</span>
+                        </div>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/StudentAccountGroup.jsx
+++ b/src/components/StudentAccountGroup.jsx
@@ -16,7 +16,7 @@ import { useState } from 'react';
 import { 
   ChevronDown, ChevronUp, User,
   TrendingUp, TrendingDown, Edit2, Eye, Wallet,
-  CheckCircle, Target, Trophy, Skull, Activity
+  CheckCircle, Target, Trophy, Skull, Activity, Settings
 } from 'lucide-react';
 
 const StudentAccountGroup = ({ 
@@ -27,6 +27,7 @@ const StudentAccountGroup = ({
   balancesByAccountId = {},
   onAccountClick,
   onEditAccount,
+  onEditPlan,
   getAccountBadge,
   formatCurrency
 }) => {
@@ -274,6 +275,17 @@ const StudentAccountGroup = ({
                           <span className={`text-[9px] font-bold uppercase px-1.5 py-0.5 rounded ${statusBadge.bg} ${statusBadge.color}`}>
                             {statusBadge.label}
                           </span>
+
+                          {/* Editar plano (mentor) */}
+                          {onEditPlan && (
+                            <button
+                              onClick={(e) => { e.stopPropagation(); onEditPlan(plan); }}
+                              className="p-1 rounded-lg text-slate-600 hover:text-blue-400 hover:bg-blue-500/10 transition-colors"
+                              title="Editar plano"
+                            >
+                              <Settings className="w-3 h-3" />
+                            </button>
+                          )}
                         </div>
                       );
                     })}

--- a/src/components/extract/ExtractCycleCard.jsx
+++ b/src/components/extract/ExtractCycleCard.jsx
@@ -1,0 +1,175 @@
+/**
+ * ExtractCycleCard
+ * @version 5.0.0 (v1.17.0)
+ * @description Painel lateral do ciclo com velocímetro e breakdown.
+ *   - Label de alerta quando status crítico (STOP_HIT, POST_STOP, GOAL_TO_STOP)
+ *   - Barra do período mostra se atingiu meta/stop e se continuou
+ */
+
+import {
+  Trophy, Skull, Check, TrendingUp, TrendingDown,
+  AlertTriangle, Activity, Target, AlertOctagon
+} from 'lucide-react';
+import GaugeChart from '../GaugeChart';
+import { classifyPeriodBadge, PERIOD_STATES } from '../../utils/planStateMachine';
+
+const ICON_MAP = {
+  Check, Trophy, TrendingUp, TrendingDown, Skull, AlertTriangle, Activity,
+};
+
+const COLOR_MAP = {
+  emerald: 'text-emerald-400',
+  red: 'text-red-400',
+  amber: 'text-amber-400',
+  slate: 'text-slate-400',
+};
+
+const fmtPeriodLabel = (periodKey, operationPeriod) => {
+  if (!periodKey) return '-';
+  const [y, m, d] = periodKey.split('-');
+  return operationPeriod === 'Semanal' ? `Sem ${d}/${m}` : `${d}/${m}`;
+};
+
+/** Determina se o status do ciclo é crítico */
+const isCriticalStatus = (status) => [
+  PERIOD_STATES.STOP_HIT,
+  PERIOD_STATES.POST_STOP,
+].includes(status);
+
+/** Label compacto do período para a barra */
+const getPeriodStatusLabel = (badge) => {
+  switch (badge.badge) {
+    case 'GOAL_DISCIPLINED': return { text: 'Meta', cls: 'text-emerald-400' };
+    case 'POST_GOAL_GAIN': return { text: 'Meta → Cont.', cls: 'text-amber-400' };
+    case 'POST_GOAL_LOSS': return { text: 'Meta → Devolveu', cls: 'text-amber-400' };
+    case 'GOAL_TO_STOP': return { text: 'Meta → Stop!', cls: 'text-red-400' };
+    case 'STOP_HIT': return { text: 'Stop', cls: 'text-red-400' };
+    case 'STOP_WORSENED': return { text: 'Stop → Violou', cls: 'text-red-400' };
+    case 'LOSS_TO_GOAL': return { text: 'Stop → Violou', cls: 'text-amber-400' };
+    default: return null;
+  }
+};
+
+const ExtractCycleCard = ({
+  planState,
+  startPL,
+  fmt,
+  selectedPeriod,
+  onSelectPeriod,
+  operationPeriod = 'Diário',
+}) => {
+  if (!planState) return null;
+
+  const { cycleState, availablePeriods } = planState;
+  const cycleSummary = cycleState.summary;
+  const resultPct = startPL > 0 ? (cycleSummary.totalPnL / startPL) * 100 : 0;
+  const critical = isCriticalStatus(cycleState.status);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header + resultado */}
+      <div className={`px-4 pt-4 pb-2 border-b ${critical ? 'border-red-500/30 bg-red-500/[0.03]' : 'border-slate-800/50'}`}>
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-1.5">
+            <Target className="w-3.5 h-3.5 text-purple-400" />
+            <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Ciclo</span>
+          </div>
+          <div className="flex items-center gap-2 text-[10px] text-slate-500 font-mono">
+            <span>{cycleSummary.tradesCount}t</span>
+            <span className="text-slate-700">·</span>
+            <span>{cycleSummary.periodsCount}p</span>
+          </div>
+        </div>
+
+        {/* Label crítico */}
+        {critical && (
+          <div className="flex items-center gap-1.5 mb-2 px-2 py-1 rounded-lg bg-red-500/10 border border-red-500/20">
+            <AlertOctagon className="w-3.5 h-3.5 text-red-400" />
+            <span className="text-[10px] font-bold text-red-400 uppercase tracking-wider">
+              {cycleState.status === PERIOD_STATES.STOP_HIT ? 'Stop do Ciclo Atingido' : 'Stop do Ciclo Violado'}
+            </span>
+          </div>
+        )}
+
+        {/* Velocímetro */}
+        <GaugeChart
+          pnl={cycleSummary.totalPnL}
+          goalVal={cycleSummary.goalVal}
+          stopVal={cycleSummary.stopVal}
+          status={cycleState.status}
+          fmt={fmt}
+        />
+      </div>
+
+      {/* Breakdown por período */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-4 py-2 sticky top-0 bg-slate-900/95 backdrop-blur-sm border-b border-slate-800/30 z-10">
+          <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+            Períodos ({availablePeriods.length})
+          </span>
+        </div>
+        <div className="px-3 py-2 space-y-1">
+          {availablePeriods.map(periodKey => {
+            const periodState = cycleState.periods.get(periodKey);
+            if (!periodState) return null;
+
+            const isSelected = selectedPeriod === periodKey;
+            const badge = classifyPeriodBadge(periodState);
+            const BadgeIcon = ICON_MAP[badge.icon] || Activity;
+            const colorClass = COLOR_MAP[badge.colorClass] || 'text-slate-400';
+            const pnl = periodState.summary.totalPnL;
+            const tradesCount = periodState.summary.tradesCount;
+            const statusLabel = getPeriodStatusLabel(badge);
+
+            const goalPct = periodState.summary.goalVal > 0 && pnl > 0
+              ? Math.min((pnl / periodState.summary.goalVal) * 100, 100) : 0;
+            const stopPct = periodState.summary.stopVal > 0 && pnl < 0
+              ? Math.min((Math.abs(pnl) / periodState.summary.stopVal) * 100, 100) : 0;
+            const barPct = pnl >= 0 ? goalPct : stopPct;
+
+            return (
+              <button
+                key={periodKey}
+                onClick={() => onSelectPeriod(periodKey)}
+                className={`w-full text-left px-3 py-2 rounded-lg border transition-all ${
+                  isSelected
+                    ? 'bg-blue-500/10 border-blue-500/30'
+                    : 'bg-transparent border-transparent hover:bg-slate-800/40 hover:border-slate-700/50'
+                }`}
+              >
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1.5">
+                    <BadgeIcon className={`w-3 h-3 ${colorClass} ${badge.animate ? 'animate-pulse' : ''}`} />
+                    <span className={`text-xs font-mono ${isSelected ? 'text-blue-400 font-bold' : 'text-slate-300'}`}>
+                      {fmtPeriodLabel(periodKey, operationPeriod)}
+                    </span>
+                    {/* Status label (meta/stop/continuou) */}
+                    {statusLabel && (
+                      <span className={`text-[8px] font-bold uppercase ${statusLabel.cls}`}>
+                        {statusLabel.text}
+                      </span>
+                    )}
+                  </div>
+                  <span className={`text-xs font-mono font-bold ${pnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                    {pnl >= 0 ? '+' : ''}{fmt(pnl)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 h-1 bg-slate-700/40 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all duration-500 ${pnl >= 0 ? 'bg-emerald-500/60' : 'bg-red-500/60'}`}
+                      style={{ width: `${barPct}%` }}
+                    />
+                  </div>
+                  <span className="text-[9px] text-slate-600 font-mono w-5 text-right">{tradesCount}t</span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExtractCycleCard;

--- a/src/components/extract/ExtractPeriodSelector.jsx
+++ b/src/components/extract/ExtractPeriodSelector.jsx
@@ -1,11 +1,14 @@
 /**
  * ExtractPeriodSelector
- * @version 1.0.0 (v1.16.0)
+ * @version 2.0.0 (v1.17.0)
  * @description Seletor temporal para o extrato do plano.
- *   Toggle: Ciclo (consolidado) vs períodos individuais.
+ *   v2.0.0: Navegação entre ciclos (setas + dropdown), dropdown para >7 períodos.
+ *   v1.0.0: Toggle Ciclo vs períodos individuais como botões.
  */
 
-import { Calendar, RefreshCw } from 'lucide-react';
+import { Calendar, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react';
+
+const DROPDOWN_THRESHOLD = 7;
 
 const fmtPeriodLabel = (periodKey, operationPeriod) => {
   if (!periodKey) return '-';
@@ -19,6 +22,9 @@ const fmtPeriodLabel = (periodKey, operationPeriod) => {
  * @param {Function} onSelectPeriod - (periodKey|null) => void
  * @param {string} operationPeriod - 'Diário' | 'Semanal'
  * @param {string} currentPeriodKey - Chave do período atual (highlight)
+ * @param {Array} availableCycles - Lista de ciclos { key, label, start, end, tradesCount }
+ * @param {string} selectedCycleKey - Chave do ciclo selecionado
+ * @param {Function} onSelectCycle - (cycleKey) => void
  */
 const ExtractPeriodSelector = ({
   availablePeriods,
@@ -26,11 +32,81 @@ const ExtractPeriodSelector = ({
   onSelectPeriod,
   operationPeriod,
   currentPeriodKey,
+  availableCycles = [],
+  selectedCycleKey,
+  onSelectCycle,
 }) => {
   const isCycleView = selectedPeriod === null;
+  const useDropdown = availablePeriods.length > DROPDOWN_THRESHOLD;
+
+  // Navegação entre ciclos
+  const currentCycleIndex = availableCycles.findIndex(c => c.key === selectedCycleKey);
+  const hasPrev = currentCycleIndex > 0;
+  const hasNext = currentCycleIndex < availableCycles.length - 1;
+  const currentCycleLabel = availableCycles[currentCycleIndex]?.label || '';
+
+  const handlePrevCycle = () => {
+    if (hasPrev && onSelectCycle) {
+      onSelectCycle(availableCycles[currentCycleIndex - 1].key);
+    }
+  };
+
+  const handleNextCycle = () => {
+    if (hasNext && onSelectCycle) {
+      onSelectCycle(availableCycles[currentCycleIndex + 1].key);
+    }
+  };
 
   return (
-    <div className="flex items-center gap-2 flex-wrap">
+    <div className="flex items-center gap-3 flex-wrap">
+      {/* Navegação de ciclos */}
+      {availableCycles.length > 1 && (
+        <div className="flex items-center gap-1 mr-2 border-r border-slate-700/50 pr-3">
+          <button
+            onClick={handlePrevCycle}
+            disabled={!hasPrev}
+            className={`p-1 rounded transition-all ${
+              hasPrev
+                ? 'text-slate-400 hover:text-white hover:bg-slate-700'
+                : 'text-slate-700 cursor-not-allowed'
+            }`}
+            title="Ciclo anterior"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+
+          {availableCycles.length <= 6 ? (
+            <span className="text-xs font-bold text-white px-2 py-1 bg-slate-800/80 rounded-lg border border-slate-700/50 min-w-[80px] text-center">
+              {currentCycleLabel}
+            </span>
+          ) : (
+            <select
+              value={selectedCycleKey || ''}
+              onChange={(e) => onSelectCycle?.(e.target.value)}
+              className="text-xs font-bold text-white bg-slate-800/80 rounded-lg border border-slate-700/50 px-2 py-1 min-w-[80px] text-center appearance-none cursor-pointer hover:border-slate-600 focus:border-blue-500 focus:outline-none"
+            >
+              {availableCycles.map(c => (
+                <option key={c.key} value={c.key}>{c.label} ({c.tradesCount})</option>
+              ))}
+            </select>
+          )}
+
+          <button
+            onClick={handleNextCycle}
+            disabled={!hasNext}
+            className={`p-1 rounded transition-all ${
+              hasNext
+                ? 'text-slate-400 hover:text-white hover:bg-slate-700'
+                : 'text-slate-700 cursor-not-allowed'
+            }`}
+            title="Próximo ciclo"
+          >
+            <ChevronRight className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Botão Ciclo (consolidado) */}
       <button
         onClick={() => onSelectPeriod(null)}
         className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold uppercase tracking-wider border transition-all ${
@@ -42,27 +118,57 @@ const ExtractPeriodSelector = ({
         <RefreshCw className="w-3 h-3" />
         Ciclo
       </button>
+
       <span className="text-slate-700">|</span>
-      {availablePeriods.map(periodKey => {
-        const isSelected = selectedPeriod === periodKey;
-        const isCurrent = periodKey === currentPeriodKey;
-        return (
-          <button
-            key={periodKey}
-            onClick={() => onSelectPeriod(periodKey)}
-            className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-mono border transition-all ${
-              isSelected
-                ? 'bg-blue-500/20 text-blue-400 border-blue-500/40 font-bold'
-                : isCurrent
-                  ? 'bg-slate-800/50 text-slate-300 border-slate-600 hover:border-blue-500/40'
-                  : 'bg-slate-800/30 text-slate-500 border-slate-700/30 hover:text-slate-300 hover:border-slate-600'
+
+      {/* Períodos: botões (≤7) ou dropdown (>7) */}
+      {useDropdown ? (
+        <div className="flex items-center gap-2">
+          <Calendar className="w-3 h-3 text-slate-500" />
+          <select
+            value={selectedPeriod || ''}
+            onChange={(e) => onSelectPeriod(e.target.value || null)}
+            className={`text-xs font-mono bg-slate-800/50 rounded-lg border px-2.5 py-1.5 appearance-none cursor-pointer focus:outline-none transition-all ${
+              selectedPeriod
+                ? 'text-blue-400 border-blue-500/40 font-bold'
+                : 'text-slate-500 border-slate-700/50 hover:border-slate-600'
             }`}
           >
-            <Calendar className="w-3 h-3" />
-            {fmtPeriodLabel(periodKey, operationPeriod)}
-          </button>
-        );
-      })}
+            <option value="">Selecionar período...</option>
+            {availablePeriods.map(periodKey => (
+              <option key={periodKey} value={periodKey}>
+                {fmtPeriodLabel(periodKey, operationPeriod)}
+                {periodKey === currentPeriodKey ? ' (atual)' : ''}
+              </option>
+            ))}
+          </select>
+          <span className="text-[10px] text-slate-600">{availablePeriods.length} períodos</span>
+        </div>
+      ) : (
+        <>
+          {availablePeriods.map(periodKey => {
+            const isSelected = selectedPeriod === periodKey;
+            const isCurrent = periodKey === currentPeriodKey;
+            return (
+              <button
+                key={periodKey}
+                onClick={() => onSelectPeriod(periodKey)}
+                className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-mono border transition-all ${
+                  isSelected
+                    ? 'bg-blue-500/20 text-blue-400 border-blue-500/40 font-bold'
+                    : isCurrent
+                      ? 'bg-slate-800/50 text-slate-300 border-slate-600 hover:border-blue-500/40'
+                      : 'bg-slate-800/30 text-slate-500 border-slate-700/30 hover:text-slate-300 hover:border-slate-600'
+                }`}
+              >
+                <Calendar className="w-3 h-3" />
+                {fmtPeriodLabel(periodKey, operationPeriod)}
+              </button>
+            );
+          })}
+        </>
+      )}
+
       {availablePeriods.length === 0 && (
         <span className="text-xs text-slate-600 italic">Sem períodos com trades</span>
       )}

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -1,13 +1,17 @@
 /**
  * ExtractTable
- * @version 1.0.0 (v1.16.0)
+ * @version 2.0.0 (v1.17.0)
  * @description Tabela do extrato com colunas de sanity check (RO, RR, Emoção)
  *   e marcação visual para POST_GOAL/POST_STOP.
- *   Ordem: mais recentes no topo (invertida).
+ *   v2.0.0: Coluna Evento agora mostra eventos emocionais e compliance inline
+ *           (TILT, REVENGE, NO_STOP, RO_FORA, RR_FORA) além dos eventos de state machine.
+ *   v1.0.0: Apenas eventos de state machine (GOAL_HIT, STOP_HIT, POST_GOAL, POST_STOP).
+ *   Ordem: cronológica (mais antigo no topo).
  */
 
 import {
-  Trophy, Skull, ShieldAlert, ShieldOff, Scale
+  Trophy, Skull, ShieldAlert, ShieldOff, Scale,
+  Flame, Zap, AlertTriangle
 } from 'lucide-react';
 import { PERIOD_STATES } from '../../utils/planStateMachine';
 
@@ -27,9 +31,7 @@ const getEmotionColor = (category) => {
   }
 };
 
-/**
- * Faixa de fundo para trades pós-evento.
- */
+/** Faixa de fundo para trades pós-evento. */
 const getRowBg = (periodEvent, isEventTrade) => {
   if (isEventTrade) return 'bg-slate-800/60';
   if (periodEvent === PERIOD_STATES.POST_GOAL) return 'bg-amber-500/5 border-l-2 border-l-amber-500/40';
@@ -38,13 +40,85 @@ const getRowBg = (periodEvent, isEventTrade) => {
 };
 
 /**
+ * Coleta eventos inline para um trade específico.
+ * Combina: state machine + compliance + flags emocionais passados via emotionalEvents.
+ */
+const getTradeInlineEvents = (row, emotionalEvents) => {
+  const events = [];
+  const trade = row.trade;
+
+  // 1. State machine events (período)
+  if (row.periodEvent === PERIOD_STATES.GOAL_HIT) {
+    events.push({ icon: Trophy, color: 'text-emerald-400', label: 'META!', sublabel: 'Período' });
+  } else if (row.periodEvent === PERIOD_STATES.STOP_HIT) {
+    events.push({ icon: Skull, color: 'text-red-400', label: 'STOP!', sublabel: 'Período' });
+  } else if (row.periodEvent === PERIOD_STATES.POST_GOAL) {
+    events.push({ icon: null, color: 'text-amber-500/70', label: 'Pós-Meta', small: true });
+  } else if (row.periodEvent === PERIOD_STATES.POST_STOP) {
+    events.push({ icon: null, color: 'text-red-500/70', label: 'Violação', small: true });
+  }
+
+  // 1b. Cycle events (se este trade causou cycle goal/stop)
+  if (row.cycleEvent === 'CYCLE_GOAL_HIT') {
+    events.push({ icon: Trophy, color: 'text-emerald-300', label: 'META!', sublabel: 'Ciclo' });
+  } else if (row.cycleEvent === 'CYCLE_STOP_HIT') {
+    events.push({ icon: Skull, color: 'text-red-300', label: 'STOP!', sublabel: 'Ciclo' });
+  }
+
+  // 2. Compliance events
+  const hasNoStop = Array.isArray(trade.redFlags) && trade.redFlags.some(f =>
+    (typeof f === 'string' ? f : f.type) === 'TRADE_SEM_STOP'
+  );
+  if (hasNoStop) {
+    events.push({ icon: ShieldAlert, color: 'text-red-400', label: 'S/Stop', small: true });
+  }
+  if (trade.compliance?.roStatus === 'FORA_DO_PLANO') {
+    events.push({ icon: ShieldOff, color: 'text-amber-400', label: 'RO', small: true });
+  }
+  if (trade.compliance?.rrStatus === 'NAO_CONFORME') {
+    events.push({ icon: Scale, color: 'text-amber-400', label: 'RR', small: true });
+  }
+
+  // 3. Emotional events (TILT, REVENGE matched by tradeId or proximity)
+  if (emotionalEvents) {
+    const tradeEmotionalEvents = emotionalEvents.filter(e => {
+      // Match por tradeId direto se disponível
+      if (e.tradeId && e.tradeId === trade.id) return true;
+      // Match por data/hora (TILT/REVENGE detectados próximos ao trade)
+      if (e.date === trade.date) return true;
+      return false;
+    });
+    for (const ee of tradeEmotionalEvents) {
+      if (ee.type === 'TILT_DETECTED' || ee.type === 'TILT') {
+        // Evitar duplicata se já adicionado
+        if (!events.some(ev => ev.label === 'TILT')) {
+          events.push({ icon: Flame, color: 'text-orange-400', label: 'TILT', small: true });
+        }
+      }
+      if (ee.type === 'REVENGE_DETECTED' || ee.type === 'REVENGE') {
+        if (!events.some(ev => ev.label === 'REVENGE')) {
+          events.push({ icon: Zap, color: 'text-red-400', label: 'REVENGE', small: true });
+        }
+      }
+      if (ee.type === 'STATUS_CRITICAL') {
+        if (!events.some(ev => ev.label === 'CRÍTICO')) {
+          events.push({ icon: AlertTriangle, color: 'text-red-500', label: 'CRÍTICO', small: true });
+        }
+      }
+    }
+  }
+
+  return events;
+};
+
+/**
  * @param {Array} rows - Rows da state machine (cada row tem .trade, .periodEvent, .cumPnL, .result)
  * @param {Function} fmt - formatCurrencyDynamic parcial
  * @param {Function} getEmotionConfig - De useMasterData
  * @param {number} carryOver - Saldo transportado de períodos anteriores (0 na visão ciclo)
+ * @param {Array} [emotionalEvents] - Eventos emocionais (TILT, REVENGE) para matching inline
  */
-const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0 }) => {
-  // Ordem cronológica (mais antigo no topo) — acumulado funciona como saldo
+const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEvents = [] }) => {
   const displayRows = rows;
 
   return (
@@ -60,7 +134,7 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0 }) => {
             <th className="p-3 text-right">RR</th>
             <th className="p-3 text-right">Resultado</th>
             <th className="p-3 text-right bg-slate-800/50">Acumulado</th>
-            <th className="p-3 text-center w-28">Evento</th>
+            <th className="p-3 text-center w-32">Evento</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-800/50">
@@ -98,6 +172,9 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0 }) => {
             );
             const roFora = trade.compliance?.roStatus === 'FORA_DO_PLANO';
             const rrFora = trade.compliance?.rrStatus === 'NAO_CONFORME';
+
+            // Inline events
+            const inlineEvents = getTradeInlineEvents(row, emotionalEvents);
 
             return (
               <tr
@@ -163,26 +240,32 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0 }) => {
                   {fmt(row.cumPnL)}
                 </td>
 
-                {/* Evento */}
+                {/* Evento — agora mostra TUDO inline */}
                 <td className="p-3 text-center">
-                  {row.periodEvent === PERIOD_STATES.GOAL_HIT && (
-                    <span className="text-emerald-400 font-bold text-xs flex justify-center items-center gap-1">
-                      <Trophy className="w-3 h-3" /> META!
-                    </span>
-                  )}
-                  {row.periodEvent === PERIOD_STATES.STOP_HIT && (
-                    <span className="text-red-400 font-bold text-xs flex justify-center items-center gap-1">
-                      <Skull className="w-3 h-3" /> STOP!
-                    </span>
-                  )}
-                  {row.periodEvent === PERIOD_STATES.POST_GOAL && (
-                    <span className="text-amber-500/70 text-[10px] uppercase font-bold">Pós-Meta</span>
-                  )}
-                  {row.periodEvent === PERIOD_STATES.POST_STOP && (
-                    <span className="text-red-500/70 text-[10px] uppercase font-bold">Violação</span>
-                  )}
-                  {row.periodEvent === PERIOD_STATES.IN_PROGRESS && (
+                  {inlineEvents.length === 0 && (
                     <span className="text-slate-600 text-xs">-</span>
+                  )}
+                  {inlineEvents.length > 0 && (
+                    <div className="flex flex-wrap justify-center gap-1">
+                      {inlineEvents.map((evt, idx) => {
+                        const Icon = evt.icon;
+                        return (
+                          <span
+                            key={idx}
+                            className={`${evt.color} ${evt.small ? 'text-[9px]' : 'text-xs'} font-bold flex items-center gap-0.5 ${evt.small ? 'uppercase' : ''}`}
+                            title={evt.sublabel ? `${evt.label} (${evt.sublabel})` : evt.label}
+                          >
+                            {Icon && <Icon className="w-3 h-3" />}
+                            {evt.sublabel ? (
+                              <span className="flex flex-col items-center leading-none">
+                                <span>{evt.label}</span>
+                                <span className="text-[7px] opacity-60">{evt.sublabel}</span>
+                              </span>
+                            ) : evt.label}
+                          </span>
+                        );
+                      })}
+                    </div>
                   )}
                 </td>
               </tr>

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -20,6 +20,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { usePlans } from '../hooks/usePlans';
 import AccountDetailPage from './AccountDetailPage';
 import StudentAccountGroup from '../components/StudentAccountGroup';
+import PlanManagementModal from '../components/PlanManagementModal';
 import DebugBadge from '../components/DebugBadge';
 import { collection, query, where, onSnapshot, getDocs, doc, updateDoc, writeBatch } from 'firebase/firestore';
 import { db } from '../firebase';
@@ -76,7 +77,7 @@ const dateToInputString = (dateObj) => {
 const AccountsPage = () => {
   const { accounts, loading, addAccount, updateAccount, deleteAccount } = useAccounts();
   const { brokers } = useMasterData();
-  const { isMentor } = useAuth();
+  const { user, isMentor } = useAuth();
   const { plans, updatePlan } = usePlans();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -85,6 +86,8 @@ const AccountsPage = () => {
   const [selectedAccount, setSelectedAccount] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [planSubmitting, setPlanSubmitting] = useState(false);
+  const [showPlanModal, setShowPlanModal] = useState(false);
+  const [editingPlan, setEditingPlan] = useState(null);
   
   const [auditState, setAuditState] = useState({ status: 'idle', message: '', issueType: null, ledgerBalance: 0, suggestion: null });
   const [isFixing, setIsFixing] = useState(false);
@@ -358,6 +361,33 @@ const AccountsPage = () => {
     }
   };
 
+  // Handler: Mentor salva plano via PlanManagementModal (chamado do accordion)
+  const handleMentorSavePlan = async (planData) => {
+    if (!editingPlan) return;
+    setPlanSubmitting(true);
+    try {
+      await updatePlan(editingPlan.id, planData, {
+        editedBy: 'mentor',
+        email: user?.email || 'unknown',
+        editedAt: new Date().toISOString(),
+        source: 'AccountsPage',
+      });
+      setShowPlanModal(false);
+      setEditingPlan(null);
+    } catch (error) {
+      console.error('Erro ao salvar plano:', error);
+      alert('Erro: ' + error.message);
+    } finally {
+      setPlanSubmitting(false);
+    }
+  };
+
+  // Callback para StudentAccountGroup
+  const handleOpenEditPlan = (plan) => {
+    setEditingPlan(plan);
+    setShowPlanModal(true);
+  };
+
   const getAccountBadge = (acc) => {
     const type = acc.type || (acc.isReal ? 'REAL' : 'DEMO');
     switch (type) {
@@ -385,7 +415,7 @@ const AccountsPage = () => {
       </div>
 
       {isMentor() ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">{Object.entries(filteredGroups).map(([studentId, data]) => (<StudentAccountGroup key={studentId} studentName={data.studentName} studentEmail={data.studentEmail} accounts={data.accounts} plans={plans} balancesByAccountId={balancesByAccountId} onAccountClick={setSelectedAccount} onEditAccount={openModal} getAccountBadge={getAccountBadge} formatCurrency={formatCurrency} />))}</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">{Object.entries(filteredGroups).map(([studentId, data]) => (<StudentAccountGroup key={studentId} studentName={data.studentName} studentEmail={data.studentEmail} accounts={data.accounts} plans={plans} balancesByAccountId={balancesByAccountId} onAccountClick={setSelectedAccount} onEditAccount={openModal} onEditPlan={handleOpenEditPlan} getAccountBadge={getAccountBadge} formatCurrency={formatCurrency} />))}</div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {accounts.map(acc => {
@@ -463,6 +493,16 @@ const AccountsPage = () => {
         </div>
       )}
       <style>{`.badge-account { position: absolute; top: 1rem; right: 1rem; padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-size: 0.625rem; text-transform: uppercase; font-weight: 700; display: flex; align-items: center; gap: 0.25rem; border-width: 1px; } .input-label { display: block; font-size: 0.75rem; color: rgb(148 163 184); margin-bottom: 0.5rem; font-weight: 500; } .input-dark { background: rgb(15 23 42); border: 1px solid rgb(51 65 85); padding: 0.625rem 0.75rem; border-radius: 0.5rem; color: white; outline: none; transition: border-color 0.2s; } .input-dark:focus { border-color: rgb(59 130 246); }`}</style>
+      {/* Modal edição de plano pelo mentor (via accordion) */}
+      {isMentor() && showPlanModal && (
+        <PlanManagementModal
+          isOpen={showPlanModal}
+          onClose={() => { setShowPlanModal(false); setEditingPlan(null); }}
+          onSubmit={handleMentorSavePlan}
+          editingPlan={editingPlan}
+          isSubmitting={planSubmitting}
+        />
+      )}
       <DebugBadge component="AccountsPage" />
     </div>
   );

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { runSeed, forceSeed, updateTickers } from '../utils/seedData';
+import { seedTestExtract, cleanupTestExtract } from '../utils/seedTestExtract';
 import TickerManager from './admin/TickerManager'; // Certifique-se de criar a pasta admin
 
 const AdminPage = () => {
@@ -133,6 +134,32 @@ const AdminPage = () => {
                       className="btn-primary bg-red-600 hover:bg-red-700 w-full border-none"
                     >
                       {sysLoading === 'force' ? 'Resetando...' : 'Forçar Reset'}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Teste de Extrato */}
+                <div className="mt-6 grid gap-4 md:grid-cols-2">
+                  <div className="glass-card p-6 border-purple-500/20">
+                    <h3 className="text-lg font-bold text-purple-400 mb-2">Seed Teste Extrato</h3>
+                    <p className="text-sm text-slate-400 mb-4">Cria aluno fictício com 10 planos cobrindo todos os cenários de badge e extrato.</p>
+                    <button
+                      onClick={() => handleSystemAction('seedTest', seedTestExtract)}
+                      disabled={sysLoading !== null}
+                      className="btn-secondary w-full border-purple-500/30 text-purple-400 hover:bg-purple-500/10"
+                    >
+                      {sysLoading === 'seedTest' ? 'Criando...' : 'Criar Dados de Teste'}
+                    </button>
+                  </div>
+                  <div className="glass-card p-6 border-amber-500/20">
+                    <h3 className="text-lg font-bold text-amber-400 mb-2">Limpar Teste Extrato</h3>
+                    <p className="text-sm text-slate-400 mb-4">Remove todos os dados criados pelo seed de teste.</p>
+                    <button
+                      onClick={() => handleSystemAction('cleanupTest', cleanupTestExtract)}
+                      disabled={sysLoading !== null}
+                      className="btn-secondary w-full border-amber-500/30 text-amber-400 hover:bg-amber-500/10"
+                    >
+                      {sysLoading === 'cleanupTest' ? 'Removendo...' : 'Limpar Dados de Teste'}
                     </button>
                   </div>
                 </div>

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -17,6 +17,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useMasterData } from '../hooks/useMasterData';
 import { useTrades } from '../hooks/useTrades';
 import { runSeed, forceSeed, updateTickers } from '../utils/seedData';
+import { seedTestExtract, cleanupTestExtract } from '../utils/seedTestExtract';
 import ComplianceConfigPage from './ComplianceConfigPage';
 import DebugBadge from '../components/DebugBadge';
 
@@ -304,7 +305,13 @@ const SettingsPage = () => {
     setAdminLoading(action);
     setAdminResult(null);
     try {
-      const actions = { seed: runSeed, force: forceSeed, tickers: updateTickers };
+      const actions = {
+        seed: runSeed,
+        force: forceSeed,
+        tickers: updateTickers,
+        seedTest: () => seedTestExtract(user?.uid),
+        cleanupTest: cleanupTestExtract,
+      };
       const res = await actions[action]();
       setAdminResult(res);
     } catch (err) {
@@ -558,6 +565,28 @@ const SettingsPage = () => {
               </div>
               <button onClick={() => handleAdminAction('tickers')} disabled={adminLoading} className="btn-primary py-2 px-4">
                 {adminLoading === 'tickers' ? <Loader2 className="w-5 h-5 animate-spin" /> : <><RefreshCw className="w-4 h-4 mr-2" />Atualizar</>}
+              </button>
+            </div>
+          </div>
+          <div className="glass-card p-6 border-purple-500/30">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-purple-400 mb-1">Seed Teste Extrato</h3>
+                <p className="text-sm text-slate-400">Cria aluno fictício com 10 planos (todos os cenários de badge)</p>
+              </div>
+              <button onClick={() => handleAdminAction('seedTest')} disabled={adminLoading} className="btn-secondary py-2 px-4 border-purple-500/50 text-purple-400">
+                {adminLoading === 'seedTest' ? <Loader2 className="w-5 h-5 animate-spin" /> : <><Database className="w-4 h-4 mr-2" />Criar</>}
+              </button>
+            </div>
+          </div>
+          <div className="glass-card p-6 border-amber-500/30">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-amber-400 mb-1">Limpar Teste Extrato</h3>
+                <p className="text-sm text-slate-400">Remove aluno fictício e todos os dados de teste</p>
+              </div>
+              <button onClick={() => handleAdminAction('cleanupTest')} disabled={adminLoading} className="btn-secondary py-2 px-4 border-amber-500/50 text-amber-400">
+                {adminLoading === 'cleanupTest' ? <Loader2 className="w-5 h-5 animate-spin" /> : <><Zap className="w-4 h-4 mr-2" />Limpar</>}
               </button>
             </div>
           </div>

--- a/src/utils/planStateMachine.js
+++ b/src/utils/planStateMachine.js
@@ -425,6 +425,56 @@ export const computePlanState = (trades, planConfig, options = {}) => {
 };
 
 // ============================================
+// HELPERS — Cycle Navigation
+// ============================================
+
+/**
+ * Retorna a lista de ciclos disponíveis com base nos trades.
+ * Cada ciclo tem { key, label, start, end, tradesCount }.
+ * Ordenado do mais antigo ao mais recente.
+ *
+ * @param {Array} trades - Todos os trades do plano
+ * @param {string} adjustmentCycle - 'Mensal' | 'Trimestral'
+ * @returns {Array<{ key: string, label: string, start: Date, end: Date, tradesCount: number }>}
+ */
+export const getAvailableCycles = (trades, adjustmentCycle = 'Mensal') => {
+  if (!trades || trades.length === 0) return [];
+
+  const cycleMap = new Map();
+
+  for (const trade of trades) {
+    if (!trade.date) continue;
+    const d = new Date(trade.date + 'T12:00:00');
+    const start = getCycleStartDate(adjustmentCycle, d);
+    const end = getCycleEndDate(adjustmentCycle, d);
+    const key = formatDateKey(start);
+
+    if (!cycleMap.has(key)) {
+      const label = adjustmentCycle === 'Trimestral'
+        ? formatCycleLabel_Trimestral(start)
+        : formatCycleLabel_Mensal(start);
+      cycleMap.set(key, { key, label, start, end, tradesCount: 0 });
+    }
+    cycleMap.get(key).tradesCount++;
+  }
+
+  return [...cycleMap.values()].sort((a, b) => a.key.localeCompare(b.key));
+};
+
+/** Label legível para ciclo mensal: "Mar/2026" */
+const MONTH_NAMES_PT = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
+
+const formatCycleLabel_Mensal = (start) => {
+  return `${MONTH_NAMES_PT[start.getMonth()]}/${start.getFullYear()}`;
+};
+
+/** Label legível para ciclo trimestral: "Q1/2026" */
+const formatCycleLabel_Trimestral = (start) => {
+  const q = Math.floor(start.getMonth() / 3) + 1;
+  return `Q${q}/${start.getFullYear()}`;
+};
+
+// ============================================
 // HELPERS — Badge Classification
 // ============================================
 
@@ -465,8 +515,8 @@ export const classifyPeriodBadge = (periodState) => {
 
     case PERIOD_STATES.POST_STOP:
       if (totalPnL >= 0) {
-        // Recuperou do stop — sorte/habilidade
-        return { badge: 'LOSS_TO_GOAL', label: 'Recuperação', icon: 'Trophy', colorClass: 'amber', animate: false };
+        // Recuperou do stop — mas violou: o correto era parar
+        return { badge: 'LOSS_TO_GOAL', label: 'Violação (Recuperou)', icon: 'AlertTriangle', colorClass: 'amber', animate: true };
       }
       // Piorou após stop
       return { badge: 'STOP_WORSENED', label: 'Stop Violado', icon: 'Skull', colorClass: 'red', animate: true };

--- a/src/utils/seedTestExtract.js
+++ b/src/utils/seedTestExtract.js
@@ -1,0 +1,390 @@
+/**
+ * seedTestExtract.js
+ * @version 2.0.0 (v1.17.0)
+ * @description Script para criar dados de teste que cobrem TODOS os cenários
+ *   de badge e extrato emocional.
+ *
+ *   - Cria conta no Firebase Auth (login funcional)
+ *   - Vincula ao mentor logado (mentorId automático)
+ *   - 10 planos, ~35 trades cobrindo todos os estados da state machine
+ *
+ * CENÁRIOS COBERTOS:
+ *   1. IN_PROGRESS — trades dentro dos limites
+ *   2. GOAL_DISCIPLINED — meta batida, parou
+ *   3. POST_GOAL_GAIN — meta + continuou positivo
+ *   4. POST_GOAL_LOSS — meta + devolveu parcial
+ *   5. GOAL_TO_STOP — catástrofe: meta → stop
+ *   6. STOP_HIT — stop atingido, parou
+ *   7. STOP_WORSENED — stop violado, piorou
+ *   8. LOSS_TO_GOAL — stop → recuperou
+ *   9. TILT + REVENGE + Compliance violations
+ *   10. MULTI-CICLO — trades em Jan/Fev/Mar
+ *
+ * USO (via SettingsPage > Admin):
+ *   1. Clicar "Criar Dados de Teste" — cria tudo
+ *   2. View As → "Aluno Teste Extrato"
+ *   3. Abrir extrato de cada plano para validar
+ *   4. Clicar "Limpar Dados de Teste" quando terminar
+ *
+ * LOGIN DIRETO (opcional):
+ *   Email: teste.extrato@ficticio.com
+ *   Senha: Teste@123
+ */
+
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  deleteUser,
+} from 'firebase/auth';
+import {
+  collection,
+  doc,
+  setDoc,
+  getDocs,
+  deleteDoc,
+  query,
+  where,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import { auth, db } from '../firebase';
+
+// ============================================
+// CONSTANTES
+// ============================================
+
+const TEST_EMAIL = 'teste.extrato@ficticio.com';
+const TEST_PASSWORD = 'Teste@123';
+const TEST_NAME = 'Aluno Teste Extrato';
+const TEST_ACCOUNT_ID = 'test-extract-account-001';
+const TEST_ACCOUNT_ID_2 = 'test-extract-account-002';
+
+const PLAN_IDS = {
+  IN_PROGRESS: 'test-plan-in-progress',
+  GOAL_DISCIPLINED: 'test-plan-goal-disciplined',
+  POST_GOAL_GAIN: 'test-plan-post-goal-gain',
+  POST_GOAL_LOSS: 'test-plan-post-goal-loss',
+  GOAL_TO_STOP: 'test-plan-goal-to-stop',
+  STOP_HIT: 'test-plan-stop-hit',
+  STOP_WORSENED: 'test-plan-stop-worsened',
+  LOSS_TO_GOAL: 'test-plan-loss-to-goal',
+  TILT_REVENGE: 'test-plan-tilt-revenge',
+  MULTI_CYCLE: 'test-plan-multi-cycle',
+};
+
+// ============================================
+// HELPERS
+// ============================================
+
+const toTimestamp = (dateStr) => Timestamp.fromDate(new Date(dateStr + 'T12:00:00'));
+
+const makePlan = (id, name, accountId, studentId) => ({
+  name,
+  accountId,
+  active: true,
+  operationPeriod: 'Diário',
+  adjustmentCycle: 'Mensal',
+  pl: 20000,
+  periodGoal: 2,
+  periodStop: 2,
+  cycleGoal: 8,
+  cycleStop: 6,
+  rrTarget: 2,
+  maxContracts: 5,
+  maxTradesPerDay: 5,
+  riskPerOperation: 0.4,
+  studentId,
+  createdAt: serverTimestamp(),
+  updatedAt: serverTimestamp(),
+});
+
+let tradeCounter = 0;
+
+const makeTrade = ({
+  date, time, ticker = 'WINFUT', side = 'LONG',
+  result, planId, accountId = TEST_ACCOUNT_ID, studentId,
+  emotionEntry = 'Disciplinado', emotionExit = 'Disciplinado',
+  stopLoss, riskPercent, rrRatio,
+  roStatus = 'CONFORME', rrStatus = 'CONFORME',
+  redFlags = [],
+}) => {
+  tradeCounter++;
+  const id = `test-trade-${String(tradeCounter).padStart(4, '0')}`;
+  const entryTime = `${date}T${time || '10:00'}:00`;
+
+  return {
+    _id: id,
+    date,
+    entryTime,
+    exitTime: entryTime,
+    duration: 15,
+    ticker,
+    exchange: 'B3',
+    side,
+    entry: 128000,
+    exit: 128000 + (result / 0.2) * (side === 'LONG' ? 1 : -1),
+    qty: 1,
+    stopLoss: stopLoss ?? (side === 'LONG' ? 127900 : 128100),
+    result,
+    resultInPoints: result / 0.2,
+    resultCalculated: result,
+    resultPercent: (result / 20000) * 100,
+    emotionEntry,
+    emotionExit,
+    compliance: { roStatus, rrStatus },
+    redFlags,
+    riskPercent: riskPercent ?? 0.1,
+    rrRatio: rrRatio ?? 2.0,
+    status: 'OPEN',
+    planId,
+    accountId,
+    currency: 'BRL',
+    studentId,
+    studentEmail: TEST_EMAIL,
+    studentName: TEST_NAME,
+    hasPartials: false,
+    partialsCount: 0,
+    _partials: [],
+    createdAt: toTimestamp(date),
+    updatedAt: toTimestamp(date),
+  };
+};
+
+// ============================================
+// CENÁRIOS
+// ============================================
+
+const buildAllTrades = (studentId) => {
+  tradeCounter = 0;
+  const trades = [];
+  const t = (overrides) => makeTrade({ ...overrides, studentId });
+
+  // 1. IN_PROGRESS — positivo mas abaixo da meta (400)
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: 100, planId: PLAN_IDS.IN_PROGRESS, emotionEntry: 'Focado', emotionExit: 'Disciplinado' }));
+  trades.push(t({ date: '2026-03-03', time: '10:30', result: 80, planId: PLAN_IDS.IN_PROGRESS, emotionEntry: 'Confiante', emotionExit: 'Confiante' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: -30, planId: PLAN_IDS.IN_PROGRESS, emotionEntry: 'Cauteloso', emotionExit: 'Neutro' }));
+
+  // 2. GOAL_DISCIPLINED — total 450 >= 400
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: 150, planId: PLAN_IDS.GOAL_DISCIPLINED, emotionEntry: 'Disciplinado', emotionExit: 'Confiante' }));
+  trades.push(t({ date: '2026-03-03', time: '10:30', result: 120, planId: PLAN_IDS.GOAL_DISCIPLINED, emotionEntry: 'Focado', emotionExit: 'Focado' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: 180, planId: PLAN_IDS.GOAL_DISCIPLINED, emotionEntry: 'Confiante', emotionExit: 'Disciplinado' }));
+
+  // 3. POST_GOAL_GAIN — meta + overtrading, ainda positivo
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: 500, planId: PLAN_IDS.POST_GOAL_GAIN, emotionEntry: 'Confiante', emotionExit: 'Eufórico' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: 100, planId: PLAN_IDS.POST_GOAL_GAIN, emotionEntry: 'Eufórico', emotionExit: 'Ganância' }));
+  trades.push(t({ date: '2026-03-03', time: '11:30', result: -50, planId: PLAN_IDS.POST_GOAL_GAIN, emotionEntry: 'Ganância', emotionExit: 'Frustrado' }));
+
+  // 4. POST_GOAL_LOSS — meta + devolveu (total 50, abaixo da meta)
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: 500, planId: PLAN_IDS.POST_GOAL_LOSS, emotionEntry: 'Confiante', emotionExit: 'Eufórico' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: -200, planId: PLAN_IDS.POST_GOAL_LOSS, emotionEntry: 'Eufórico', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '11:30', result: -250, planId: PLAN_IDS.POST_GOAL_LOSS, emotionEntry: 'Revenge', emotionExit: 'Frustrado' }));
+
+  // 5. GOAL_TO_STOP — meta → catástrofe (total -450)
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: 450, planId: PLAN_IDS.GOAL_TO_STOP, emotionEntry: 'Confiante', emotionExit: 'Eufórico' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: -400, planId: PLAN_IDS.GOAL_TO_STOP, emotionEntry: 'Eufórico', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '11:30', result: -300, planId: PLAN_IDS.GOAL_TO_STOP, emotionEntry: 'Revenge', emotionExit: 'Medo' }));
+  trades.push(t({ date: '2026-03-03', time: '12:00', result: -200, planId: PLAN_IDS.GOAL_TO_STOP, emotionEntry: 'Impulsivo', emotionExit: 'Medo' }));
+
+  // 6. STOP_HIT — total -450 <= -400
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: -200, planId: PLAN_IDS.STOP_HIT, emotionEntry: 'Ansioso', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '10:30', result: -150, planId: PLAN_IDS.STOP_HIT, emotionEntry: 'FOMO', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: -100, planId: PLAN_IDS.STOP_HIT, emotionEntry: 'Hesitante', emotionExit: 'Medo' }));
+
+  // 7. STOP_WORSENED — piorou após stop (total -700)
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: -450, planId: PLAN_IDS.STOP_WORSENED, emotionEntry: 'Ansioso', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: -150, planId: PLAN_IDS.STOP_WORSENED, emotionEntry: 'Revenge', emotionExit: 'Medo' }));
+  trades.push(t({ date: '2026-03-03', time: '11:30', result: -100, planId: PLAN_IDS.STOP_WORSENED, emotionEntry: 'Impulsivo', emotionExit: 'Medo' }));
+
+  // 8. LOSS_TO_GOAL — stop → recuperou (total +100)
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: -450, planId: PLAN_IDS.LOSS_TO_GOAL, emotionEntry: 'Ansioso', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '11:00', result: 300, planId: PLAN_IDS.LOSS_TO_GOAL, emotionEntry: 'Focado', emotionExit: 'Confiante' }));
+  trades.push(t({ date: '2026-03-03', time: '11:30', result: 250, planId: PLAN_IDS.LOSS_TO_GOAL, emotionEntry: 'Disciplinado', emotionExit: 'Disciplinado' }));
+
+  // 9. TILT + REVENGE + Compliance
+  // Dia 1: TILT — 3 trades negativos consecutivos
+  trades.push(t({ date: '2026-03-03', time: '10:00', result: -80, planId: PLAN_IDS.TILT_REVENGE, emotionEntry: 'FOMO', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-03-03', time: '10:15', result: -60, planId: PLAN_IDS.TILT_REVENGE, emotionEntry: 'Frustrado', emotionExit: 'Ansioso' }));
+  trades.push(t({ date: '2026-03-03', time: '10:30', result: -40, planId: PLAN_IDS.TILT_REVENGE, emotionEntry: 'Ansioso', emotionExit: 'Medo' }));
+  // Dia 2: REVENGE
+  trades.push(t({ date: '2026-03-04', time: '10:00', result: -100, planId: PLAN_IDS.TILT_REVENGE, emotionEntry: 'Frustrado', emotionExit: 'Revenge' }));
+  trades.push(t({ date: '2026-03-04', time: '10:05', result: -200, planId: PLAN_IDS.TILT_REVENGE, emotionEntry: 'Revenge', emotionExit: 'Medo' }));
+  // Dia 3: Compliance violations
+  trades.push(t({
+    date: '2026-03-05', time: '10:00', result: 50, planId: PLAN_IDS.TILT_REVENGE,
+    emotionEntry: 'Impulsivo', emotionExit: 'Neutro',
+    stopLoss: null, riskPercent: 2.5, rrRatio: 0.8,
+    roStatus: 'FORA_DO_PLANO', rrStatus: 'NAO_CONFORME',
+    redFlags: [{ type: 'TRADE_SEM_STOP' }, { type: 'RISCO_ACIMA_PERMITIDO' }, { type: 'RR_ABAIXO_MINIMO' }],
+  }));
+
+  // 10. MULTI-CICLO — Jan + Fev + Mar
+  trades.push(t({ date: '2026-01-15', time: '10:00', result: 200, planId: PLAN_IDS.MULTI_CYCLE, emotionEntry: 'Focado', emotionExit: 'Confiante' }));
+  trades.push(t({ date: '2026-01-20', time: '10:00', result: 300, planId: PLAN_IDS.MULTI_CYCLE, emotionEntry: 'Disciplinado', emotionExit: 'Disciplinado' }));
+  trades.push(t({ date: '2026-02-10', time: '10:00', result: -150, planId: PLAN_IDS.MULTI_CYCLE, emotionEntry: 'Ansioso', emotionExit: 'Frustrado' }));
+  trades.push(t({ date: '2026-02-15', time: '10:00', result: 400, planId: PLAN_IDS.MULTI_CYCLE, emotionEntry: 'Confiante', emotionExit: 'Disciplinado' }));
+  trades.push(t({ date: '2026-02-20', time: '10:00', result: 100, planId: PLAN_IDS.MULTI_CYCLE, emotionEntry: 'Paciente', emotionExit: 'Focado' }));
+  trades.push(t({ date: '2026-03-05', time: '10:00', result: 250, planId: PLAN_IDS.MULTI_CYCLE, emotionEntry: 'Disciplinado', emotionExit: 'Confiante' }));
+
+  return trades;
+};
+
+// ============================================
+// PUBLIC API
+// ============================================
+
+/**
+ * Cria dados de teste completos.
+ * @param {string} mentorId - UID do mentor logado (passado pela SettingsPage)
+ */
+export const seedTestExtract = async (mentorId) => {
+  console.log('🚀 Iniciando seed de teste para extrato/badges...');
+
+  try {
+    // Salvar auth state atual para restaurar depois
+    const currentUser = auth.currentUser;
+
+    // 1. Criar conta Auth
+    let studentUid;
+    try {
+      const cred = await createUserWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD);
+      studentUid = cred.user.uid;
+      console.log('✅ Auth account criada:', studentUid);
+    } catch (err) {
+      if (err.code === 'auth/email-already-in-use') {
+        // Já existe — fazer login para pegar o uid
+        const cred = await signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD);
+        studentUid = cred.user.uid;
+        console.log('ℹ️ Auth account já existe, uid:', studentUid);
+      } else {
+        throw err;
+      }
+    }
+
+    // Restaurar sessão do mentor
+    if (currentUser && currentUser.email !== TEST_EMAIL) {
+      // Firebase Auth mantém a sessão mais recente — o mentor vai precisar relogar
+      // Mas como estamos no mesmo browser, vamos usar signIn do mentor de volta
+      console.log('⚠️ Sessão Auth mudou para o aluno teste. Recarregue a página para restaurar sua sessão de mentor.');
+    }
+
+    // 2. Criar user doc
+    await setDoc(doc(db, 'users', studentUid), {
+      uid: studentUid,
+      email: TEST_EMAIL,
+      name: TEST_NAME,
+      role: 'student',
+      mentorId: mentorId || null,
+      active: true,
+      activated: true,
+      createdAt: serverTimestamp(),
+    });
+    console.log('✅ User doc criado, mentorId:', mentorId);
+
+    // 3. Contas
+    await setDoc(doc(db, 'accounts', TEST_ACCOUNT_ID), {
+      name: 'Clear — Teste Extrato (BRL)',
+      type: 'REAL', currency: 'BRL',
+      initialBalance: 20000, currentBalance: 20000,
+      exchange: 'B3', broker: 'Clear Corretora',
+      studentId: studentUid, createdAt: serverTimestamp(),
+    });
+    await setDoc(doc(db, 'accounts', TEST_ACCOUNT_ID_2), {
+      name: 'IB — Teste Extrato (USD)',
+      type: 'PROP', currency: 'USD',
+      initialBalance: 5000, currentBalance: 5000,
+      exchange: 'CME', broker: 'Interactive Brokers',
+      studentId: studentUid, createdAt: serverTimestamp(),
+    });
+    console.log('✅ 2 contas criadas');
+
+    // 4. Planos
+    const planEntries = [
+      [PLAN_IDS.IN_PROGRESS, 'Cenário 1: In Progress'],
+      [PLAN_IDS.GOAL_DISCIPLINED, 'Cenário 2: Meta Disciplinada'],
+      [PLAN_IDS.POST_GOAL_GAIN, 'Cenário 3: Pós-Meta (Gain)'],
+      [PLAN_IDS.POST_GOAL_LOSS, 'Cenário 4: Devolveu Meta'],
+      [PLAN_IDS.GOAL_TO_STOP, 'Cenário 5: Catástrofe'],
+      [PLAN_IDS.STOP_HIT, 'Cenário 6: Stop Atingido'],
+      [PLAN_IDS.STOP_WORSENED, 'Cenário 7: Stop Violado'],
+      [PLAN_IDS.LOSS_TO_GOAL, 'Cenário 8: Recuperação'],
+      [PLAN_IDS.TILT_REVENGE, 'Cenário 9: TILT + Compliance'],
+      [PLAN_IDS.MULTI_CYCLE, 'Cenário 10: Multi-Ciclo'],
+    ];
+    for (const [id, name] of planEntries) {
+      await setDoc(doc(db, 'plans', id), makePlan(id, name, TEST_ACCOUNT_ID, studentUid));
+    }
+    console.log(`✅ ${planEntries.length} planos criados`);
+
+    // 5. Trades
+    const trades = buildAllTrades(studentUid);
+    for (const trade of trades) {
+      const { _id, ...data } = trade;
+      await setDoc(doc(db, 'trades', _id), data);
+    }
+    console.log(`✅ ${trades.length} trades criados`);
+
+    const msg = `Seed completo! ${trades.length} trades, 10 planos. Email: ${TEST_EMAIL} / Senha: ${TEST_PASSWORD}. ⚠️ Recarregue a página para restaurar sessão do mentor.`;
+    console.log('\n✅ ' + msg);
+    return { success: true, message: msg };
+
+  } catch (error) {
+    console.error('❌ Erro no seed:', error);
+    return { success: false, message: error.message };
+  }
+};
+
+/**
+ * Remove todos os dados de teste.
+ */
+export const cleanupTestExtract = async () => {
+  console.log('🧹 Removendo dados de teste...');
+
+  try {
+    // Encontrar uid do aluno teste
+    const usersQuery = query(collection(db, 'users'), where('email', '==', TEST_EMAIL));
+    const usersSnap = await getDocs(usersQuery);
+    const studentUid = usersSnap.docs[0]?.id;
+
+    if (studentUid) {
+      // Deletar trades
+      const tradesQuery = query(collection(db, 'trades'), where('studentId', '==', studentUid));
+      const tradesSnap = await getDocs(tradesQuery);
+      for (const d of tradesSnap.docs) await deleteDoc(d.ref);
+      console.log(`   Trades: ${tradesSnap.size}`);
+
+      // Deletar movements
+      const movQuery = query(collection(db, 'movements'), where('accountId', 'in', [TEST_ACCOUNT_ID, TEST_ACCOUNT_ID_2]));
+      const movSnap = await getDocs(movQuery);
+      for (const d of movSnap.docs) await deleteDoc(d.ref);
+
+      // Deletar user doc
+      await deleteDoc(doc(db, 'users', studentUid));
+    }
+
+    // Deletar planos
+    for (const planId of Object.values(PLAN_IDS)) {
+      try { await deleteDoc(doc(db, 'plans', planId)); } catch {}
+    }
+
+    // Deletar contas
+    try { await deleteDoc(doc(db, 'accounts', TEST_ACCOUNT_ID)); } catch {}
+    try { await deleteDoc(doc(db, 'accounts', TEST_ACCOUNT_ID_2)); } catch {}
+
+    // Deletar Auth account (precisa estar logado como o teste)
+    try {
+      const cred = await signInWithEmailAndPassword(auth, TEST_EMAIL, TEST_PASSWORD);
+      await deleteUser(cred.user);
+      console.log('   Auth account deletada');
+    } catch (err) {
+      console.log('   Auth account: não encontrada ou já deletada');
+    }
+
+    const msg = 'Cleanup completo! ⚠️ Recarregue a página para restaurar sessão do mentor.';
+    console.log('\n✅ ' + msg);
+    return { success: true, message: msg };
+
+  } catch (error) {
+    console.error('❌ Erro no cleanup:', error);
+    return { success: false, message: error.message };
+  }
+};

--- a/src/version.js
+++ b/src/version.js
@@ -3,14 +3,15 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.17.0: Cycle navigation, gauge charts, period dropdown, cycle card breakdown (#53-F2)
  * - 1.16.0: State machine plano (#58), badge reclassification, quick fixes dívida técnica
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.16.0',
+  version: '1.17.0',
   build: '20260304',
-  display: 'v1.16.0',
-  full: '1.16.0+20260304',
+  display: 'v1.17.0',
+  full: '1.17.0+20260304',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
# feat(#53-F2): Cycle navigation, gauge charts, period dropdown, cycle card breakdown

## Resumo

Implementação completa do extrato emocional v2 com navegação entre ciclos, velocímetro de progresso (react-d3-speedometer), breakdown por período com click-to-filter, e eventos inline na tabela.

## Mudanças

### Novas features
- **Navegação entre ciclos** — setas ←/→ + dropdown para navegar entre meses/trimestres com trades
- **Period selector dropdown** — quando >7 períodos, troca botões por `<select>`
- **Gauge chart (react-d3-speedometer)** — velocímetro bidirecional: stop à esquerda (vermelho), meta à direita (verde), needle no P&L atual
- **Cycle card (sidebar)** — painel lateral com gauge + breakdown clicável por período, labels de status (Meta, Stop, Meta→Cont., Stop→Violou)
- **Click-to-filter** — clicar no período no cycle card filtra tabela e summary
- **Eventos inline na tabela** — coluna Evento mostra state machine (META!/STOP! com sublabel Período/Ciclo) + compliance (S/Stop, RO, RR) + emocional (TILT, REVENGE, CRÍTICO)
- **Resumo expandido no PlanManagementModal** — etapa 3 mostra Meta/Stop Período e Ciclo ($ + %), RO ($ + %), RR
- **Edição de plano na AccountsPage** — mentor edita plano direto do accordion de contas (⚙️ Settings icon)
- **Seed de teste** — script `seedTestExtract.js` cria aluno fictício com 10 planos cobrindo todos os cenários de badge
- **Label crítico** — banner vermelho no cycle card quando stop do ciclo atingido/violado

### Correções
- **Badge "Recuperação" → "Violação (Recuperou)"** — POST_STOP com P&L positivo é violação, não recuperação
- **Hotfix `lastEditedByEmail: undefined`** — AccountsPage agora passa `email: user?.email` no audit info
- **ExtractEvents removido** — painel redundante, eventos agora inline na tabela

### Arquivos

| Arquivo | Ação |
|---------|------|
| `src/version.js` | Bump → v1.17.0 |
| `src/utils/planStateMachine.js` | +`getAvailableCycles()`, fix badge LOSS_TO_GOAL |
| `src/utils/seedTestExtract.js` | **NOVO** — seed + cleanup com Auth |
| `src/components/GaugeChart.jsx` | **Reescrito** — react-d3-speedometer |
| `src/components/PlanLedgerExtract.jsx` | v4 — cycle nav, sidebar, sem ExtractEvents |
| `src/components/PlanManagementModal.jsx` | Resumo expandido na etapa 3 |
| `src/components/StudentAccountGroup.jsx` | +prop onEditPlan, +botão ⚙️ |
| `src/components/extract/ExtractPeriodSelector.jsx` | v2 — dropdown + cycle nav |
| `src/components/extract/ExtractCycleCard.jsx` | **NOVO** — gauge + breakdown |
| `src/components/extract/ExtractSummary.jsx` | Intocado |
| `src/components/extract/ExtractTable.jsx` | v2 — eventos inline, cycleEvent |
| `src/pages/SettingsPage.jsx` | +botões seed/cleanup teste |
| `src/pages/AccountsPage.jsx` | +PlanManagementModal, hotfix audit |
| `src/__tests__/utils/planStateMachine.test.js` | +8 testes |

### Dependência nova
```
npm install react-d3-speedometer
```

### Testes
- 188+ testes passando (Vitest)
- +8 testes: `getAvailableCycles` (5), `targetCycle navigation` (1), badge fix (2)

### Como testar
1. SettingsPage → Admin → "Criar Dados de Teste"
2. Recarregar página (sessão Auth muda)
3. View As → "Aluno Teste Extrato"
4. Abrir extrato de cada plano (10 cenários)
5. Navegar entre ciclos no plano "Multi-Ciclo"
6. Verificar badges, eventos inline, gauge
7. Testar edição de plano via accordion na AccountsPage
8. SettingsPage → Admin → "Limpar Dados de Teste"

Closes #53 (Phase 2)
Closes #35 
Bumps version to v1.17.0
