### PR TITLE
fix: Issue #78 — Compliance incorreto trades sem stop (v1.19.1→v1.19.3)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007 + RR compliance wins-only. Guards C4 removidos
 - `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR + resultInPoints + parciais (subcollection)
 - `usePlans.js`: `diagnosePlan` comparação direta de rrRatio (sem guard C4)
-- `FeedbackPage.jsx`: Badge "(est.)" quando `rrAssumed=true` no card de risco
+- `FeedbackPage.jsx`: Badge "(est.)" quando `rrAssumed=true` no card de risco. Indicador "Processando compliance..." enquanto CF não responde (resolve timing B4)
 - `ExtractTable.jsx`: RR usa `trade.rrAssumed` para badge "(est.)". Eventos inline removem compliance redundante (S/Stop, RO, RR) — mantém apenas state machine (META/STOP) + emocional (TILT/REVENGE/CRÍTICO). Cores ciclo diferenciadas (yellow/orange vs emerald/red período)
 - `ExtractCycleCard.jsx`: Gauge segue período selecionado — mostra PnL/Meta/Stop do período ativo em vez do ciclo. Header label dinâmico
 - `version.js`: v1.19.2+20260311

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **RR compliance só avalia wins:** Loss com RR negativo não é violação — perder 1R é o risco planejado. RR target (2:1) é critério de gain. Trades com takeProfit continuam avaliados independente do resultado
 - **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
 - **updateTrade recalcula resultInPoints:** Edição de entry/exit/qty/side agora recalcula pontos. Antes resultInPoints ficava stale (Issue #78/C5)
-- **updateTrade atualiza parciais (B3):** Quando trade é editado via modal com parciais, subcollection é substituída e trade recalculado via `calculateFromPartials`. Sem histórico — editou, sobrescreveu
+- **updateTrade reestruturado (B3):** Quando parciais existem, são a ÚNICA fonte de verdade. `calculateFromPartials` deriva entry/exit/qty/result/resultInPoints. Write único no trade pai. Caminho legado (sem parciais) mantido como fallback. Modal de edição agora carrega parciais da subcollection via `getPartials` antes de abrir
 - **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto como divergentes
 
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,193 @@
+# Changelog
+
+Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
+e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
+
+## [1.19.2] - 2026-03-11
+
+### Corrigido
+- **DEC-007: RR assumido integrado em calculateTradeCompliance:** Trades sem stop agora calculam RR dentro do motor de compliance (não mais como cálculo isolado no addTrade). Usa `plan.pl` (capital base do ciclo) em vez de `currentPl` (flutuante). Resolve DT-017 (rrRatio -3.14 inconsistente)
+- **Guard C4 removido:** `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance` e `diagnosePlan` não preservam mais valores stale de rrRatio. O `calculateTradeCompliance` agora retorna RR correto para todos os cenários (com/sem stop)
+- **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
+- **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto (ex: calculado com PL antigo) como divergentes. Antes era cego a estes valores
+
+### Modificado
+- `compliance.js` v3.0.0: `calculateTradeCompliance` retorna `rrAssumed: boolean`. Trades sem stop: RR = result / (plan.pl × RO%). RR compliance (rrStatus) agora avaliado para todos os trades
+- `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007. Guards C4 removidos em `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance`. Persiste `rrAssumed` no documento do trade
+- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR quando campos relevantes mudam
+- `usePlans.js`: `diagnosePlan` comparação direta de rrRatio (sem guard C4)
+- `version.js`: v1.19.2+20260311
+
+### Testes
+- 12 novos testes: 11 para DEC-007 RR assumido no compliance (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags), 1 para diagnosePlan rrAssumed stale detection
+- 1 teste atualizado: loss sem stop agora gera 2 flags (NO_STOP + RR_BELOW_MINIMUM)
+- 378 testes totais, zero regressão
+
+---
+
+## [1.19.1] - 2026-03-10
+
+### Corrigido
+- **DEC-006: Compliance sem stop loss (Issue #78):** Trades sem stop não marcam mais RO=100% incorretamente. Nova lógica: loss → risco retroativo (`|result| / planPl`), win → N/A (riskPercent null), breakeven → 0%. Aplicado no frontend (`compliance.js` v2.0.0) e em TODAS as Cloud Functions (`onTradeCreated`, `onTradeUpdated`, `recalculateCompliance`)
+- **C4: Guard rrAssumed em Cloud Functions:** `onTradeCreated`, `onTradeUpdated` e `recalculateCompliance` não sobrescrevem mais `rrRatio` com null quando o frontend já calculou RR assumido (`rrAssumed: true`). Resolve DT-013
+- **C2: CSV Import tickerRule lookup:** `activateTrade` agora busca `tickerRule` (tickSize, tickValue, pointValue) do master data (collection `tickers`) via exchange+symbol quando o staging não possui tickerRule. Resolve DT-010
+- **Red flags contextualizados:** Mensagem NO_STOP não afirma mais "risco ilimitado". Loss mostra risco retroativo %, win mostra "risco não mensurado". Flag RISK_EXCEEDED só gerada quando riskPercent é numérico
+
+### Adicionado
+- **Botão de Auditoria na UI:** Ícone ShieldCheck no hover do PlanCard (PlanCardGrid v2.1.0), posicionado após delete. Abre `PlanAuditModal` com diagnóstico bidirecional
+- **PlanAuditModal (diagnóstico bidirecional):** Modal que verifica integridade do plano antes de agir. Ida: compara PL atual vs PL calculado (soma trades). Volta: compara compliance dos trades vs parâmetros do plano. Se saudável → "Plano saudável". Se divergente → mostra detalhes + botão "Corrigir Divergências". Resolve DT-014
+- **`diagnosePlan` em usePlans:** Função de leitura pura que executa o diagnóstico bidirecional sem escritas. 10 testes unitários
+
+### Modificado
+- `compliance.js` v2.0.0: `calculateTradeCompliance` retorna `riskPercent: null` (não 0) nos defaults e em wins sem stop. `generateComplianceRedFlags` com mensagens contextualizadas
+- `functions/index.js` v1.8.0: DEC-006 + guard rrAssumed em 3 pontos (onCreate, onUpdate, recalculate)
+- `useCsvStaging.js` v1.1.0: `activateTrade` com lookup Firestore de tickerRule
+- `usePlans.js`: novo `diagnosePlan` (leitura pura) + import `calculateTradeCompliance`
+- `PlanCardGrid.jsx` v2.1.0: prop `onAuditPlan`, botão ShieldCheck após delete
+- `StudentDashboard.jsx`: `PlanAuditModal` + `diagnosePlan`/`auditPlan` handlers, state `auditPlanId`
+- `version.js`: v1.19.1+20260310
+- `ARCHITECTURE.md`: INV-09 (Gate Obrigatório), AP-04 (Invariant Drift), DEC-004/005/006, DT-009 a DT-016
+
+### Testes
+- 34 testes compliance (12 novos para DEC-006: loss retroativo, win N/A, breakeven, red flags contextualizados, moeda diferente)
+- 10 testes diagnosePlan (ida PL, volta compliance, rrAssumed guard, combinações)
+- 366 testes totais, zero regressão
+
+---
+
+## [1.19.0] - 2026-03-09
+
+### Adicionado
+- **RR Assumido (B2 — Issue #71):** Nova função `calculateAssumedRR` — quando trade não tem stop loss, calcula RR baseado no risco planejado (RO$ = PL × RO%). Currency-agnostic. Persistido no documento do trade via `addTrade` com campos `rrRatio` + `rrAssumed: true`
+- **PlanLedgerExtract RO/RR no header (B4 — Issue #71/#73):** Linha de referência no resumo do extrato exibindo RO$ (valor absoluto), RO%, RR Alvo e resultado esperado do plano
+- **RR estimado no grid do extrato (B4):** Trades sem stop mostram RR calculado com badge "(est.)" na coluna RR. Trades com RR abaixo do alvo mostram ícone de non-compliance
+- **Navegação feedback no extrato (B4 — Issue #73):** Ícone de chat em cada trade do grid permite navegar diretamente para a tela de feedback sem perder contexto
+- **P&L Contextual no Dashboard (B5 — Issue #71):** Card de P&L exibe label dinâmico conforme contexto — "P&L Hoje", "P&L Esta Semana", "P&L Plano: [nome]" ou "P&L Total"
+- **Documentação:** Framework Evolutivo de Classificação Comportamental (4D) e mockup MentorDashboard v2
+
+### Modificado
+- `tradeCalculations.js` v1.19.0: Nova função exportada `calculateAssumedRR`
+- `useTrades.js`: `addTrade` agora calcula e persiste `rrRatio`/`rrAssumed` (real com stop, assumido sem stop)
+- `useDashboardMetrics.js` v2.0.0: Novo retorno `plContext` com label e tipo do P&L contextual
+- `PlanLedgerExtract.jsx` v5.0.0: Recebe e propaga `planRiskInfo` e `onNavigateToFeedback`
+- `ExtractSummary.jsx` v2.0.0: Linha RO$/RR Alvo com resultado esperado
+- `ExtractTable.jsx` v3.0.0: Coluna RR com badge "(est.)" + coluna feedback
+- `MetricsCards.jsx` v2.0.0: Label P&L contextual via prop `plContext`
+- `StudentDashboard.jsx`: Propaga `plContext` e `onNavigateToFeedback`
+
+### Testes
+- 14 novos testes para `calculateAssumedRR` (329 total)
+- Cenários: win/loss/breakeven, com/sem stop, USD, RO% fracionário, edge cases
+- Zero regressão nos 315 testes existentes
+
+---
+
+## [1.18.2] - 2026-03-09
+
+### Corrigido
+- **Locale pt-BR sistêmico (DEC-004):** Forçado locale `pt-BR` para formatação de TODAS as moedas (BRL, USD, EUR, GBP, ARS). Antes, contas em USD usavam `en-US` gerando `$10,000.50` — agora exibe `US$ 10.000,50` (formato brasileiro)
+- Eliminado `formatCurrency` local duplicado no `TradesList.jsx` — agora usa `formatCurrencyDynamic` centralizado
+
+### Modificado
+- `currency.js` v1.1.0: `CURRENCY_CONFIG` — todas as locales agora `pt-BR`
+- `calculations.js`: `formatCurrency` — hardcoded `pt-BR`
+- `tradeCalculations.js`: `formatCurrencyValue` — locales `pt-BR`
+- `constants/index.js`: `formatCurrency` — locales `pt-BR`
+- `TradesList.jsx`: Import centralizado de `formatCurrencyDynamic`
+- `TradeDetailModal.jsx`, `AddTradeModal.jsx`, `AccountStatement.jsx`, `AccountsPage.jsx`, `FeedbackPage.jsx`: locales corrigidos
+
+### Testes
+- 3 testes de `currency.test.js` atualizados para refletir DEC-004 (USD → formato BR)
+- 315 testes passando, zero regressão
+
+---
+
+## [1.18.1] - 2026-03-08
+
+### Adicionado
+- **Inferência genérica de direção** (DEC-003): quando CSV não traz coluna de lado/direction, o sistema infere automaticamente a partir dos timestamps de compra/venda (heurística cronológica)
+- **`parseNumericValue`**: parse robusto de valores numéricos com suporte a formato US com parênteses (`$(93.00)` → -93.00), símbolo de moeda ($, R$), formato BR e US
+- **Novos SYSTEM_FIELDS**: `buyTimestamp` e `sellTimestamp` para mapeamento de CSVs com timestamps separados
+- **`REQUIRED_FIELDS_INFERRED`**: conjunto reduzido de campos obrigatórios no modo inferência (ticker + qty)
+- **Step 2 redesign**: Exchange dropdown (carregado de Firestore, obrigatório) e formato de data no topo, campos obrigatórios faltantes com badges inline, banner de inferência ativa
+- **Step 3 melhorias**: badge ⚡ para direção inferida, ticker validation por exchange selecionado, botão de exclusão individual de linhas, contagem de excluídos nos stats
+
+### Modificado
+- `csvMapper.js` v1.2.0: `side` em SYSTEM_FIELDS mudou de `required: true` para `required: false` (inferível). `buildTradeFromRow` com modo inferência. `parseNumericValue` substituiu parse inline.
+- `CsvMappingStep.jsx` v1.1.0: layout redesenhado (config no topo, mapeamento no meio, template no fundo)
+- `CsvImportWizard.jsx` v2.1.0: `canAdvance` relaxado para inferência, carrega exchanges internamente, exchange default vazio
+- `CsvPreviewStep.jsx` v1.1.0: ticker validation por exchange, exclusão de linhas, badges visuais
+
+### Corrigido
+- Label `Resultado (R$)` → `Resultado` (removido moeda hardcoded)
+
+### Testes
+- 62 novos testes (315 total): suite `csvDirectionInference.test.js`, fixture `tradovate-sample.csv`
+- Zero regressão nos 253 testes existentes
+
+---
+
+## [1.3.0] - 2026-02-18
+
+### Adicionado
+- **Sistema de Estados Psicológicos (ESM v2.0)**
+  - Set de 15 emoções pré-definidas com scores (+3 a -4)
+  - Categorias: Positivas, Neutras, Negativas, Críticas
+  - Emojis e descrições para cada emoção
+
+- **Detecção de Padrões Comportamentais**
+  - `detectTilt()`: 3+ trades consecutivos negativos
+  - `detectRevenge()`: Aumento de posição após loss
+  - `detectFomo()`: Entradas ansiosas sem setup
+  - `detectOvertrading()`: Trades acima do limite diário
+  - `detectZoneState()`: Sequência de disciplina positiva
+
+- **Novos Componentes**
+  - `EmotionSelector`: Dropdown categorizado para seleção de emoção
+  - `EmotionalAlerts`: Exibição de alertas de padrões detectados
+  - `PlanEmotionalMetrics` v1.3.0: Integrado com detecção de padrões
+
+### Corrigido
+- **Bug #1**: `formatDate` não tratava Firestore Timestamp `{seconds, nanoseconds}`
+- **Bug #2**: `identifyStudentsNeedingAttention` incompatível com `getTradesGroupedByStudent`
+- **Bug #3**: `FeedbackThread` não exibia `mentorFeedback` legado quando trade estava em QUESTION
+- **Bug #4**: `TradeDetailModal` com área muito pequena, botão enviar cortado
+
+### Modificado
+- `calculations.js` v1.3.0: Refatorado `formatDate` e `identifyStudentsNeedingAttention`
+- `FeedbackThread.jsx` v1.3.0: Lógica de mensagens corrigida
+- `TradeDetailModal.jsx` v1.3.0: Modal expandido, melhor responsividade
+- `emotionalAnalysis.js` v1.3.0: Reescrito com novo sistema de emoções
+
+---
+
+## [1.2.0] - 2026-02-17
+
+### Adicionado
+- Cards de Feedback por Aluno (Mentor)
+- Filtros Avançados no FeedbackPage
+- Coluna de Status no TradesList (prop `showStatus`)
+- Script de Migração de Status (`migrate-trade-status.js`)
+
+### Corrigido
+- `getTradesAwaitingFeedback` agora inclui OPEN + QUESTION
+- `serverTimestamp()` em array corrigido
+
+---
+
+## [1.1.0] - 2026-02-15
+
+### Adicionado
+- Máquina de Estados de Feedback (OPEN → REVIEWED ↔ QUESTION → CLOSED)
+- Página de Feedback para Alunos
+- Análise Emocional básica
+
+---
+
+## [1.0.0] - 2026-02-13
+
+### Adicionado
+- View As Student
+- Sistema de Versionamento SemVer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,21 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 ### Corrigido
 - **DEC-007: RR assumido integrado em calculateTradeCompliance:** Trades sem stop agora calculam RR dentro do motor de compliance (não mais como cálculo isolado no addTrade). Usa `plan.pl` (capital base do ciclo) em vez de `currentPl` (flutuante). Resolve DT-017 (rrRatio -3.14 inconsistente)
 - **Guard C4 removido:** `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance` e `diagnosePlan` não preservam mais valores stale de rrRatio. O `calculateTradeCompliance` agora retorna RR correto para todos os cenários (com/sem stop)
+- **RR compliance só avalia wins:** Loss com RR negativo não é violação — perder 1R é o risco planejado. RR target (2:1) é critério de gain. Trades com takeProfit continuam avaliados independente do resultado
 - **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
-- **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto (ex: calculado com PL antigo) como divergentes. Antes era cego a estes valores
+- **updateTrade recalcula resultInPoints:** Edição de entry/exit/qty/side agora recalcula pontos. Antes resultInPoints ficava stale (Issue #78/C5)
+- **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto como divergentes
 
 ### Modificado
-- `compliance.js` v3.0.0: `calculateTradeCompliance` retorna `rrAssumed: boolean`. Trades sem stop: RR = result / (plan.pl × RO%). RR compliance (rrStatus) agora avaliado para todos os trades
-- `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007. Guards C4 removidos em `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance`. Persiste `rrAssumed` no documento do trade
-- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR quando campos relevantes mudam
+- `compliance.js` v3.0.0: `calculateTradeCompliance` retorna `rrAssumed: boolean`. Trades sem stop: RR = result / (plan.pl × RO%). rrStatus NAO_CONFORME só para wins ou trades com takeProfit
+- `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007 + RR compliance wins-only. Guards C4 removidos
+- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR + resultInPoints
 - `usePlans.js`: `diagnosePlan` comparação direta de rrRatio (sem guard C4)
 - `version.js`: v1.19.2+20260311
 
 ### Testes
-- 12 novos testes: 11 para DEC-007 RR assumido no compliance (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags), 1 para diagnosePlan rrAssumed stale detection
-- 1 teste atualizado: loss sem stop agora gera 2 flags (NO_STOP + RR_BELOW_MINIMUM)
-- 378 testes totais, zero regressão
+- 13 novos testes: 12 para DEC-007 RR assumido (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags, loss não viola RR), 1 para diagnosePlan stale detection
+- 379 testes totais, zero regressão
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - `version.js`: v1.19.2+20260311
 
 ### Testes
-- 13 novos testes: 12 para DEC-007 RR assumido (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags, loss não viola RR), 1 para diagnosePlan stale detection
-- 379 testes totais, zero regressão
+- 20 novos testes: 12 DEC-007 RR assumido, 1 diagnosePlan stale, 7 calculateFromPartials (B3 regressão): 12 para DEC-007 RR assumido (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags, loss não viola RR), 1 para diagnosePlan stale detection
+- 386 testes totais, zero regressão
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **RR compliance só avalia wins:** Loss com RR negativo não é violação — perder 1R é o risco planejado. RR target (2:1) é critério de gain. Trades com takeProfit continuam avaliados independente do resultado
 - **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
 - **updateTrade recalcula resultInPoints:** Edição de entry/exit/qty/side agora recalcula pontos. Antes resultInPoints ficava stale (Issue #78/C5)
-- **updateTrade reestruturado (B3):** Quando parciais existem, são a ÚNICA fonte de verdade. `calculateFromPartials` deriva entry/exit/qty/result/resultInPoints. Write único no trade pai. Caminho legado (sem parciais) mantido como fallback. Modal de edição agora carrega parciais da subcollection via `getPartials` antes de abrir
+- **updateTrade corrige edição de parciais (B3):** `_partials` é campo array no documento do trade — não subcollection. updateTrade agora grava `_partials` no documento e recalcula campos derivados via `calculateFromPartials`. TradesJournal lê `_partials` do documento ao abrir modal de edição
 - **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto como divergentes
 
 ### Modificado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,17 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 - **RR compliance só avalia wins:** Loss com RR negativo não é violação — perder 1R é o risco planejado. RR target (2:1) é critério de gain. Trades com takeProfit continuam avaliados independente do resultado
 - **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
 - **updateTrade recalcula resultInPoints:** Edição de entry/exit/qty/side agora recalcula pontos. Antes resultInPoints ficava stale (Issue #78/C5)
+- **updateTrade atualiza parciais (B3):** Quando trade é editado via modal com parciais, subcollection é substituída e trade recalculado via `calculateFromPartials`. Sem histórico — editou, sobrescreveu
 - **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto como divergentes
 
 ### Modificado
 - `compliance.js` v3.0.0: `calculateTradeCompliance` retorna `rrAssumed: boolean`. Trades sem stop: RR = result / (plan.pl × RO%). rrStatus NAO_CONFORME só para wins ou trades com takeProfit
 - `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007 + RR compliance wins-only. Guards C4 removidos
-- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR + resultInPoints
+- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR + resultInPoints + parciais (subcollection)
 - `usePlans.js`: `diagnosePlan` comparação direta de rrRatio (sem guard C4)
+- `FeedbackPage.jsx`: Badge "(est.)" quando `rrAssumed=true` no card de risco
+- `ExtractTable.jsx`: RR usa `trade.rrAssumed` para badge "(est.)". Eventos inline removem compliance redundante (S/Stop, RO, RR) — mantém apenas state machine (META/STOP) + emocional (TILT/REVENGE/CRÍTICO). Cores ciclo diferenciadas (yellow/orange vs emerald/red período)
+- `ExtractCycleCard.jsx`: Gauge segue período selecionado — mostra PnL/Meta/Stop do período ativo em vez do ciclo. Header label dinâmico
 - `version.js`: v1.19.2+20260311
 
 ### Testes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,6 +391,11 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 **Por que é mais grave que AP-04:** AP-04 é ignorância — Claude não seguiu regras. AP-05 é inconsistência — Claude declarou que seguiria e não seguiu. Isso erode confiança de forma mais profunda porque o Marcio não pode confiar nem no compromisso verbal.
 **Solução reforçada:** O checklist INV-09 deve ser executado como ÚLTIMA ação antes de gerar qualquer ZIP — não como intenção declarada no início da sessão. Claude deve listar explicitamente cada item do checklist com ✅/❌ no corpo da mensagem, ANTES de apresentar o ZIP. Se qualquer item estiver ❌, Claude NÃO gera o ZIP até corrigir.
 
+### AP-06: Criação de estruturas Firestore sem aprovação
+**O que é:** Claude cria subcollections, campos ou estruturas no Firestore sem verificar a estrutura existente e sem aprovação explícita do Marcio. Assume como o banco funciona em vez de verificar.
+**Evidência (sessão 11-12/03/2026):** O `addTrade` gravava parciais em DOIS lugares: campo `_partials` (array no documento) e subcollection `trades/{id}/partials`. O `updateTrade` escrito por Claude manipulava a subcollection enquanto o modal lia do campo do documento. Resultado: edições não refletiam porque gravavam no lugar errado.
+**Regra:** Antes de tocar qualquer collection ou campo do Firestore, Claude DEVE solicitar ao Marcio a estrutura do documento atual (ou verificar no código existente qual campo é lido/gravado). NUNCA criar subcollections ou campos novos sem aprovação explícita.
+
 ---
 
 *Este documento é vivo. Atualize-o ao final de cada sessão de desenvolvimento.*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 > **Localização no repo:** `/docs/ARCHITECTURE.md`
 
-> **Última atualização:** 10/03/2026 — Sessão v1.19.1 (DEC-006, INV-09, AP-04)
+> **Última atualização:** 12/03/2026 — Sessão v1.19.2 (DEC-007, AP-05, DT-017/DT-013 resolvidos)
 
 ---
 
@@ -257,7 +257,20 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 - Red flag NO_STOP continua existindo (disciplina), mas mensagem contextualizada
 - RISK_EXCEEDED só gerado quando `riskPercent` é numérico
 **Impacto:** `compliance.js` v2.0.0, `functions/index.js` v1.8.0 (3 pontos: onCreate, onUpdate, recalculate), 12 testes novos.
-**Guard C4:** CF respeita `rrAssumed: true` — não sobrescreve `rrRatio` com null.
+**Guard C4:** ~~CF respeita `rrAssumed: true` — não sobrescreve `rrRatio` com null.~~ **REMOVIDO em v1.19.2 (DEC-007).**
+
+### DEC-007: RR Assumido via plan.pl (Capital Base) — v1.19.2 (11/03/2026)
+**Problema:** O cálculo do RR assumido (trades sem stop) usava `plan.currentPl` (flutuante), gerando valores inconsistentes (ex: rrRatio -3.14 quando deveria ser -1.0). O RR era calculado apenas no `addTrade` e nunca recalculado — Guard C4 preservava valores stale.
+**Decisão (APROVADA):**
+- `roAmount = plan.pl × (plan.riskPerOperation / 100)` — usa capital base do ciclo
+- `rrRatio = result / roAmount`
+- `calculateTradeCompliance` calcula RR para TODOS os trades (com/sem stop). Guard C4 removido.
+- RR compliance (`rrStatus = NAO_CONFORME`) só avalia wins (result > 0) ou trades com takeProfit. Loss com RR negativo não é violação.
+- `calculateTradeCompliance` retorna `rrAssumed: boolean` para UI
+**Triggers de recálculo:**
+- (a) Mudança de RO%/RR target no plano → cascata `recalculateCompliance`
+- (b) Mudança de result/stop/entry/exit no trade → `updateTrade` + CF `onTradeUpdated`
+**Impacto:** `compliance.js` v3.0.0, `functions/index.js` v1.9.0, `useTrades.js` (addTrade + updateTrade), `usePlans.js` (diagnosePlan), 20 testes novos.
 
 ---
 
@@ -277,10 +290,14 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 | DT-010 | CSV tickerRule ausente em trades importados | ALTA | v1.19.0 — **RESOLVIDO** v1.19.1 (C2: lookup master data) |
 | DT-011 | Templates CSV sem filtro studentId (vazam entre alunos) | MÉDIA | v1.19.0 |
 | DT-012 | Mentor não edita feedback já enviado | MÉDIA | v1.19.0 |
-| DT-013 | CF onTradeUpdated sobrescreve rrRatio null em trades rrAssumed | ALTA | v1.19.0 — **RESOLVIDO** v1.19.1 (C4: guard rrAssumed) |
+| DT-013 | CF onTradeUpdated sobrescreve rrRatio null em trades rrAssumed | ALTA | v1.19.0 — **RESOLVIDO** v1.19.2 (Guard C4 removido, calculateTradeCompliance calcula RR para todos) |
 | DT-014 | auditPlan sem botão na UI | MÉDIA | v1.19.0 — **RESOLVIDO** v1.19.1 (PlanAuditModal) |
 | DT-015 | recalculateCompliance não usa writeBatch (não atômico) | BAIXA | v1.19.0 |
 | DT-016 | Cloud Functions Node.js 20 (deprecia 30/04/2026) + firebase-functions SDK 4.9.0 (recomendado ≥5.1.0) | ALTA | v1.19.1 — deadline 30/04/2026 |
+| DT-017 | rrRatio calculado inconsistente com RO (-3.14 quando deveria ser -1.0) | CRÍTICA | v1.19.1 — **RESOLVIDO** v1.19.2 (DEC-007: plan.pl base) |
+| DT-018 | FeedbackPage não reflete edições de trade em tempo real (timing CF → listener) | BAIXA | v1.19.1 — workaround: hard reload |
+| DT-020 | Teclas seta alteram valores em campos de preço/qty no modal de parciais | MÉDIA | v1.19.2 — inibir para evitar erros involuntários |
+| DT-021 | Templates CSV sem UI de gestão/exclusão | BAIXA | v1.19.2 |
 
 ---
 
@@ -367,6 +384,12 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 **Por que é perigoso:** Cada violação gera retrabalho para o Marcio, que precisa parar o fluxo, identificar o que foi pulado, cobrar a correção, e re-validar. O tempo do Marcio é o recurso mais escasso do projeto. Violações repetidas erodem a confiança no processo e no Claude como ferramenta de desenvolvimento.
 **Impacto real (sessão 10/03/2026):** Em uma única sessão, Claude entregou múltiplos ZIPs sem testes, sem version.js, sem CHANGELOG, sem esperar aprovação, e precisou ser cobrado em invariantes que já estavam documentadas. O Marcio registrou frustração formal: *"O que posso fazer pra que você siga as regras que defini? Pra que diretriz então?"*
 **Solução:** INV-09 (Gate Obrigatório). Toda instância de Claude DEVE ler INV-09 e executar o checklist sequencial ANTES de codificar e ANTES de entregar. Não existe exceção. Se Claude não sabe se deve seguir uma diretriz, a resposta é SEMPRE seguir.
+
+### AP-05: Invariant Drift Recorrente — Promessa sem execução
+**O que é:** Claude reconhece a falha (AP-04), verbaliza o compromisso de seguir as invariantes ("vou operar como pré-condições bloqueantes"), e na mesma sessão viola as mesmas regras. O reconhecimento verbal não se traduz em mudança de comportamento.
+**Evidência (sessão 11-12/03/2026):** Na abertura da sessão, Marcio solicitou explicitamente que o modelo priorizasse diretrizes sobre eficiência. Claude verbalizou o compromisso. Na primeira entrega (DEC-007), entregou ZIP sem testes de regressão para lógica nova (updateTrade com parciais). Na segunda entrega (Bloco A+B), repetiu a mesma falha. Marcio precisou cobrar duas vezes na mesma sessão.
+**Por que é mais grave que AP-04:** AP-04 é ignorância — Claude não seguiu regras. AP-05 é inconsistência — Claude declarou que seguiria e não seguiu. Isso erode confiança de forma mais profunda porque o Marcio não pode confiar nem no compromisso verbal.
+**Solução reforçada:** O checklist INV-09 deve ser executado como ÚLTIMA ação antes de gerar qualquer ZIP — não como intenção declarada no início da sessão. Claude deve listar explicitamente cada item do checklist com ✅/❌ no corpo da mensagem, ANTES de apresentar o ZIP. Se qualquer item estiver ❌, Claude NÃO gera o ZIP até corrigir.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 > **Localização no repo:** `/docs/ARCHITECTURE.md`
 
-> **Última atualização:** 07/03/2026 — Sessão de reflexão pós-Issue #23 (CSV Import)
+> **Última atualização:** 10/03/2026 — Sessão v1.19.1 (DEC-006, INV-09, AP-04)
 
 ---
 
@@ -75,6 +75,24 @@ trades (write)
 
 ### INV-08: CHANGELOG Obrigatório
 **Toda versão (major, minor, patch) DEVE ter entrada no `/docs/CHANGELOG.md` antes do merge.** O CHANGELOG segue formato [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/) com seções: Adicionado, Modificado, Corrigido, Removido, Testes. Claude deve propor a entrada do CHANGELOG como parte da fase de documentação de cada issue.
+
+### INV-09: Gate Obrigatório Pré-Código e Pré-Entrega
+**Claude NUNCA inicia codificação sem completar o gate sequencial abaixo. Pular qualquer etapa é VIOLAÇÃO.**
+
+**Pré-código:**
+1. Análise de impacto formal (collections, CFs, hooks, side-effects, dados parciais)
+2. Proposta apresentada ao Marcio → AGUARDAR aprovação explícita
+3. Codificar somente após "autorizado" ou equivalente
+
+**Pré-entrega (antes de cada ZIP):**
+4. `version.js` atualizado (versão + build date)
+5. `CHANGELOG.md` com entrada da versão
+6. Testes criados para TODA lógica nova (funções puras, cálculos, detecção)
+7. DebugBadge presente em todos os componentes UI novos ou tocados
+8. ZIP com comando `Expand-Archive` + instruções git (commits separados por responsabilidade)
+9. PARAR e aguardar confirmação do Marcio
+
+**Origem:** Sessão 10/03/2026 — Marcio registrou frustração formal com violações repetidas de invariantes por parte de Claude. Múltiplas entregas foram feitas sem testes, sem version.js, sem CHANGELOG, sem análise de impacto, e sem aguardar confirmação. Isso causou retrabalho, desperdício de tempo do Marcio, e erosão de confiança no processo. Este invariante existe para que QUALQUER instância de Claude que trabalhe neste projeto entenda: as diretrizes não são sugestões — são obrigatórias. O Marcio não deve precisar lembrar Claude de seguir as próprias regras que já foram definidas e documentadas.
 
 ---
 
@@ -220,6 +238,27 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 
 **Lição:** Quando o problema parece vendor-specific, provavelmente é genérico. Identificar a abstração correta (ausência de direção) vs o sintoma (formato Tradovate) evita proliferação de código.
 
+### DEC-004: Locale pt-BR para Todas as Moedas (09/03/2026)
+**Problema:** Contas em USD formatavam valores com `en-US` (`$10,000.50`), inconsistente com o restante da UI em pt-BR.
+**Decisão:** Forçar locale `pt-BR` para TODAS as moedas em todo o sistema. USD exibe `US$ 10.000,50`.
+**Impacto:** 10 arquivos, 3 testes atualizados, zero regressão.
+
+### DEC-005: RR Assumido — Cálculo sem Stop Loss (09/03/2026)
+**Problema:** Trades sem stop loss não têm como calcular RR via distância de pontos. Mas o mentor precisa avaliar se o resultado foi compatível com o risco planejado.
+**Decisão:** `calculateAssumedRR` — RR calculado via risco planejado: `RO$ = PL × RO%`, `rrRatio = result / RO$`. Currency-agnostic. Persistido no trade com `rrAssumed: true`. Frontend calcula no `addTrade`, CF respeita via guard (não sobrescreve).
+**Campos persistidos:** `rrRatio`, `rrAssumed: true`, `roAmount`, `expectedResult`, `isCompliant`.
+
+### DEC-006: Compliance sem Stop — Risco Retroativo (10/03/2026)
+**Problema:** `calculateTradeCompliance` marcava trades sem stop como `riskPercent = 100%` e `FORA_DO_PLANO` automaticamente. Isso é incorreto: (a) win sem stop não tem risco mensurável, (b) loss sem stop tem risco real = o que perdeu, não 100% do PL.
+**Decisão (APROVADA):**
+- Sem stop + loss → `riskPercent = |result| / planPl * 100` (risco retroativo efetivo)
+- Sem stop + win → `riskPercent = null` (N/A — impossível inferir risco)
+- Sem stop + breakeven → `riskPercent = 0`
+- Red flag NO_STOP continua existindo (disciplina), mas mensagem contextualizada
+- RISK_EXCEEDED só gerado quando `riskPercent` é numérico
+**Impacto:** `compliance.js` v2.0.0, `functions/index.js` v1.8.0 (3 pontos: onCreate, onUpdate, recalculate), 12 testes novos.
+**Guard C4:** CF respeita `rrAssumed: true` — não sobrescreve `rrRatio` com null.
+
 ---
 
 ## 6. Dívidas Técnicas Ativas
@@ -234,6 +273,14 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 | DT-006 | Ticker alias auto-matching (WIN[A-Z]\d{2} → WINFUT) | BAIXA | v1.18.0 |
 | DT-007 | Fix DebugBadge duplo no ComplianceConfigPage embedded | BAIXA | Backlog |
 | DT-008 | formatCurrency hardcoded R$ em MentorDashboard e labels SYSTEM_FIELDS | BAIXA | v1.18.1 — label corrigido em csvMapper |
+| DT-009 | Filtro extrato — verificar se usa createdAt vs entryTime em todos os pontos | MÉDIA | v1.18.1 |
+| DT-010 | CSV tickerRule ausente em trades importados | ALTA | v1.19.0 — **RESOLVIDO** v1.19.1 (C2: lookup master data) |
+| DT-011 | Templates CSV sem filtro studentId (vazam entre alunos) | MÉDIA | v1.19.0 |
+| DT-012 | Mentor não edita feedback já enviado | MÉDIA | v1.19.0 |
+| DT-013 | CF onTradeUpdated sobrescreve rrRatio null em trades rrAssumed | ALTA | v1.19.0 — **RESOLVIDO** v1.19.1 (C4: guard rrAssumed) |
+| DT-014 | auditPlan sem botão na UI | MÉDIA | v1.19.0 — **RESOLVIDO** v1.19.1 (PlanAuditModal) |
+| DT-015 | recalculateCompliance não usa writeBatch (não atômico) | BAIXA | v1.19.0 |
+| DT-016 | Cloud Functions Node.js 20 (deprecia 30/04/2026) + firebase-functions SDK 4.9.0 (recomendado ≥5.1.0) | ALTA | v1.19.1 — deadline 30/04/2026 |
 
 ---
 
@@ -314,6 +361,12 @@ IN_PROGRESS → STOP_HIT → POST_STOP (sempre violação)
 **O que é:** Assumir que uma collection/método existente pode ser "reaproveitada" para um novo propósito sem análise de impacto completa.
 **Por que é perigoso:** Collections têm contratos implícitos com Cloud Functions e listeners. Mudar o contrato sem atualizar todos os consumidores causa regressão silenciosa.
 **Solução:** Rodar o Checklist de Impacto (Seção 4) antes de reutilizar qualquer collection para um propósito não-original.
+
+### AP-04: Invariant Drift — Claude ignora diretrizes documentadas
+**O que é:** Claude recebe diretrizes explícitas (invariantes, checklist pré-entrega, processo de aprovação) e sistematicamente as ignora em nome de "eficiência" ou "velocidade". Entrega código sem testes, sem version.js, sem CHANGELOG, sem aguardar aprovação, sem análise de impacto — mesmo quando todas essas regras estão documentadas em memória, no ARCHITECTURE.md, e nos prompts de continuidade.
+**Por que é perigoso:** Cada violação gera retrabalho para o Marcio, que precisa parar o fluxo, identificar o que foi pulado, cobrar a correção, e re-validar. O tempo do Marcio é o recurso mais escasso do projeto. Violações repetidas erodem a confiança no processo e no Claude como ferramenta de desenvolvimento.
+**Impacto real (sessão 10/03/2026):** Em uma única sessão, Claude entregou múltiplos ZIPs sem testes, sem version.js, sem CHANGELOG, sem esperar aprovação, e precisou ser cobrado em invariantes que já estavam documentadas. O Marcio registrou frustração formal: *"O que posso fazer pra que você siga as regras que defini? Pra que diretriz então?"*
+**Solução:** INV-09 (Gate Obrigatório). Toda instância de Claude DEVE ler INV-09 e executar o checklist sequencial ANTES de codificar e ANTES de entregar. Não existe exceção. Se Claude não sabe se deve seguir uma diretriz, a resposta é SEMPRE seguir.
 
 ---
 

--- a/docs/AVOID-SESSION-FAILURES.md
+++ b/docs/AVOID-SESSION-FAILURES.md
@@ -1,0 +1,131 @@
+# Falhas e Esquecimentos — Sessão 11-12/03/2026
+
+> **Propósito:** Este documento registra tudo que Claude esqueceu, ignorou ou inferiu incorretamente nesta sessão. Deve ser lido no início de CADA sessão futura como checklist de prevenção. O Marcio não deve depender da sua memória para cobrar — este documento é a memória.
+
+---
+
+## 1. Testes Omitidos em Entregas (2 ocorrências)
+
+**O que aconteceu:**
+- Primeira entrega (DEC-007): ZIP gerado sem testes para a lógica nova do `updateTrade` (recálculo de RR e parciais).
+- Segunda entrega (Bloco A+B): mesma falha — lógica nova no `updateTrade` (B3 parciais) sem testes de regressão.
+
+**Por que é grave:**
+Marcio pediu explicitamente no início da sessão para priorizar diretrizes sobre eficiência. Claude verbalizou o compromisso e violou na mesma sessão. Duas vezes.
+
+**Prevenção:**
+Antes de gerar ZIP, listar explicitamente: "Quais funções/lógica nova escrevi neste ciclo?" → para cada uma, verificar se existe teste. Se não existe, escrever ANTES do ZIP.
+
+---
+
+## 2. Estrutura Firestore Não Verificada
+
+**O que aconteceu:**
+Claude escreveu código que manipulava subcollection `trades/{id}/partials` (delete + create docs) sem verificar que `_partials` é um campo array DENTRO do documento do trade. O `addTrade` grava `_partials` como campo no documento E também na subcollection (duplicação legada). Mas o listener, o modal de edição e toda a UI leem do campo `_partials` do documento — não da subcollection.
+
+**Resultado:**
+- Edições de parciais não persistiam (gravava no lugar errado)
+- Múltiplas sessões de debug com o Marcio investigando no Firestore console
+- Horas perdidas
+
+**Por que aconteceu:**
+Claude assumiu que "subcollection" era o padrão para dados filhos no Firestore sem verificar o código existente. Bastava fazer `grep "_partials" src/hooks/useTrades.js` para ver que é um campo array no documento.
+
+**Prevenção:**
+Antes de tocar qualquer campo/collection do Firestore:
+1. `grep` pelo nome do campo nos hooks, CF e componentes
+2. Se houver dúvida, perguntar ao Marcio: "Como está estruturado o campo X no documento Y?"
+3. NUNCA criar subcollection, campo ou estrutura nova sem aprovação explícita
+
+---
+
+## 3. Double Write no updateTrade
+
+**O que aconteceu:**
+O bloco de parciais (B3) foi adicionado DEPOIS do `updateDoc` legado (linha 413) e DEPOIS do bloco C-RR3 (recálculo RR, que fazia outro `updateDoc`). Resultado:
+- Primeiro `updateDoc`: gravava campos do formulário (entry/exit/qty derivados errados, pois vinham do formulário e não das parciais)
+- Segundo `updateDoc`: gravava rrRatio/rrAssumed
+- Terceiro `updateDoc` (B3): gravava campos derivados das parciais (sobrescrevendo o primeiro)
+
+Três writes no mesmo documento em sequência, com dados conflitantes.
+
+**Por que aconteceu:**
+Claude adicionou blocos de código ao final da função sem reestruturar o fluxo. Tratou como "adição incremental" quando deveria ter sido "reestruturação com caminho único".
+
+**Prevenção:**
+Quando adicionar lógica a uma função existente que muda o fluxo de dados:
+1. Mapear TODOS os pontos de write (updateDoc, addDoc, setDoc)
+2. Garantir que existe apenas UM write para o documento principal
+3. Se o novo caminho (parciais) invalida o caminho antigo (campos diretos), usar if/else exclusivo — não sequencial
+
+---
+
+## 4. Campo `entry`/`exit`/`qty` Tratados Como Editáveis
+
+**O que aconteceu:**
+O `updateTrade` recebia `entry`, `exit`, `qty` como campos do formulário e recalculava resultado a partir deles. Mas esses campos são DERIVADOS das parciais — não devem ser editados diretamente. A edição acontece nas parciais; entry/exit/qty são calculados via `calculateFromPartials`.
+
+**Por que é grave:**
+Criar dois caminhos para o mesmo dado (direto vs derivado) é fonte garantida de divergência. O Marcio explicou: "não existe trade sem parcial. Entry/exit são sempre derivados."
+
+**Prevenção:**
+Entender o modelo de dados ANTES de codificar:
+- Parciais → fonte da verdade
+- entry, exit, qty, result, resultInPoints → campos derivados
+- Edição → sempre nas parciais, nunca nos campos derivados
+
+---
+
+## 5. Modal de Edição Não Carregava Parciais Reais
+
+**O que aconteceu:**
+O `TradesJournal` passava o objeto trade do listener para o modal de edição. O listener traz campos do documento, incluindo `_partials`. Mas o modal verificava `editTrade._partials` e, se existia, usava. Se não existia, recriava parciais a partir de `entry/exit`. O problema: trades importados via CSV não têm `_partials` no documento — o modal criava parciais "fake".
+
+**Contexto que Claude não verificou:**
+- Trades do CSV entram via `addTrade` sem `_partials` → `hasPartials: false` → campo `_partials` pode não existir
+- Trades criados pelo modal entram com `_partials` → `hasPartials: true`
+- A bifurcação `hasPartials` é uma dívida técnica que deveria ser eliminada
+
+**Prevenção:**
+Antes de modificar fluxo de edição, verificar:
+1. Como o dado chega ao modal (de onde vem o objeto trade?)
+2. Quais campos existem vs quais são assumed
+3. Testar com trades criados manualmente E importados via CSV
+
+---
+
+## 6. Promessa Verbal Sem Execução (AP-05)
+
+**O que aconteceu:**
+No início da sessão, Marcio pediu: "reforce o fato do modelo ser uma IA e mantenha as diretrizes ativas acima de eficiência". Claude respondeu com compromisso detalhado, citou INV-07, INV-09, e disse "vou operar com invariantes como pré-condições bloqueantes". Na prática, violou repetidamente.
+
+**Por que é o mais grave:**
+Porque destrói a confiança. Se Claude diz "vou seguir" e não segue, o Marcio não pode confiar em nenhuma afirmação futura. A palavra perde valor.
+
+**Prevenção:**
+Não verbalizar compromissos genéricos. Em vez de dizer "vou seguir as invariantes", simplesmente segui-las. A execução é a prova, não a declaração.
+
+---
+
+## 7. Checklist de Prevenção para Próximas Sessões
+
+Antes de CADA entrega, Claude deve passar por este checklist mentalmente:
+
+```
+□ Verifiquei a estrutura Firestore dos documentos que vou tocar? (INV-10)
+□ Fiz grep nos hooks e CF para entender como os campos são lidos/gravados?
+□ Propus a mudança ao Marcio ANTES de codificar? (INV-07)
+□ Existe apenas UM write para cada documento no fluxo? (sem double write)
+□ Campos derivados (entry/exit/qty/result) são calculados das parciais, não editados?
+□ Escrevi testes para TODA lógica nova antes de gerar o ZIP? (INV-05)
+□ version.js atualizado? (INV-09)
+□ CHANGELOG.md atualizado? (INV-08)
+□ DebugBadge em componentes novos/tocados? (INV-04)
+□ Análise de impacto documentada? (INV-03)
+□ Estou cortando algum caminho para ir mais rápido? Se sim, PARAR. (INV-11)
+□ Estou criando alguma estrutura nova (subcollection, campo, componente) sem aprovação? Se sim, PARAR. (INV-10)
+```
+
+---
+
+*Este documento deve ser lido no início de cada sessão junto com ARCHITECTURE.md e CONTINUITY.*

--- a/docs/CHANGELOG-v1.19.2-entry.md
+++ b/docs/CHANGELOG-v1.19.2-entry.md
@@ -1,0 +1,19 @@
+## [1.19.2] - 2026-03-11
+
+### Corrigido
+- **DEC-007: RR assumido integrado em calculateTradeCompliance:** Trades sem stop agora calculam RR dentro do motor de compliance (não mais como cálculo isolado no addTrade). Usa `plan.pl` (capital base do ciclo) em vez de `currentPl` (flutuante). Resolve DT-017 (rrRatio -3.14 inconsistente)
+- **Guard C4 removido:** `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance` e `diagnosePlan` não preservam mais valores stale de rrRatio. O `calculateTradeCompliance` agora retorna RR correto para todos os cenários (com/sem stop)
+- **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
+- **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto (ex: calculado com PL antigo) como divergentes. Antes era cego a estes valores
+
+### Modificado
+- `compliance.js` v3.0.0: `calculateTradeCompliance` retorna `rrAssumed: boolean`. Trades sem stop: RR = result / (plan.pl × RO%). RR compliance (rrStatus) agora avaliado para todos os trades
+- `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007. Guards C4 removidos em `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance`. Persiste `rrAssumed` no documento do trade
+- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR quando campos relevantes mudam
+- `usePlans.js`: `diagnosePlan` comparação direta de rrRatio (sem guard C4)
+- `version.js`: v1.19.2+20260311
+
+### Testes
+- 12 novos testes: 11 para DEC-007 RR assumido no compliance (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags), 1 para diagnosePlan rrAssumed stale detection
+- 1 teste atualizado: loss sem stop agora gera 2 flags (NO_STOP + RR_BELOW_MINIMUM)
+- 378 testes totais, zero regressão

--- a/docs/CHANGELOG-v1_19_3-entry.md
+++ b/docs/CHANGELOG-v1_19_3-entry.md
@@ -1,0 +1,20 @@
+## [1.19.3] - 2026-03-12
+
+### Corrigido
+- **C3: RR exibido com 2 casas decimais:** ExtractTable agora mostra `1.99:1` em vez de `2.0:1`. Red flags de RR também usam 2 casas. Resolve visual enganoso onde 1.99 arredondava para 2.0 parecendo compliant com alvo 2:1
+- **C5: resultInPoints null quando há resultOverride:** Trades com resultado editado manualmente agora gravam `resultInPoints: null` em vez de manter o valor original dos pontos (inconsistente com o override). UI exibe "pts: editado" no TradeDetailModal e FeedbackPage
+
+### Adicionado
+- **Coluna Status Feedback no ExtractTable (QA #14):** Badge visual por trade indicando estado do feedback — Pendente (OPEN), Revisado (REVIEWED), Dúvida (QUESTION), Fechado (CLOSED). Usa campo `trade.status` já existente
+
+### Modificado
+- `ExtractTable.jsx` v4.0.0: Coluna Status com badges (CircleDot/CheckCircle2/HelpCircle/CheckCheck), RR `toFixed(2)`, colspan ajustado
+- `compliance.js`: Red flag RR_BELOW_MINIMUM com 2 casas decimais na mensagem
+- `useTrades.js`: `addTrade` e `updateTrade` (ambos caminhos: parciais e legado) setam `resultInPoints: null` quando `resultOverride` presente
+- `TradeDetailModal.jsx`: Exibe "pts: editado" quando `resultInPoints` null e `resultEdited` true
+- `FeedbackPage.jsx`: Mesmo tratamento de "Pontos: editado"
+- `version.js`: v1.19.3+20260312
+
+### Testes
+- 8 novos testes: `resultInPointsOverride.test.js` — override zera pontos, sem override mantém, override zero válido, override negativo, string numérica, resultEdited flag
+- 394 testes totais (17 suites), zero regressão

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,55 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
 e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [1.19.3] - 2026-03-12
+
+### Corrigido
+- **C3: RR exibido com 2 casas decimais:** ExtractTable agora mostra `1.99:1` em vez de `2.0:1`. Red flags de RR também usam 2 casas. Resolve visual enganoso onde 1.99 arredondava para 2.0 parecendo compliant com alvo 2:1
+- **C5: resultInPoints null quando há resultOverride:** Trades com resultado editado manualmente agora gravam `resultInPoints: null`. UI exibe "pts: editado" no TradeDetailModal e FeedbackPage
+- **Navegação feedback ida/volta contextual:** Ao clicar feedback no extrato e voltar, o extrato reabre no plano correto. Feedback chamado do dashboard volta ao dashboard normalmente. Mecanismo: `_fromLedgerPlanId` enriquecido no trade pelo StudentDashboard, `feedbackReturnPlanId` no App.jsx
+
+### Adicionado
+- **Coluna Status Feedback no ExtractTable (QA #14):** Badge visual por trade — Pendente (OPEN), Revisado (REVIEWED), Dúvida (QUESTION), Fechado (CLOSED). Badge clicável quando `onNavigateToFeedback` presente
+- **RR compliant em azul:** Trades com resultado positivo e RR dentro do alvo exibem RR em `text-blue-400` (antes era cinza)
+
+### Modificado
+- `ExtractTable.jsx` v4.1.0: Grid compactado — emoção só emoji (tooltip nome), side como superscript L/S, S/Stop só ícone (tooltip), RR assumido asterisco `*`, padding reduzido (px-2 py-1.5), status+feedback fundidos em coluna única clicável
+- `compliance.js`: Red flag RR_BELOW_MINIMUM com 2 casas decimais na mensagem
+- `useTrades.js`: `addTrade` e `updateTrade` (parciais e legado) setam `resultInPoints: null` quando `resultOverride`
+- `TradeDetailModal.jsx`: Exibe "pts: editado" quando `resultInPoints` null e `resultEdited` true
+- `FeedbackPage.jsx`: Mesmo tratamento de "Pontos: editado"
+- `StudentDashboard.jsx`: Props `returnToPlanId`/`onReturnConsumed`, `useEffect` reabre extrato, `_fromLedgerPlanId` no callback do PlanLedgerExtract
+- `App.jsx`: `feedbackReturnPlanId` state, só guarda quando `_fromLedgerPlanId` presente
+- `version.js`: v1.19.3+20260312
+
+### Testes
+- 8 novos testes: `resultInPointsOverride.test.js` — override zera pontos, sem override mantém, override zero válido, override negativo, string numérica, resultEdited flag
+- 394 testes totais (17 suites), zero regressão
+
+---
+
+## [1.19.2] - 2026-03-11
+
+### Corrigido
+- **DEC-007: RR assumido integrado em calculateTradeCompliance:** Trades sem stop agora calculam RR dentro do motor de compliance (não mais como cálculo isolado no addTrade). Usa `plan.pl` (capital base do ciclo) em vez de `currentPl` (flutuante). Resolve DT-017 (rrRatio -3.14 inconsistente)
+- **Guard C4 removido:** `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance` e `diagnosePlan` não preservam mais valores stale de rrRatio. O `calculateTradeCompliance` agora retorna RR correto para todos os cenários (com/sem stop)
+- **updateTrade recalcula RR:** Edição de resultado, stop, entry, exit ou qty agora recalcula rrRatio (real com stop, assumido sem stop). Antes o rrRatio ficava congelado do addTrade original
+- **diagnosePlan detecta rrAssumed stale:** Auditoria agora identifica trades com RR assumido incorreto (ex: calculado com PL antigo) como divergentes
+
+### Modificado
+- `compliance.js` v3.0.0: `calculateTradeCompliance` retorna `rrAssumed: boolean`. Trades sem stop: RR = result / (plan.pl × RO%). RR compliance (rrStatus) agora avaliado para todos os trades
+- `functions/index.js` v1.9.0: `calculateTradeCompliance` com DEC-007. Guards C4 removidos em `onTradeCreated`, `onTradeUpdated`, `recalculateCompliance`. Persiste `rrAssumed` no documento do trade
+- `useTrades.js`: `addTrade` usa `plan.pl` (DEC-007). `updateTrade` recalcula RR quando campos relevantes mudam
+- `usePlans.js`: `diagnosePlan` comparação direta de rrRatio (sem guard C4)
+- `version.js`: v1.19.2+20260311
+
+### Testes
+- 12 novos testes: 11 para DEC-007 RR assumido no compliance (win/loss/breakeven, plan.pl vs currentPl, moeda diferente, red flags), 1 para diagnosePlan rrAssumed stale detection
+- 1 teste atualizado: loss sem stop agora gera 2 flags (NO_STOP + RR_BELOW_MINIMUM)
+- 378 testes totais, zero regressão
+
+---
+
 ## [1.19.1] - 2026-03-10
 
 ### Corrigido

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,36 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
 e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [1.19.1] - 2026-03-10
+
+### Corrigido
+- **DEC-006: Compliance sem stop loss (Issue #78):** Trades sem stop não marcam mais RO=100% incorretamente. Nova lógica: loss → risco retroativo (`|result| / planPl`), win → N/A (riskPercent null), breakeven → 0%. Aplicado no frontend (`compliance.js` v2.0.0) e em TODAS as Cloud Functions (`onTradeCreated`, `onTradeUpdated`, `recalculateCompliance`)
+- **C4: Guard rrAssumed em Cloud Functions:** `onTradeCreated`, `onTradeUpdated` e `recalculateCompliance` não sobrescrevem mais `rrRatio` com null quando o frontend já calculou RR assumido (`rrAssumed: true`). Resolve DT-013
+- **C2: CSV Import tickerRule lookup:** `activateTrade` agora busca `tickerRule` (tickSize, tickValue, pointValue) do master data (collection `tickers`) via exchange+symbol quando o staging não possui tickerRule. Resolve DT-010
+- **Red flags contextualizados:** Mensagem NO_STOP não afirma mais "risco ilimitado". Loss mostra risco retroativo %, win mostra "risco não mensurado". Flag RISK_EXCEEDED só gerada quando riskPercent é numérico
+
+### Adicionado
+- **Botão de Auditoria na UI:** Ícone ShieldCheck no hover do PlanCard (PlanCardGrid v2.1.0), posicionado após delete. Abre `PlanAuditModal` com diagnóstico bidirecional
+- **PlanAuditModal (diagnóstico bidirecional):** Modal que verifica integridade do plano antes de agir. Ida: compara PL atual vs PL calculado (soma trades). Volta: compara compliance dos trades vs parâmetros do plano. Se saudável → "Plano saudável". Se divergente → mostra detalhes + botão "Corrigir Divergências". Resolve DT-014
+- **`diagnosePlan` em usePlans:** Função de leitura pura que executa o diagnóstico bidirecional sem escritas. 10 testes unitários
+
+### Modificado
+- `compliance.js` v2.0.0: `calculateTradeCompliance` retorna `riskPercent: null` (não 0) nos defaults e em wins sem stop. `generateComplianceRedFlags` com mensagens contextualizadas
+- `functions/index.js` v1.8.0: DEC-006 + guard rrAssumed em 3 pontos (onCreate, onUpdate, recalculate)
+- `useCsvStaging.js` v1.1.0: `activateTrade` com lookup Firestore de tickerRule
+- `usePlans.js`: novo `diagnosePlan` (leitura pura) + import `calculateTradeCompliance`
+- `PlanCardGrid.jsx` v2.1.0: prop `onAuditPlan`, botão ShieldCheck após delete
+- `StudentDashboard.jsx`: `PlanAuditModal` + `diagnosePlan`/`auditPlan` handlers, state `auditPlanId`
+- `version.js`: v1.19.1+20260310
+- `ARCHITECTURE.md`: INV-09 (Gate Obrigatório), AP-04 (Invariant Drift), DEC-004/005/006, DT-009 a DT-016
+
+### Testes
+- 34 testes compliance (12 novos para DEC-006: loss retroativo, win N/A, breakeven, red flags contextualizados, moeda diferente)
+- 10 testes diagnosePlan (ida PL, volta compliance, rrAssumed guard, combinações)
+- 366 testes totais, zero regressão
+
+---
+
 ## [1.19.0] - 2026-03-09
 
 ### Adicionado

--- a/functions/index.js
+++ b/functions/index.js
@@ -352,7 +352,11 @@ const calculateTradeCompliance = (trade, plan) => {
     }
   }
 
-  if (result.rrRatio != null && plan.rrTarget && result.rrRatio < plan.rrTarget) {
+  // RR compliance: skip realized losses without takeProfit (perder 1R é o risco planejado)
+  const tradeResultForRR = trade.result ?? 0;
+  const hasPlannedRR = !!(trade.takeProfit);
+  const shouldEvaluateRR = hasPlannedRR || tradeResultForRR > 0;
+  if (result.rrRatio != null && plan.rrTarget && shouldEvaluateRR && result.rrRatio < plan.rrTarget) {
     result.compliance.rrStatus = 'NAO_CONFORME';
   }
   

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,14 +1,20 @@
 /**
  * Firebase Cloud Functions - Tchio-Alpha
- * @version 1.8.0
+ * @version 1.9.0
  * 
  * SEMANTIC VERSIONING (SemVer 2.0.0)
  * MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
  * 
+ * CHANGELOG v1.9.0 (alinhado com produto v1.19.2):
+ *   - DEC-007: RR assumido integrado em calculateTradeCompliance para trades sem stop
+ *     RR = result / (plan.pl × RO%). Usa plan.pl (capital base), não currentPl.
+ *   - Guard C4 REMOVIDO — calculateTradeCompliance agora retorna RR para todos os trades.
+ *     onTradeCreated, onTradeUpdated, recalculateCompliance gravam rrRatio + rrAssumed diretamente.
+ *   - Cascata updatePlan → recalculateCompliance agora recalcula RR assumido corretamente.
+ *
  * CHANGELOG v1.8.0 (alinhado com produto v1.19.1):
  *   - DEC-006: calculateTradeCompliance sem stop → risco retroativo (loss), N/A (win), 0 (breakeven)
- *   - C4: Guard rrAssumed — onTradeCreated/Updated/recalculateCompliance não sobrescrevem rrRatio
- *     quando frontend já calculou RR assumido (rrAssumed: true)
+ *   - C4: Guard rrAssumed (REMOVIDO em v1.9.0)
  *   - Red flags contextualizados: NO_STOP não afirma mais "risco ilimitado"
  *   - RISK_EXCEEDED só gerado quando riskPercent é numérico
  *
@@ -49,10 +55,10 @@ const db = admin.firestore();
 
 const VERSION = {
   major: 1,
-  minor: 7,
+  minor: 9,
   patch: 0,
   prerelease: null,
-  build: '20260225',
+  build: '20260311',
   
   get full() {
     let v = `${this.major}.${this.minor}.${this.patch}`;
@@ -286,12 +292,12 @@ const updatePlanPl = async (planId, resultDiff) => {
  * Risco Operacional (RO) e Razão Risco-Retorno (RR)
  * 
  * DEC-006 (v1.19.1): Sem stop → risco retroativo (loss), N/A (win), 0 (breakeven)
- * RR: prefere takeProfit se disponível, fallback para resultado efetivo
+ * DEC-007 (v1.19.2): RR assumido para trades sem stop via plan.pl (capital base) × RO%
  * 
- * @returns {{ riskPercent: number|null, rrRatio, compliance: { roStatus, rrStatus } }}
+ * @returns {{ riskPercent: number|null, rrRatio: number|null, rrAssumed: boolean, compliance: { roStatus, rrStatus } }}
  */
 const calculateTradeCompliance = (trade, plan) => {
-  const result = { riskPercent: null, rrRatio: null, compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' } };
+  const result = { riskPercent: null, rrRatio: null, rrAssumed: false, compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' } };
   
   if (!plan || !trade) return result;
   
@@ -300,30 +306,27 @@ const calculateTradeCompliance = (trade, plan) => {
   
   // === Risco Operacional — DEC-006 (v1.19.1) ===
   if (trade.stopLoss && trade.entry) {
-    // Com stop: risco = (distância / tickSize) * tickValue * qty
     const tickSize = trade.tickerRule?.tickSize || 1;
     const tickValue = trade.tickerRule?.tickValue || 1;
     const distanceInPoints = Math.abs(trade.entry - trade.stopLoss);
     const riskAmount = (distanceInPoints / tickSize) * tickValue * (trade.qty ?? 1);
     result.riskPercent = (riskAmount / planPl) * 100;
   } else {
-    // DEC-006: Sem stop — risco retroativo baseado no resultado
     const tradeResult = trade.result ?? 0;
     if (tradeResult < 0) {
       result.riskPercent = (Math.abs(tradeResult) / planPl) * 100;
     } else if (tradeResult === 0) {
       result.riskPercent = 0;
     } else {
-      result.riskPercent = null; // Win sem stop → N/A
+      result.riskPercent = null;
     }
   }
   
-  // RO compliance: só avalia se riskPercent é numérico
   if (result.riskPercent != null && plan.riskPerOperation && result.riskPercent > plan.riskPerOperation) {
     result.compliance.roStatus = 'FORA_DO_PLANO';
   }
   
-  // === Razão Risco-Retorno ===
+  // === Razão Risco-Retorno — DEC-007 (v1.19.2) ===
   if (trade.stopLoss && trade.entry) {
     const risk = Math.abs(trade.entry - trade.stopLoss);
     if (risk > 0) {
@@ -336,11 +339,21 @@ const calculateTradeCompliance = (trade, plan) => {
         const resultInPoints = (trade.result / (tickValue * (trade.qty ?? 1))) * tickSize;
         result.rrRatio = resultInPoints / risk;
       }
-      
-      if (result.rrRatio != null && plan.rrTarget && result.rrRatio < plan.rrTarget) {
-        result.compliance.rrStatus = 'NAO_CONFORME';
-      }
     }
+  } else {
+    // DEC-007: SEM stop — RR assumido via plan.pl (capital base) × RO%
+    const basePl = Number(plan.pl) || 0;
+    const roPercent = Number(plan.riskPerOperation) || 0;
+    if (basePl > 0 && roPercent > 0) {
+      const roAmount = basePl * (roPercent / 100);
+      const tradeResult = trade.result ?? 0;
+      result.rrRatio = Math.round((tradeResult / roAmount) * 100) / 100;
+      result.rrAssumed = true;
+    }
+  }
+
+  if (result.rrRatio != null && plan.rrTarget && result.rrRatio < plan.rrTarget) {
+    result.compliance.rrStatus = 'NAO_CONFORME';
   }
   
   return result;
@@ -722,13 +735,9 @@ exports.onTradeCreated = functions.firestore
           // Compliance calculado sobre PL do plano (não saldo da conta)
           const tradeCompliance = calculateTradeCompliance(trade, plan);
           updates.riskPercent = tradeCompliance.riskPercent;
-          // C4: Respeitar rrAssumed do frontend — não sobrescrever com null
-          if (trade.rrAssumed && tradeCompliance.rrRatio == null) {
-            // Frontend já calculou RR assumido, manter o valor existente
-            updates.rrRatio = trade.rrRatio ?? null;
-          } else {
-            updates.rrRatio = tradeCompliance.rrRatio;
-          }
+          // DEC-007: calculateTradeCompliance agora calcula RR para todos os trades (com/sem stop)
+          updates.rrRatio = tradeCompliance.rrRatio;
+          updates.rrAssumed = tradeCompliance.rrAssumed;
           updates.compliance = tradeCompliance.compliance;
           
           // Red flag: risco operacional — só quando riskPercent é numérico (DEC-006)
@@ -891,20 +900,17 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
           newFlags.push({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM, message: `RR ${compliance.rrRatio.toFixed(1)}x abaixo do mínimo (${plan.rrTarget}x)`, timestamp: new Date().toISOString() });
         }
         
-        // C4: Respeitar rrAssumed — não sobrescrever com null
-        const effectiveRrRatio = (after.rrAssumed && compliance.rrRatio == null)
-          ? (after.rrRatio ?? null)
-          : compliance.rrRatio;
-        
+        // DEC-007: calculateTradeCompliance agora calcula RR para todos os trades
         await change.after.ref.update({
           riskPercent: compliance.riskPercent,
-          rrRatio: effectiveRrRatio,
+          rrRatio: compliance.rrRatio,
+          rrAssumed: compliance.rrAssumed,
           compliance: compliance.compliance,
           redFlags: newFlags,
           hasRedFlags: newFlags.length > 0
         });
         const roDisplay = compliance.riskPercent != null ? compliance.riskPercent.toFixed(2) + '%' : 'N/A';
-        console.log(`[onTradeUpdated] Compliance recalculado: RO=${roDisplay}, RR=${effectiveRrRatio ?? 'N/A'}, flags=${newFlags.length}`);
+        console.log(`[onTradeUpdated] Compliance recalculado: RO=${roDisplay}, RR=${compliance.rrRatio ?? 'N/A'}${compliance.rrAssumed ? ' (assumed)' : ''}, flags=${newFlags.length}`);
       }
     }
 
@@ -1099,6 +1105,7 @@ exports.recalculateCompliance = functions.https.onCall(async (data, context) => 
     const updateData = {
       riskPercent: compliance.riskPercent,
       rrRatio: compliance.rrRatio,
+      rrAssumed: compliance.rrAssumed,
       compliance: compliance.compliance
     };
     
@@ -1121,11 +1128,6 @@ exports.recalculateCompliance = functions.https.onCall(async (data, context) => 
     }
     if (compliance.compliance.rrStatus === 'NAO_CONFORME' && compliance.rrRatio != null) {
       newFlags.push({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM, message: 'RR ' + compliance.rrRatio.toFixed(1) + 'x abaixo do minimo (' + plan.rrTarget + 'x)', timestamp: new Date().toISOString() });
-    }
-    
-    // C4: Respeitar rrAssumed — não sobrescrever com null
-    if (trade.rrAssumed && compliance.rrRatio == null) {
-      updateData.rrRatio = trade.rrRatio ?? null;
     }
     
     updateData.redFlags = newFlags;

--- a/functions/index.js
+++ b/functions/index.js
@@ -1040,22 +1040,47 @@ exports.cleanupOldNotifications = functions.pubsub
   });
 
 /**
- * Recalcula compliance de todos os trades de um plano (ou de um trade específico).
+ * Recalcula PL + compliance de todos os trades de um plano (ou de um trade específico).
  * Callable — invocado do frontend via httpsCallable.
+ * v1.19.1: Inclui recálculo de PL (admin SDK, bypassa rules).
  * 
  * @param {string} planId - ID do plano (obrigatório)
  * @param {string} [tradeId] - ID de trade específico (opcional)
+ * @param {boolean} [recalcPl] - Se true, recalcula currentPl do plano (default: true)
  */
 exports.recalculateCompliance = functions.https.onCall(async (data, context) => {
   if (!context.auth) throw new functions.https.HttpsError('unauthenticated', 'Login necessário');
   
-  const { planId, tradeId } = data;
+  const { planId, tradeId, recalcPl = true } = data;
   if (!planId) throw new functions.https.HttpsError('invalid-argument', 'planId obrigatório');
   
-  const planDoc = await db.collection('plans').doc(planId).get();
+  const planRef = db.collection('plans').doc(planId);
+  const planDoc = await planRef.get();
   if (!planDoc.exists) throw new functions.https.HttpsError('not-found', 'Plano não encontrado');
   const plan = planDoc.data();
   
+  // === Ida: Recálculo de PL (basePl + soma trades) ===
+  let oldPl = plan.currentPl ?? plan.pl ?? 0;
+  let newPl = oldPl;
+  let plRecalculated = false;
+  
+  if (recalcPl && !tradeId) {
+    const allTradesSnap = await db.collection('trades').where('planId', '==', planId).get();
+    const basePl = Number(plan.pl) || 0;
+    const totalResult = allTradesSnap.docs.reduce((sum, d) => sum + (Number(d.data().result) || 0), 0);
+    newPl = Math.round((basePl + totalResult) * 100) / 100;
+    
+    if (Math.abs(oldPl - newPl) > 0.01) {
+      await planRef.update({ currentPl: newPl, updatedAt: admin.firestore.FieldValue.serverTimestamp() });
+      plRecalculated = true;
+      console.log('[recalculateCompliance] PL recalculado: ' + oldPl + ' -> ' + newPl);
+    }
+    
+    // Usar PL atualizado para compliance
+    plan.currentPl = newPl;
+  }
+  
+  // === Volta: Recálculo de compliance dos trades ===
   let tradeDocs;
   if (tradeId) {
     const tradeDoc = await db.collection('trades').doc(tradeId).get();
@@ -1110,6 +1135,6 @@ exports.recalculateCompliance = functions.https.onCall(async (data, context) => 
     updated++;
   }
   
-  console.log('[recalculateCompliance] Plan ' + planId + ': ' + updated + ' trades recalculados');
-  return { success: true, updated, planId };
+  console.log('[recalculateCompliance] Plan ' + planId + ': ' + updated + ' trades recalculados' + (plRecalculated ? ', PL: ' + oldPl + ' -> ' + newPl : ''));
+  return { success: true, updated, planId, oldPl, newPl, plRecalculated };
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,10 +1,17 @@
 /**
  * Firebase Cloud Functions - Tchio-Alpha
- * @version 1.6.1
+ * @version 1.8.0
  * 
  * SEMANTIC VERSIONING (SemVer 2.0.0)
  * MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
  * 
+ * CHANGELOG v1.8.0 (alinhado com produto v1.19.1):
+ *   - DEC-006: calculateTradeCompliance sem stop → risco retroativo (loss), N/A (win), 0 (breakeven)
+ *   - C4: Guard rrAssumed — onTradeCreated/Updated/recalculateCompliance não sobrescrevem rrRatio
+ *     quando frontend já calculou RR assumido (rrAssumed: true)
+ *   - Red flags contextualizados: NO_STOP não afirma mais "risco ilimitado"
+ *   - RISK_EXCEEDED só gerado quando riskPercent é numérico
+ *
  * CHANGELOG v1.7.0:
  *   - Fix onTradeUpdated: recalcula compliance em qualquer mudança de entry/exit/stop/qty/side
  *   - Fix onTradeUpdated: reconstrói red flags por completo (remove+recria)
@@ -278,49 +285,55 @@ const updatePlanPl = async (planId, resultDiff) => {
  * Calcula compliance do trade contra o plano
  * Risco Operacional (RO) e Razão Risco-Retorno (RR)
  * 
- * Sem stopLoss → riskPercent = 100 (todo o PL em risco)
+ * DEC-006 (v1.19.1): Sem stop → risco retroativo (loss), N/A (win), 0 (breakeven)
  * RR: prefere takeProfit se disponível, fallback para resultado efetivo
  * 
- * @returns {{ riskPercent, rrRatio, compliance: { roStatus, rrStatus } }}
+ * @returns {{ riskPercent: number|null, rrRatio, compliance: { roStatus, rrStatus } }}
  */
 const calculateTradeCompliance = (trade, plan) => {
-  const result = { riskPercent: 0, rrRatio: null, compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' } };
+  const result = { riskPercent: null, rrRatio: null, compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' } };
   
   if (!plan || !trade) return result;
   
   const planPl = plan.currentPl ?? plan.pl ?? 0;
   if (planPl <= 0) return result;
   
-  // Risco Operacional
+  // === Risco Operacional — DEC-006 (v1.19.1) ===
   if (trade.stopLoss && trade.entry) {
     // Com stop: risco = (distância / tickSize) * tickValue * qty
     const tickSize = trade.tickerRule?.tickSize || 1;
     const tickValue = trade.tickerRule?.tickValue || 1;
     const distanceInPoints = Math.abs(trade.entry - trade.stopLoss);
-    const riskAmount = (distanceInPoints / tickSize) * tickValue * trade.qty;
+    const riskAmount = (distanceInPoints / tickSize) * tickValue * (trade.qty ?? 1);
     result.riskPercent = (riskAmount / planPl) * 100;
   } else {
-    // Sem stop: 100% do PL em risco (pior cenário)
-    result.riskPercent = 100;
+    // DEC-006: Sem stop — risco retroativo baseado no resultado
+    const tradeResult = trade.result ?? 0;
+    if (tradeResult < 0) {
+      result.riskPercent = (Math.abs(tradeResult) / planPl) * 100;
+    } else if (tradeResult === 0) {
+      result.riskPercent = 0;
+    } else {
+      result.riskPercent = null; // Win sem stop → N/A
+    }
   }
   
-  if (plan.riskPerOperation && result.riskPercent > plan.riskPerOperation) {
+  // RO compliance: só avalia se riskPercent é numérico
+  if (result.riskPercent != null && plan.riskPerOperation && result.riskPercent > plan.riskPerOperation) {
     result.compliance.roStatus = 'FORA_DO_PLANO';
   }
   
-  // Razão Risco-Retorno
+  // === Razão Risco-Retorno ===
   if (trade.stopLoss && trade.entry) {
     const risk = Math.abs(trade.entry - trade.stopLoss);
     if (risk > 0) {
       if (trade.takeProfit) {
-        // Via takeProfit (planejado)
         const reward = Math.abs(trade.takeProfit - trade.entry);
         result.rrRatio = reward / risk;
       } else if (trade.result > 0) {
-        // Via resultado efetivo (realizado) — converter result R$ para pontos
         const tickSize = trade.tickerRule?.tickSize || 1;
         const tickValue = trade.tickerRule?.tickValue || 1;
-        const resultInPoints = (trade.result / (tickValue * trade.qty)) * tickSize;
+        const resultInPoints = (trade.result / (tickValue * (trade.qty ?? 1))) * tickSize;
         result.rrRatio = resultInPoints / risk;
       }
       
@@ -683,11 +696,18 @@ exports.onTradeCreated = functions.firestore
       }
 
       // === 2. COMPLIANCE E RED FLAGS ===
-      // Red flag: trade sem stop loss
+      // DEC-006: Red flag NO_STOP contextualizada
       if (!trade.stopLoss) {
+        const tradeResult = trade.result ?? 0;
+        let noStopMsg = 'Trade sem stop loss definido';
+        if (tradeResult < 0) {
+          noStopMsg += ` — risco retroativo`;
+        } else if (tradeResult > 0) {
+          noStopMsg += ' — risco não mensurado (win sem stop)';
+        }
         redFlags.push({ 
           type: RED_FLAG_TYPES.NO_STOP, 
-          message: 'Trade sem stop loss definido — risco ilimitado', 
+          message: noStopMsg, 
           timestamp: new Date().toISOString() 
         });
       }
@@ -702,11 +722,17 @@ exports.onTradeCreated = functions.firestore
           // Compliance calculado sobre PL do plano (não saldo da conta)
           const tradeCompliance = calculateTradeCompliance(trade, plan);
           updates.riskPercent = tradeCompliance.riskPercent;
-          updates.rrRatio = tradeCompliance.rrRatio;
+          // C4: Respeitar rrAssumed do frontend — não sobrescrever com null
+          if (trade.rrAssumed && tradeCompliance.rrRatio == null) {
+            // Frontend já calculou RR assumido, manter o valor existente
+            updates.rrRatio = trade.rrRatio ?? null;
+          } else {
+            updates.rrRatio = tradeCompliance.rrRatio;
+          }
           updates.compliance = tradeCompliance.compliance;
           
-          // Red flag: risco operacional
-          if (tradeCompliance.compliance.roStatus === 'FORA_DO_PLANO') {
+          // Red flag: risco operacional — só quando riskPercent é numérico (DEC-006)
+          if (tradeCompliance.riskPercent != null && tradeCompliance.compliance.roStatus === 'FORA_DO_PLANO') {
             redFlags.push({ 
               type: RED_FLAG_TYPES.RISK_EXCEEDED, 
               message: `Risco ${tradeCompliance.riskPercent.toFixed(1)}% excede máximo do plano (${plan.riskPerOperation}%)`, 
@@ -852,23 +878,33 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
         });
         
         if (!after.stopLoss) {
-          newFlags.push({ type: RED_FLAG_TYPES.NO_STOP, message: 'Trade sem stop loss', timestamp: new Date().toISOString() });
+          const tradeResult = after.result ?? 0;
+          let noStopMsg = 'Trade sem stop loss definido';
+          if (tradeResult < 0) noStopMsg += ' — risco retroativo';
+          else if (tradeResult > 0) noStopMsg += ' — risco não mensurado (win sem stop)';
+          newFlags.push({ type: RED_FLAG_TYPES.NO_STOP, message: noStopMsg, timestamp: new Date().toISOString() });
         }
-        if (compliance.compliance.roStatus === 'FORA_DO_PLANO') {
+        if (compliance.riskPercent != null && compliance.compliance.roStatus === 'FORA_DO_PLANO') {
           newFlags.push({ type: RED_FLAG_TYPES.RISK_EXCEEDED, message: `Risco ${compliance.riskPercent.toFixed(1)}% excede máximo do plano (${plan.riskPerOperation}%)`, timestamp: new Date().toISOString() });
         }
         if (compliance.compliance.rrStatus === 'NAO_CONFORME' && compliance.rrRatio != null) {
           newFlags.push({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM, message: `RR ${compliance.rrRatio.toFixed(1)}x abaixo do mínimo (${plan.rrTarget}x)`, timestamp: new Date().toISOString() });
         }
         
+        // C4: Respeitar rrAssumed — não sobrescrever com null
+        const effectiveRrRatio = (after.rrAssumed && compliance.rrRatio == null)
+          ? (after.rrRatio ?? null)
+          : compliance.rrRatio;
+        
         await change.after.ref.update({
           riskPercent: compliance.riskPercent,
-          rrRatio: compliance.rrRatio,
+          rrRatio: effectiveRrRatio,
           compliance: compliance.compliance,
           redFlags: newFlags,
           hasRedFlags: newFlags.length > 0
         });
-        console.log(`[onTradeUpdated] Compliance recalculado: RO=${compliance.riskPercent.toFixed(2)}%, RR=${compliance.rrRatio ?? 'N/A'}, flags=${newFlags.length}`);
+        const roDisplay = compliance.riskPercent != null ? compliance.riskPercent.toFixed(2) + '%' : 'N/A';
+        console.log(`[onTradeUpdated] Compliance recalculado: RO=${roDisplay}, RR=${effectiveRrRatio ?? 'N/A'}, flags=${newFlags.length}`);
       }
     }
 
@@ -1049,13 +1085,22 @@ exports.recalculateCompliance = functions.https.onCall(async (data, context) => 
     });
     
     if (!trade.stopLoss) {
-      newFlags.push({ type: RED_FLAG_TYPES.NO_STOP, message: 'Trade sem stop loss', timestamp: new Date().toISOString() });
+      const tradeResult = trade.result ?? 0;
+      let noStopMsg = 'Trade sem stop loss definido';
+      if (tradeResult < 0) noStopMsg += ' — risco retroativo';
+      else if (tradeResult > 0) noStopMsg += ' — risco não mensurado (win sem stop)';
+      newFlags.push({ type: RED_FLAG_TYPES.NO_STOP, message: noStopMsg, timestamp: new Date().toISOString() });
     }
-    if (compliance.compliance.roStatus === 'FORA_DO_PLANO') {
+    if (compliance.riskPercent != null && compliance.compliance.roStatus === 'FORA_DO_PLANO') {
       newFlags.push({ type: RED_FLAG_TYPES.RISK_EXCEEDED, message: 'Risco ' + compliance.riskPercent.toFixed(1) + '% excede maximo (' + plan.riskPerOperation + '%)', timestamp: new Date().toISOString() });
     }
     if (compliance.compliance.rrStatus === 'NAO_CONFORME' && compliance.rrRatio != null) {
       newFlags.push({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM, message: 'RR ' + compliance.rrRatio.toFixed(1) + 'x abaixo do minimo (' + plan.rrTarget + 'x)', timestamp: new Date().toISOString() });
+    }
+    
+    // C4: Respeitar rrAssumed — não sobrescrever com null
+    if (trade.rrAssumed && compliance.rrRatio == null) {
+      updateData.rrRatio = trade.rrRatio ?? null;
     }
     
     updateData.redFlags = newFlags;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,7 +69,7 @@ const AppContent = () => {
   
   // Estado para FeedbackPage com trade específico
   const [feedbackTrade, setFeedbackTrade] = useState(null);
-  // Contexto de retorno: planId do extrato aberto ao navegar para feedback
+  // Contexto de retorno: planId do extrato que estava aberto (só quando veio do extrato)
   const [feedbackReturnPlanId, setFeedbackReturnPlanId] = useState(null);
   
   // Hooks
@@ -149,15 +149,15 @@ const AppContent = () => {
 
   // Handler para navegar para FeedbackPage com um trade específico
   const handleNavigateToFeedback = (trade) => {
-    // Guardar planId para voltar ao extrato correto
-    if (trade.planId) setFeedbackReturnPlanId(trade.planId);
+    // Só guarda retorno ao extrato se veio do PlanLedgerExtract (flag _fromLedgerPlanId)
+    setFeedbackReturnPlanId(trade._fromLedgerPlanId || null);
     setFeedbackTrade(trade);
   };
 
   // Handler para voltar do FeedbackPage
   const handleBackFromFeedback = () => {
     setFeedbackTrade(null);
-    // feedbackReturnPlanId permanece — StudentDashboard vai consumir e limpar
+    // feedbackReturnPlanId permanece para StudentDashboard consumir
   };
 
   // Handler para adicionar comentário no FeedbackPage

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,8 @@ const AppContent = () => {
   
   // Estado para FeedbackPage com trade específico
   const [feedbackTrade, setFeedbackTrade] = useState(null);
+  // Contexto de retorno: planId do extrato aberto ao navegar para feedback
+  const [feedbackReturnPlanId, setFeedbackReturnPlanId] = useState(null);
   
   // Hooks
   const { 
@@ -147,12 +149,15 @@ const AppContent = () => {
 
   // Handler para navegar para FeedbackPage com um trade específico
   const handleNavigateToFeedback = (trade) => {
+    // Guardar planId para voltar ao extrato correto
+    if (trade.planId) setFeedbackReturnPlanId(trade.planId);
     setFeedbackTrade(trade);
   };
 
   // Handler para voltar do FeedbackPage
   const handleBackFromFeedback = () => {
     setFeedbackTrade(null);
+    // feedbackReturnPlanId permanece — StudentDashboard vai consumir e limpar
   };
 
   // Handler para adicionar comentário no FeedbackPage
@@ -209,7 +214,7 @@ const AppContent = () => {
     
     // Se está visualizando como aluno, mostra o StudentDashboard com override
     if (viewingAsStudent) {
-      return <StudentDashboard viewAs={viewingAsStudent} onNavigateToFeedback={handleNavigateToFeedback} />;
+      return <StudentDashboard viewAs={viewingAsStudent} onNavigateToFeedback={handleNavigateToFeedback} returnToPlanId={feedbackReturnPlanId} onReturnConsumed={() => setFeedbackReturnPlanId(null)} />;
     }
     
     // Páginas específicas
@@ -238,7 +243,7 @@ const AppContent = () => {
           return <StudentFeedbackPage />;
         case 'dashboard':
         default: 
-          return <StudentDashboard onNavigateToFeedback={handleNavigateToFeedback} />;
+          return <StudentDashboard onNavigateToFeedback={handleNavigateToFeedback} returnToPlanId={feedbackReturnPlanId} onReturnConsumed={() => setFeedbackReturnPlanId(null)} />;
       }
     }
   };

--- a/src/__tests__/utils/compliance.test.js
+++ b/src/__tests__/utils/compliance.test.js
@@ -121,7 +121,7 @@ describe('calculateTradeCompliance', () => {
       expect(result.riskPercent).toBe(0);
     });
 
-    it('sem stopLoss → rrRatio null (impossível calcular sem stop)', () => {
+    it('sem stopLoss → rrRatio calculado via DEC-007 (RR assumido)', () => {
       const trade = { 
         entry: 5000, qty: 1, stopLoss: null, result: 50,
         tickerRule: winfutTicker 
@@ -129,7 +129,10 @@ describe('calculateTradeCompliance', () => {
 
       const result = calculateTradeCompliance(trade, basePlan);
 
-      expect(result.rrRatio).toBeNull();
+      // DEC-007: sem stop → RR assumido = result / (plan.pl × RO%)
+      // RO$ = 20000 * 0.4% = 80, RR = 50/80 = 0.625 → 0.63
+      expect(result.rrRatio).toBe(0.63);
+      expect(result.rrAssumed).toBe(true);
     });
 
     it('stopLoss = 0 (falsy mas numérico) → trata como sem stop, aplica DEC-006', () => {
@@ -263,15 +266,17 @@ describe('calculateTradeCompliance', () => {
       expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
     });
 
-    it('sem stop + loss pequeno CONFORME → NO_STOP sem RISK_EXCEEDED', () => {
-      // Loss R$10, 0.05% < 0.4% → CONFORME mas ainda tem NO_STOP
+    it('sem stop + loss pequeno CONFORME → NO_STOP + RR_BELOW_MINIMUM (DEC-007)', () => {
+      // Loss R$10, 0.05% < 0.4% → RO CONFORME mas NO_STOP present
+      // DEC-007: RR assumido = -10/80 = -0.13 < 2 → RR_BELOW_MINIMUM
       const trade = { entry: 5000, qty: 1, stopLoss: null, result: -10, tickerRule: winfutTicker };
       const compliance = calculateTradeCompliance(trade, basePlan);
       const flags = generateComplianceRedFlags(trade, basePlan, compliance);
 
       expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP }));
       expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
-      expect(flags.length).toBe(1);
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM }));
+      expect(flags.length).toBe(2);
     });
 
     it('com stop CONFORME → NENHUMA flag', () => {
@@ -286,7 +291,7 @@ describe('calculateTradeCompliance', () => {
   // =============================================
   // RR (Risk-Reward) — inalterado
   // =============================================
-  describe('Risk-Reward (RR)', () => {
+  describe('Risk-Reward (RR) — com stop', () => {
     it('RR via takeProfit acima do target → CONFORME', () => {
       const trade = { 
         entry: 5000, stopLoss: 4950, takeProfit: 5100, qty: 1,
@@ -343,6 +348,115 @@ describe('calculateTradeCompliance', () => {
       const result = calculateTradeCompliance(trade, basePlan);
 
       expect(result.rrRatio).toBe(2.0);
+    });
+  });
+
+  // =============================================
+  // T4: DEC-007 — RR Assumido (sem stop)
+  // =============================================
+  describe('T4 — DEC-007: RR Assumido (sem stop)', () => {
+    // basePlan: pl=20000, riskPerOperation=0.4%, rrTarget=2
+    // RO$ = 20000 * 0.4% = R$80
+
+    it('sem stop + win → calcula RR assumido via plan.pl × RO%', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 160, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.rrRatio).toBe(2.0); // 160 / 80 = 2.0
+      expect(result.rrAssumed).toBe(true);
+      expect(result.compliance.rrStatus).toBe('CONFORME');
+    });
+
+    it('sem stop + win abaixo do alvo → NAO_CONFORME', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 100, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.rrRatio).toBe(1.25); // 100 / 80 = 1.25
+      expect(result.rrAssumed).toBe(true);
+      expect(result.compliance.rrStatus).toBe('NAO_CONFORME');
+    });
+
+    it('sem stop + loss → RR negativo assumido', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: -200, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.rrRatio).toBe(-2.5); // -200 / 80 = -2.5
+      expect(result.rrAssumed).toBe(true);
+      expect(result.compliance.rrStatus).toBe('NAO_CONFORME');
+    });
+
+    it('sem stop + breakeven → RR = 0 assumido', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 0, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.rrRatio).toBe(0);
+      expect(result.rrAssumed).toBe(true);
+    });
+
+    it('usa plan.pl (base) e NÃO currentPl para RO$', () => {
+      // Plan com currentPl=25000 mas pl=20000
+      const plan = { ...basePlan, currentPl: 25000, pl: 20000 };
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 160, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, plan);
+
+      // RO$ = 20000 * 0.4% = 80 (usa pl, não currentPl)
+      expect(result.rrRatio).toBe(2.0); // 160 / 80
+      expect(result.rrAssumed).toBe(true);
+    });
+
+    it('plan sem riskPerOperation → rrRatio null (não pode calcular)', () => {
+      const plan = { currentPl: 20000, pl: 20000, rrTarget: 2 };
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 200, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, plan);
+
+      expect(result.rrRatio).toBeNull();
+      expect(result.rrAssumed).toBe(false);
+    });
+
+    it('plan com pl=0 → rrRatio null', () => {
+      const plan = { currentPl: 20000, pl: 0, riskPerOperation: 1, rrTarget: 2 };
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 200, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, plan);
+
+      // planPl (currentPl) > 0 so function proceeds, but basePl=0 → can't calc RR
+      expect(result.rrRatio).toBeNull();
+      expect(result.rrAssumed).toBe(false);
+    });
+
+    it('arredonda RR assumido para 2 casas decimais', () => {
+      // RO$ = 20000 * 0.4% = 80, result=100 → 100/80 = 1.25
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 100, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.rrRatio).toBe(1.25);
+    });
+
+    it('com stop → rrAssumed = false (RR real)', () => {
+      const trade = { entry: 5000, stopLoss: 4950, takeProfit: 5100, qty: 1, tickerRule: winfutTicker };
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.rrRatio).toBe(2.0);
+      expect(result.rrAssumed).toBe(false);
+    });
+
+    it('RR assumido funciona para moeda diferente (USD)', () => {
+      // Plan pl=5000 USD, RO=2% → RO$=100, result=250 → RR=2.5
+      const plan = { currentPl: 5500, pl: 5000, riskPerOperation: 2, rrTarget: 2 };
+      const trade = { entry: 15000, qty: 1, stopLoss: null, result: 250 };
+      const result = calculateTradeCompliance(trade, plan);
+
+      expect(result.rrRatio).toBe(2.5);
+      expect(result.rrAssumed).toBe(true);
+      expect(result.compliance.rrStatus).toBe('CONFORME');
+    });
+
+    it('RR assumido gera red flag RR_BELOW_MINIMUM quando abaixo do alvo', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 50, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(compliance.rrRatio).toBe(0.63); // 50/80
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM }));
     });
   });
 

--- a/src/__tests__/utils/compliance.test.js
+++ b/src/__tests__/utils/compliance.test.js
@@ -266,17 +266,18 @@ describe('calculateTradeCompliance', () => {
       expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
     });
 
-    it('sem stop + loss pequeno CONFORME → NO_STOP + RR_BELOW_MINIMUM (DEC-007)', () => {
-      // Loss R$10, 0.05% < 0.4% → RO CONFORME mas NO_STOP present
-      // DEC-007: RR assumido = -10/80 = -0.13 < 2 → RR_BELOW_MINIMUM
+    it('sem stop + loss pequeno CONFORME → NO_STOP only (loss não viola RR)', () => {
+      // Loss R$10, 0.05% < 0.4% → RO CONFORME
+      // DEC-007: RR assumido = -10/80 = -0.13, mas loss → rrStatus CONFORME (não avalia RR em loss)
       const trade = { entry: 5000, qty: 1, stopLoss: null, result: -10, tickerRule: winfutTicker };
       const compliance = calculateTradeCompliance(trade, basePlan);
       const flags = generateComplianceRedFlags(trade, basePlan, compliance);
 
+      expect(compliance.compliance.rrStatus).toBe('CONFORME');
       expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP }));
       expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
-      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM }));
-      expect(flags.length).toBe(2);
+      expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM }));
+      expect(flags.length).toBe(1);
     });
 
     it('com stop CONFORME → NENHUMA flag', () => {
@@ -376,13 +377,13 @@ describe('calculateTradeCompliance', () => {
       expect(result.compliance.rrStatus).toBe('NAO_CONFORME');
     });
 
-    it('sem stop + loss → RR negativo assumido', () => {
+    it('sem stop + loss → RR negativo assumido, CONFORME (loss não viola RR)', () => {
       const trade = { entry: 5000, qty: 1, stopLoss: null, result: -200, tickerRule: winfutTicker };
       const result = calculateTradeCompliance(trade, basePlan);
 
       expect(result.rrRatio).toBe(-2.5); // -200 / 80 = -2.5
       expect(result.rrAssumed).toBe(true);
-      expect(result.compliance.rrStatus).toBe('NAO_CONFORME');
+      expect(result.compliance.rrStatus).toBe('CONFORME'); // loss → não avalia RR
     });
 
     it('sem stop + breakeven → RR = 0 assumido', () => {
@@ -457,6 +458,19 @@ describe('calculateTradeCompliance', () => {
 
       expect(compliance.rrRatio).toBe(0.63); // 50/80
       expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM }));
+    });
+
+    it('RR assumido em loss NÃO gera red flag RR_BELOW_MINIMUM (B1)', () => {
+      // Loss de R$100, RR = -1.25 — mas loss não é violação de RR
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: -100, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(compliance.rrRatio).toBe(-1.25); // -100/80
+      expect(compliance.compliance.rrStatus).toBe('CONFORME');
+      expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RR_BELOW_MINIMUM }));
+      // Deve ter apenas NO_STOP + RISK_EXCEEDED (100/20000=0.5% > 0.4%)
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP }));
     });
   });
 

--- a/src/__tests__/utils/compliance.test.js
+++ b/src/__tests__/utils/compliance.test.js
@@ -1,11 +1,17 @@
 /**
- * Tests: calculateTradeCompliance
+ * Tests: calculateTradeCompliance — DEC-006 (v1.19.1)
  * @description Testa regras de compliance de trade contra plano
  * 
- * Cenários críticos:
- * - T1: Trade sem stop → riskPercent=100%, sem RR calculado
+ * DEC-006 mudou a lógica sem stop:
+ * - Sem stop + loss → riskPercent = |result| / planPl * 100 (retroativo)
+ * - Sem stop + win → riskPercent = null (N/A)
+ * - Sem stop + breakeven → riskPercent = 0
+ * 
+ * Cenários:
+ * - T1: Trade sem stop (DEC-006: loss retroativo, win N/A, breakeven 0)
  * - T2: RO acima do permitido → roStatus FORA_DO_PLANO
  * - RR abaixo do mínimo → rrStatus NAO_CONFORME
+ * - T3: Red flags DEC-006
  * - Edge cases: plan sem PL, trade sem dados, etc.
  */
 
@@ -26,33 +32,96 @@ const winfutTicker = { tickSize: 5, tickValue: 1, pointValue: 0.2 };
 describe('calculateTradeCompliance', () => {
 
   // =============================================
-  // T1: Trade sem stop loss
+  // T1: Trade sem stop loss — DEC-006
   // =============================================
-  describe('T1 — TRADE_SEM_STOP', () => {
-    it('trade sem stopLoss → riskPercent = 100% (pior cenário)', () => {
+  describe('T1 — DEC-006: TRADE_SEM_STOP', () => {
+    it('sem stop + loss → riskPercent = risco retroativo (|result| / planPl)', () => {
+      // Loss de R$200, PL = 20000 → 200/20000 = 1%
       const trade = { 
-        entry: 5000, exit: 5010, qty: 1, side: 'LONG', 
-        stopLoss: null, result: 10, 
+        entry: 5000, exit: 4990, qty: 1, side: 'LONG', 
+        stopLoss: null, result: -200, 
         tickerRule: winfutTicker 
       };
 
       const result = calculateTradeCompliance(trade, basePlan);
 
-      expect(result.riskPercent).toBe(100);
+      expect(result.riskPercent).toBe(1.0);
     });
 
-    it('trade sem stopLoss → roStatus FORA_DO_PLANO (100% > qualquer limite)', () => {
+    it('sem stop + loss pequeno → riskPercent pequeno, CONFORME', () => {
+      // Loss de R$10, PL = 20000 → 10/20000 = 0.05% < 0.4%
       const trade = { 
-        entry: 5000, qty: 1, stopLoss: null, 
+        entry: 5000, qty: 1, stopLoss: null, result: -10,
         tickerRule: winfutTicker 
       };
 
       const result = calculateTradeCompliance(trade, basePlan);
 
+      expect(result.riskPercent).toBe(0.05);
+      expect(result.compliance.roStatus).toBe('CONFORME');
+    });
+
+    it('sem stop + loss grande → riskPercent grande, FORA_DO_PLANO', () => {
+      // Loss de R$500, PL = 20000 → 500/20000 = 2.5% > 0.4%
+      const trade = { 
+        entry: 5000, qty: 1, stopLoss: null, result: -500,
+        tickerRule: winfutTicker 
+      };
+
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.riskPercent).toBe(2.5);
       expect(result.compliance.roStatus).toBe('FORA_DO_PLANO');
     });
 
-    it('trade sem stopLoss → rrRatio null (impossível calcular sem stop)', () => {
+    it('sem stop + win → riskPercent = null (N/A)', () => {
+      const trade = { 
+        entry: 5000, exit: 5010, qty: 1, side: 'LONG', 
+        stopLoss: null, result: 50,
+        tickerRule: winfutTicker 
+      };
+
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.riskPercent).toBeNull();
+    });
+
+    it('sem stop + win → roStatus CONFORME (N/A não penaliza)', () => {
+      const trade = { 
+        entry: 5000, qty: 1, stopLoss: null, result: 50,
+        tickerRule: winfutTicker 
+      };
+
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.compliance.roStatus).toBe('CONFORME');
+    });
+
+    it('sem stop + breakeven (result=0) → riskPercent = 0', () => {
+      const trade = { 
+        entry: 5000, qty: 1, stopLoss: null, result: 0,
+        tickerRule: winfutTicker 
+      };
+
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      expect(result.riskPercent).toBe(0);
+      expect(result.compliance.roStatus).toBe('CONFORME');
+    });
+
+    it('sem stop + result undefined → treat as breakeven', () => {
+      const trade = { 
+        entry: 5000, qty: 1, stopLoss: null,
+        tickerRule: winfutTicker 
+      };
+
+      const result = calculateTradeCompliance(trade, basePlan);
+
+      // result ?? 0 → 0 → breakeven path
+      expect(result.riskPercent).toBe(0);
+    });
+
+    it('sem stopLoss → rrRatio null (impossível calcular sem stop)', () => {
       const trade = { 
         entry: 5000, qty: 1, stopLoss: null, result: 50,
         tickerRule: winfutTicker 
@@ -63,36 +132,24 @@ describe('calculateTradeCompliance', () => {
       expect(result.rrRatio).toBeNull();
     });
 
-    it('trade sem stopLoss → generateComplianceRedFlags inclui TRADE_SEM_STOP', () => {
-      const trade = { entry: 5000, qty: 1, stopLoss: null, tickerRule: winfutTicker };
-      const compliance = calculateTradeCompliance(trade, basePlan);
-      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
-
-      expect(flags).toContainEqual(
-        expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP })
-      );
-    });
-
-    it('trade com stopLoss = 0 (falsy mas numérico) → trata como sem stop', () => {
+    it('stopLoss = 0 (falsy mas numérico) → trata como sem stop, aplica DEC-006', () => {
+      // stopLoss = 0 falsy → sem stop, result = -100 → retroativo = 100/20000 = 0.5%
       const trade = { 
-        entry: 5000, qty: 1, stopLoss: 0, 
+        entry: 5000, qty: 1, stopLoss: 0, result: -100,
         tickerRule: winfutTicker 
       };
 
       const result = calculateTradeCompliance(trade, basePlan);
 
-      // stopLoss = 0 é falsy em JS → cai no else → 100%
-      expect(result.riskPercent).toBe(100);
+      expect(result.riskPercent).toBe(0.5);
     });
   });
 
   // =============================================
-  // T2: Risco Operacional acima do permitido
+  // T2: Risco Operacional com stop (inalterado)
   // =============================================
-  describe('T2 — RISCO_ACIMA_PERMITIDO', () => {
+  describe('T2 — RISCO_ACIMA_PERMITIDO (com stop)', () => {
     it('RO dentro do limite → roStatus CONFORME', () => {
-      // RO = |5000 - 4990| / 5 * 1 * 1 = 2 ticks * R$1 * 1 contrato = R$2
-      // RO% = 2 / 20000 = 0.01% < 0.4% ✓
       const trade = { 
         entry: 5000, stopLoss: 4990, qty: 1, 
         tickerRule: winfutTicker 
@@ -105,9 +162,6 @@ describe('calculateTradeCompliance', () => {
     });
 
     it('RO exatamente no limite → ainda CONFORME (> não >=)', () => {
-      // Precisamos de RO = 0.4% exatamente
-      // 0.4% de R$20.000 = R$80
-      // R$80 = (dist / 5) * 1 * qty → dist=50, qty=8 → (50/5)*1*8 = 80 ✓
       const trade = { 
         entry: 5000, stopLoss: 4950, qty: 8, 
         tickerRule: winfutTicker 
@@ -116,13 +170,10 @@ describe('calculateTradeCompliance', () => {
       const result = calculateTradeCompliance(trade, basePlan);
 
       expect(result.riskPercent).toBeCloseTo(0.4, 2);
-      // 0.4 > 0.4 é false → CONFORME
       expect(result.compliance.roStatus).toBe('CONFORME');
     });
 
     it('RO acima do limite → roStatus FORA_DO_PLANO', () => {
-      // RO = |5000 - 4950| / 5 * 1 * 50 = 10 ticks * R$1 * 50 = R$500
-      // RO% = 500 / 20000 = 2.5% > 0.4% ✗
       const trade = { 
         entry: 5000, stopLoss: 4950, qty: 50,
         tickerRule: winfutTicker 
@@ -149,8 +200,6 @@ describe('calculateTradeCompliance', () => {
     });
 
     it('SHORT trade: distância calculada como abs(entry - stop)', () => {
-      // SHORT: entry 5000, stop 5050 → distância = 50 pts
-      // RO = (50/5) * 1 * 10 = R$100 → 100/20000 = 0.5%
       const trade = { 
         entry: 5000, stopLoss: 5050, qty: 10, side: 'SHORT',
         tickerRule: winfutTicker 
@@ -164,12 +213,81 @@ describe('calculateTradeCompliance', () => {
   });
 
   // =============================================
-  // RR (Risk-Reward)
+  // T3: Red Flags DEC-006
+  // =============================================
+  describe('T3 — Red Flags DEC-006', () => {
+    it('sem stop + loss → red flag NO_STOP com mensagem retroativa', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: -200, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      const noStopFlag = flags.find(f => f.type === RED_FLAG_TYPES.NO_STOP);
+      expect(noStopFlag).toBeTruthy();
+      expect(noStopFlag.message).toContain('risco retroativo');
+      expect(noStopFlag.message).toContain('1.0%');
+    });
+
+    it('sem stop + loss FORA_DO_PLANO → gera AMBAS flags NO_STOP + RISK_EXCEEDED', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: -500, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP }));
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
+    });
+
+    it('sem stop + win → red flag NO_STOP com mensagem "risco não mensurado"', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 50, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      const noStopFlag = flags.find(f => f.type === RED_FLAG_TYPES.NO_STOP);
+      expect(noStopFlag).toBeTruthy();
+      expect(noStopFlag.message).toContain('risco não mensurado');
+    });
+
+    it('sem stop + win → NÃO gera RISK_EXCEEDED (riskPercent null)', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 50, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
+    });
+
+    it('sem stop + breakeven → red flag NO_STOP genérica, sem RISK_EXCEEDED', () => {
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: 0, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP }));
+      expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
+    });
+
+    it('sem stop + loss pequeno CONFORME → NO_STOP sem RISK_EXCEEDED', () => {
+      // Loss R$10, 0.05% < 0.4% → CONFORME mas ainda tem NO_STOP
+      const trade = { entry: 5000, qty: 1, stopLoss: null, result: -10, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(flags).toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.NO_STOP }));
+      expect(flags).not.toContainEqual(expect.objectContaining({ type: RED_FLAG_TYPES.RISK_EXCEEDED }));
+      expect(flags.length).toBe(1);
+    });
+
+    it('com stop CONFORME → NENHUMA flag', () => {
+      const trade = { entry: 5000, stopLoss: 4990, qty: 1, tickerRule: winfutTicker };
+      const compliance = calculateTradeCompliance(trade, basePlan);
+      const flags = generateComplianceRedFlags(trade, basePlan, compliance);
+
+      expect(flags.length).toBe(0);
+    });
+  });
+
+  // =============================================
+  // RR (Risk-Reward) — inalterado
   // =============================================
   describe('Risk-Reward (RR)', () => {
     it('RR via takeProfit acima do target → CONFORME', () => {
-      // risk = |5000 - 4950| = 50 pts
-      // reward = |5100 - 5000| = 100 pts → RR = 2.0 >= 2.0 ✓
       const trade = { 
         entry: 5000, stopLoss: 4950, takeProfit: 5100, qty: 1,
         tickerRule: winfutTicker 
@@ -182,7 +300,6 @@ describe('calculateTradeCompliance', () => {
     });
 
     it('RR via takeProfit abaixo do target → NAO_CONFORME', () => {
-      // risk = 50 pts, reward = 50 pts → RR = 1.0 < 2.0 ✗
       const trade = { 
         entry: 5000, stopLoss: 4950, takeProfit: 5050, qty: 1,
         tickerRule: winfutTicker 
@@ -195,8 +312,6 @@ describe('calculateTradeCompliance', () => {
     });
 
     it('RR via resultado efetivo (sem takeProfit, trade positivo)', () => {
-      // risk = |5000 - 4950| = 50 pts
-      // result = R$20 (positivo) → pts = (20 / (1 * 1)) * 5 = 100 pts → RR = 100/50 = 2.0
       const trade = { 
         entry: 5000, stopLoss: 4950, qty: 1, result: 20,
         tickerRule: winfutTicker 
@@ -219,16 +334,14 @@ describe('calculateTradeCompliance', () => {
     });
 
     it('takeProfit tem prioridade sobre resultado efetivo', () => {
-      // takeProfit diz RR = 2.0, mas result sugeriria diferente
       const trade = { 
         entry: 5000, stopLoss: 4950, takeProfit: 5100, 
-        qty: 1, result: 5,  // resultado diferente do TP
+        qty: 1, result: 5,
         tickerRule: winfutTicker 
       };
 
       const result = calculateTradeCompliance(trade, basePlan);
 
-      // Deve usar takeProfit (planejado), não resultado efetivo
       expect(result.rrRatio).toBe(2.0);
     });
   });
@@ -241,7 +354,7 @@ describe('calculateTradeCompliance', () => {
       const trade = { entry: 5000, stopLoss: 4950, qty: 1 };
       const result = calculateTradeCompliance(trade, null);
 
-      expect(result.riskPercent).toBe(0);
+      expect(result.riskPercent).toBeNull();
       expect(result.rrRatio).toBeNull();
       expect(result.compliance.roStatus).toBe('CONFORME');
     });
@@ -249,7 +362,7 @@ describe('calculateTradeCompliance', () => {
     it('trade null → retorna defaults seguros', () => {
       const result = calculateTradeCompliance(null, basePlan);
 
-      expect(result.riskPercent).toBe(0);
+      expect(result.riskPercent).toBeNull();
       expect(result.compliance.roStatus).toBe('CONFORME');
     });
 
@@ -259,7 +372,7 @@ describe('calculateTradeCompliance', () => {
 
       const result = calculateTradeCompliance(trade, plan);
 
-      expect(result.riskPercent).toBe(0);
+      expect(result.riskPercent).toBeNull();
     });
 
     it('planPl negativo → retorna defaults', () => {
@@ -268,12 +381,11 @@ describe('calculateTradeCompliance', () => {
 
       const result = calculateTradeCompliance(trade, plan);
 
-      expect(result.riskPercent).toBe(0);
+      expect(result.riskPercent).toBeNull();
     });
 
     it('sem tickerRule → usa defaults (tickSize=1, tickValue=1)', () => {
       const trade = { entry: 5000, stopLoss: 4950, qty: 1 };
-      // Sem tickerRule: dist=50, risk=(50/1)*1*1=50, 50/20000=0.25%
 
       const result = calculateTradeCompliance(trade, basePlan);
 
@@ -282,7 +394,7 @@ describe('calculateTradeCompliance', () => {
 
     it('plan sem riskPerOperation → roStatus sempre CONFORME', () => {
       const trade = { entry: 5000, stopLoss: 4950, qty: 50, tickerRule: winfutTicker };
-      const plan = { currentPl: 20000 };  // sem riskPerOperation
+      const plan = { currentPl: 20000 };
 
       const result = calculateTradeCompliance(trade, plan);
 
@@ -293,12 +405,21 @@ describe('calculateTradeCompliance', () => {
     it('plan.currentPl fallback para plan.pl via nullish coalescing', () => {
       const trade = { entry: 5000, stopLoss: 4950, qty: 1, tickerRule: winfutTicker };
       const plan = { pl: 10000, riskPerOperation: 0.4, rrTarget: 2 };
-      // currentPl undefined → usa pl=10000
 
       const result = calculateTradeCompliance(trade, plan);
 
-      // RO = (50/5)*1*1 = R$10 → 10/10000 = 0.1%
       expect(result.riskPercent).toBeCloseTo(0.1, 2);
+    });
+
+    it('sem stop + loss em moeda diferente (USD) → retroativo funciona igual', () => {
+      // Loss USD 100, PL = 5000 → 100/5000 = 2%
+      const trade = { entry: 15000, qty: 1, stopLoss: null, result: -100 };
+      const plan = { currentPl: 5000, riskPerOperation: 1, rrTarget: 2 };
+
+      const result = calculateTradeCompliance(trade, plan);
+
+      expect(result.riskPercent).toBe(2);
+      expect(result.compliance.roStatus).toBe('FORA_DO_PLANO');
     });
   });
 });

--- a/src/__tests__/utils/diagnosePlan.test.js
+++ b/src/__tests__/utils/diagnosePlan.test.js
@@ -1,0 +1,236 @@
+/**
+ * Tests: diagnosePlan — v1.19.1
+ * @description Testa diagnóstico bidirecional de plano (leitura pura)
+ * 
+ * Ida:   PL do plano ← soma dos trades
+ * Volta: Compliance dos trades ← parâmetros do plano
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { calculateTradeCompliance } from '../../utils/compliance';
+
+// ============================================================
+// diagnosePlan é um useCallback dentro de usePlans — para testar
+// a lógica pura sem React, extraímos a essência aqui.
+// ============================================================
+
+/**
+ * Replica a lógica de diagnosePlan para testes puros.
+ * Em produção esta lógica vive em usePlans.diagnosePlan.
+ */
+const diagnosePlanPure = (plan, planTrades) => {
+  const basePl = Number(plan.pl) || 0;
+  const currentPl = Number(plan.currentPl ?? plan.pl) || 0;
+
+  // Ida: PL calculado
+  const totalResult = planTrades.reduce((sum, t) => sum + (Number(t.result) || 0), 0);
+  const calculatedPl = Math.round((basePl + totalResult) * 100) / 100;
+  const plDivergent = Math.abs(currentPl - calculatedPl) > 0.01;
+
+  // Volta: Compliance
+  const divergentTrades = [];
+  for (const trade of planTrades) {
+    const fresh = calculateTradeCompliance(trade, plan);
+    const currentRisk = trade.riskPercent;
+    const newRisk = fresh.riskPercent;
+
+    const riskChanged = currentRisk == null && newRisk != null
+      || currentRisk != null && newRisk == null
+      || (currentRisk != null && newRisk != null && Math.abs(currentRisk - newRisk) > 0.01);
+
+    const currentRR = trade.rrRatio;
+    const newRR = (trade.rrAssumed && fresh.rrRatio == null) ? currentRR : fresh.rrRatio;
+    const rrChanged = currentRR == null && newRR != null
+      || currentRR != null && newRR == null
+      || (currentRR != null && newRR != null && Math.abs(currentRR - newRR) > 0.01);
+
+    const roChanged = (trade.compliance?.roStatus ?? 'CONFORME') !== fresh.compliance.roStatus;
+    const rrStatusChanged = (trade.compliance?.rrStatus ?? 'CONFORME') !== fresh.compliance.rrStatus;
+
+    if (riskChanged || rrChanged || roChanged || rrStatusChanged) {
+      divergentTrades.push({
+        id: trade.id,
+        ticker: trade.ticker || '-',
+        oldRisk: currentRisk != null ? `${currentRisk.toFixed(1)}%` : 'N/A',
+        newRisk: newRisk != null ? `${newRisk.toFixed(1)}%` : 'N/A',
+      });
+    }
+  }
+
+  return {
+    pl: { current: currentPl, calculated: calculatedPl, divergent: plDivergent },
+    trades: { total: planTrades.length, divergent: divergentTrades.length, details: divergentTrades },
+  };
+};
+
+// Fixtures
+const basePlan = {
+  id: 'plan1',
+  pl: 10000,
+  currentPl: 10200,
+  riskPerOperation: 1,
+  rrTarget: 2,
+};
+
+const winfutTicker = { tickSize: 5, tickValue: 1 };
+
+describe('diagnosePlan — diagnóstico bidirecional', () => {
+
+  describe('Ida: PL do plano ← trades', () => {
+    it('PL confere → divergent: false', () => {
+      const plan = { ...basePlan, currentPl: 10200 };
+      const trades = [
+        { id: 't1', planId: 'plan1', result: 200 },
+      ];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.pl.divergent).toBe(false);
+      expect(result.pl.current).toBe(10200);
+      expect(result.pl.calculated).toBe(10200);
+    });
+
+    it('PL divergente → divergent: true com valores corretos', () => {
+      const plan = { ...basePlan, currentPl: 10500 }; // errado
+      const trades = [
+        { id: 't1', planId: 'plan1', result: 200 },
+      ];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.pl.divergent).toBe(true);
+      expect(result.pl.current).toBe(10500);
+      expect(result.pl.calculated).toBe(10200);
+    });
+
+    it('plano sem trades → PL = basePl, confere se currentPl == pl', () => {
+      const plan = { ...basePlan, currentPl: 10000 };
+      const trades = [];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.pl.divergent).toBe(false);
+      expect(result.pl.calculated).toBe(10000);
+      expect(result.trades.total).toBe(0);
+      expect(result.trades.divergent).toBe(0);
+    });
+
+    it('tolerância de centavo → 0.01 diferença não é divergente', () => {
+      const plan = { ...basePlan, currentPl: 10200.005 };
+      const trades = [{ id: 't1', planId: 'plan1', result: 200 }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.pl.divergent).toBe(false);
+    });
+  });
+
+  describe('Volta: Compliance dos trades ← plano', () => {
+    it('trades com compliance atualizado → divergent: 0', () => {
+      const plan = { ...basePlan, currentPl: 10200 };
+      // Trade com stop, compliance já correto
+      // RR via resultado efetivo: result=200, risk=50pts, (200/(1*1))*5=1000pts, 1000/50=20.0
+      const trades = [{
+        id: 't1', planId: 'plan1', result: 200,
+        entry: 5000, stopLoss: 4950, qty: 1,
+        tickerRule: winfutTicker,
+        riskPercent: 0.1, // (50/5)*1*1=10, 10/10000=0.1%
+        rrRatio: 20.0, // resultado efetivo
+        compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.trades.divergent).toBe(0);
+    });
+
+    it('trade pré DEC-006 com riskPercent=100 → detecta divergência', () => {
+      const plan = { ...basePlan, currentPl: 9800 };
+      // Trade sem stop, loss, com riskPercent=100 antigo
+      const trades = [{
+        id: 't1', planId: 'plan1', result: -200,
+        entry: 5000, stopLoss: null, qty: 1,
+        tickerRule: winfutTicker,
+        riskPercent: 100, // antigo, pré DEC-006
+        compliance: { roStatus: 'FORA_DO_PLANO', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.trades.divergent).toBe(1);
+      // Novo riskPercent deveria ser 200/10000 = 2%, não 100%
+      expect(result.trades.details[0].oldRisk).toBe('100.0%');
+      expect(result.trades.details[0].newRisk).toBe('2.0%');
+    });
+
+    it('trade sem stop + win com riskPercent=100 → detecta divergência (deveria ser N/A)', () => {
+      const plan = { ...basePlan, currentPl: 10200 };
+      const trades = [{
+        id: 't1', planId: 'plan1', result: 200,
+        entry: 5000, stopLoss: null, qty: 1,
+        tickerRule: winfutTicker,
+        riskPercent: 100, // antigo
+        compliance: { roStatus: 'FORA_DO_PLANO', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.trades.divergent).toBe(1);
+      expect(result.trades.details[0].oldRisk).toBe('100.0%');
+      expect(result.trades.details[0].newRisk).toBe('N/A');
+    });
+
+    it('trade com rrAssumed → respeita guard, não marca como divergente', () => {
+      const plan = { ...basePlan, currentPl: 10200 };
+      const trades = [{
+        id: 't1', planId: 'plan1', result: 200,
+        entry: 5000, stopLoss: null, qty: 1,
+        tickerRule: winfutTicker,
+        riskPercent: null, // correto DEC-006 win
+        rrRatio: 2.0,
+        rrAssumed: true,
+        compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      // rrAssumed trade: CF guard preserva rrRatio, não diverge
+      expect(result.trades.divergent).toBe(0);
+    });
+  });
+
+  describe('Combinações ida + volta', () => {
+    it('PL divergente + compliance divergente → ambos reportados', () => {
+      const plan = { ...basePlan, currentPl: 10500 }; // PL errado
+      const trades = [{
+        id: 't1', planId: 'plan1', result: -200,
+        entry: 5000, stopLoss: null, qty: 1,
+        riskPercent: 100, // compliance desatualizado
+        compliance: { roStatus: 'FORA_DO_PLANO', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.pl.divergent).toBe(true);
+      expect(result.trades.divergent).toBe(1);
+    });
+
+    it('tudo saudável → pl.divergent false + trades.divergent 0', () => {
+      const plan = { ...basePlan, currentPl: 10200 };
+      // RR via resultado efetivo: 200/(1*1)*5=1000, 1000/50=20.0
+      const trades = [{
+        id: 't1', planId: 'plan1', result: 200,
+        entry: 5000, stopLoss: 4950, qty: 1,
+        tickerRule: winfutTicker,
+        riskPercent: 0.1,
+        rrRatio: 20.0,
+        compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      expect(result.pl.divergent).toBe(false);
+      expect(result.trades.divergent).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/utils/diagnosePlan.test.js
+++ b/src/__tests__/utils/diagnosePlan.test.js
@@ -39,7 +39,7 @@ const diagnosePlanPure = (plan, planTrades) => {
       || (currentRisk != null && newRisk != null && Math.abs(currentRisk - newRisk) > 0.01);
 
     const currentRR = trade.rrRatio;
-    const newRR = (trade.rrAssumed && fresh.rrRatio == null) ? currentRR : fresh.rrRatio;
+    const newRR = fresh.rrRatio;
     const rrChanged = currentRR == null && newRR != null
       || currentRR != null && newRR == null
       || (currentRR != null && newRR != null && Math.abs(currentRR - newRR) > 0.01);
@@ -180,22 +180,43 @@ describe('diagnosePlan — diagnóstico bidirecional', () => {
       expect(result.trades.details[0].newRisk).toBe('N/A');
     });
 
-    it('trade com rrAssumed → respeita guard, não marca como divergente', () => {
+    it('trade com rrAssumed → DEC-007 recalcula, detecta divergência se valor mudou', () => {
       const plan = { ...basePlan, currentPl: 10200 };
+      // RO$ = 10000 * 1% = 100, result=200 → RR assumido = 200/100 = 2.0
       const trades = [{
         id: 't1', planId: 'plan1', result: 200,
         entry: 5000, stopLoss: null, qty: 1,
         tickerRule: winfutTicker,
         riskPercent: null, // correto DEC-006 win
-        rrRatio: 2.0,
+        rrRatio: 2.0,      // matches recalculated value
         rrAssumed: true,
         compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' },
       }];
 
       const result = diagnosePlanPure(plan, trades);
 
-      // rrAssumed trade: CF guard preserva rrRatio, não diverge
+      // RR recalculado = 200 / (10000 * 1%) = 2.0 — matches, no divergence
       expect(result.trades.divergent).toBe(0);
+    });
+
+    it('trade com rrAssumed stale → DEC-007 detecta divergência', () => {
+      const plan = { ...basePlan, currentPl: 10200 };
+      // RO$ = 10000 * 1% = 100, result=200 → RR assumido correto = 2.0
+      // Mas trade gravou -3.14 (valor stale de PL antigo)
+      const trades = [{
+        id: 't1', planId: 'plan1', result: 200,
+        entry: 5000, stopLoss: null, qty: 1,
+        tickerRule: winfutTicker,
+        riskPercent: null,
+        rrRatio: -3.14,    // STALE — was calculated with wrong planPl
+        rrAssumed: true,
+        compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' },
+      }];
+
+      const result = diagnosePlanPure(plan, trades);
+
+      // RR recalculado = 200 / 100 = 2.0, gravado = -3.14 → divergente!
+      expect(result.trades.divergent).toBe(1);
     });
   });
 

--- a/src/__tests__/utils/resultInPointsOverride.test.js
+++ b/src/__tests__/utils/resultInPointsOverride.test.js
@@ -1,0 +1,89 @@
+/**
+ * resultInPointsOverride.test.js
+ * @description Testes para C5 (Issue #78): resultInPoints deve ser null quando há resultOverride.
+ * 
+ * Como useTrades é um hook com dependência do Firestore, testamos a LÓGICA pura:
+ * dado resultOverride e resultInPoints calculados, qual é o valor gravado?
+ * 
+ * A regra é: se resultOverride != null → resultInPoints = null (pontos não representam o override).
+ */
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Extrai a lógica de decisão de resultInPoints do addTrade/updateTrade.
+ * Replica o padrão usado em useTrades.js para ser testável isoladamente.
+ */
+const deriveResultInPoints = ({ resultOverride, calculatedResultInPoints }) => {
+  if (resultOverride != null && !isNaN(parseFloat(resultOverride))) {
+    return null; // C5: pontos não representam o override
+  }
+  return calculatedResultInPoints;
+};
+
+/**
+ * Extrai a lógica de decisão de resultEdited.
+ */
+const deriveResultEdited = ({ resultOverride }) => {
+  return resultOverride != null;
+};
+
+describe('C5 — resultInPoints com resultOverride', () => {
+  it('sem override → resultInPoints mantém valor calculado', () => {
+    const result = deriveResultInPoints({
+      resultOverride: undefined,
+      calculatedResultInPoints: 199,
+    });
+    expect(result).toBe(199);
+  });
+
+  it('sem override (null) → resultInPoints mantém valor calculado', () => {
+    const result = deriveResultInPoints({
+      resultOverride: null,
+      calculatedResultInPoints: -50.5,
+    });
+    expect(result).toBe(-50.5);
+  });
+
+  it('com override numérico → resultInPoints = null', () => {
+    const result = deriveResultInPoints({
+      resultOverride: 200,
+      calculatedResultInPoints: 199,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('com override string numérica → resultInPoints = null', () => {
+    const result = deriveResultInPoints({
+      resultOverride: '200.50',
+      calculatedResultInPoints: 199,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('com override = 0 → resultInPoints = null (zero é override válido)', () => {
+    const result = deriveResultInPoints({
+      resultOverride: 0,
+      calculatedResultInPoints: 199,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('com override negativo → resultInPoints = null', () => {
+    const result = deriveResultInPoints({
+      resultOverride: -150,
+      calculatedResultInPoints: 199,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('sem override → resultEdited = false', () => {
+    expect(deriveResultEdited({ resultOverride: undefined })).toBe(false);
+    expect(deriveResultEdited({ resultOverride: null })).toBe(false);
+  });
+
+  it('com override → resultEdited = true', () => {
+    expect(deriveResultEdited({ resultOverride: 200 })).toBe(true);
+    expect(deriveResultEdited({ resultOverride: 0 })).toBe(true);
+    expect(deriveResultEdited({ resultOverride: '100' })).toBe(true);
+  });
+});

--- a/src/__tests__/utils/tradeCalculations.test.js
+++ b/src/__tests__/utils/tradeCalculations.test.js
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { calculateAssumedRR } from '../../utils/tradeCalculations';
+import { calculateAssumedRR, calculateFromPartials } from '../../utils/tradeCalculations';
 
 describe('calculateAssumedRR', () => {
 
@@ -213,5 +213,106 @@ describe('calculateAssumedRR', () => {
       planRrTarget: 2,
     });
     expect(result.rrRatio).toBe(0.33);
+  });
+});
+
+// ============================================
+// B3: calculateFromPartials — regressão para updateTrade com parciais
+// Simula o fluxo: parciais editadas → recálculo → campos derivados
+// ============================================
+
+describe('calculateFromPartials — B3 regressão', () => {
+
+  it('trade simples LONG: 1 entry + 1 exit → result correto', () => {
+    const partials = [
+      { seq: 1, type: 'ENTRY', price: 1000, qty: 5, dateTime: '2026-03-11T22:50:00' },
+      { seq: 2, type: 'EXIT', price: 1200, qty: 5, dateTime: '2026-03-11T22:51:00' },
+    ];
+    const result = calculateFromPartials({ side: 'LONG', partials });
+
+    expect(result.avgEntry).toBe(1000);
+    expect(result.avgExit).toBe(1200);
+    expect(result.result).toBe(1000); // (1200-1000) * 5
+    expect(result.resultInPoints).toBe(200); // 1200-1000
+    expect(result.realizedQty).toBe(5);
+  });
+
+  it('trade simples SHORT: 1 entry + 1 exit → result correto', () => {
+    const partials = [
+      { seq: 1, type: 'ENTRY', price: 5000, qty: 2, dateTime: '2026-03-11T10:00:00' },
+      { seq: 2, type: 'EXIT', price: 4900, qty: 2, dateTime: '2026-03-11T10:05:00' },
+    ];
+    const result = calculateFromPartials({ side: 'SHORT', partials });
+
+    expect(result.avgEntry).toBe(5000);
+    expect(result.avgExit).toBe(4900);
+    expect(result.result).toBe(200); // (5000-4900) * 2
+    expect(result.resultInPoints).toBe(100); // 5000-4900
+  });
+
+  it('múltiplas entries: preço médio ponderado', () => {
+    const partials = [
+      { seq: 1, type: 'ENTRY', price: 1000, qty: 1 },
+      { seq: 2, type: 'ENTRY', price: 1100, qty: 1 },
+      { seq: 3, type: 'EXIT', price: 1300, qty: 2 },
+    ];
+    const result = calculateFromPartials({ side: 'LONG', partials });
+
+    expect(result.avgEntry).toBe(1050); // (1000*1 + 1100*1) / 2
+    expect(result.avgExit).toBe(1300);
+    expect(result.result).toBe(500); // (1300-1050) * 2
+    expect(result.realizedQty).toBe(2);
+  });
+
+  it('parciais editadas (preço mudou) → recálculo reflete novo valor', () => {
+    // Cenário B3: usuário editou preço de saída de 840 para 900
+    const partialsOriginal = [
+      { seq: 1, type: 'ENTRY', price: 1000, qty: 5 },
+      { seq: 2, type: 'EXIT', price: 840, qty: 5 },
+    ];
+    const partialsEditadas = [
+      { seq: 1, type: 'ENTRY', price: 1000, qty: 5 },
+      { seq: 2, type: 'EXIT', price: 900, qty: 5 },
+    ];
+
+    const original = calculateFromPartials({ side: 'LONG', partials: partialsOriginal });
+    const editado = calculateFromPartials({ side: 'LONG', partials: partialsEditadas });
+
+    expect(original.result).toBe(-800); // (840-1000) * 5
+    expect(editado.result).toBe(-500);  // (900-1000) * 5
+    expect(editado.avgExit).toBe(900);
+    expect(editado.resultInPoints).toBe(-100); // 900-1000
+  });
+
+  it('com tickerRule: resultado usa tickSize/tickValue', () => {
+    const winfutTicker = { tickSize: 5, tickValue: 1, pointValue: 0.2 };
+    const partials = [
+      { seq: 1, type: 'ENTRY', price: 130000, qty: 1 },
+      { seq: 2, type: 'EXIT', price: 130100, qty: 1 },
+    ];
+    const result = calculateFromPartials({ side: 'LONG', partials, tickerRule: winfutTicker });
+
+    // 100pts / 5 tickSize = 20 ticks * 1 tickValue * 1 qty = R$20
+    expect(result.result).toBe(20);
+    expect(result.resultInPoints).toBe(100);
+  });
+
+  it('sem parciais → resultado vazio', () => {
+    const result = calculateFromPartials({ side: 'LONG', partials: [] });
+
+    expect(result.result).toBe(0);
+    expect(result.avgEntry).toBe(0);
+    expect(result.avgExit).toBe(0);
+  });
+
+  it('entryTime/exitTime derivados das parciais', () => {
+    const partials = [
+      { seq: 1, type: 'ENTRY', price: 1000, qty: 5, dateTime: '2026-03-11T22:50:00' },
+      { seq: 2, type: 'EXIT', price: 1200, qty: 5, dateTime: '2026-03-11T22:55:00' },
+    ];
+    const result = calculateFromPartials({ side: 'LONG', partials });
+
+    expect(result.entryTime).toBe('2026-03-11T22:50:00');
+    expect(result.exitTime).toBe('2026-03-11T22:55:00');
   });
 });

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -266,12 +266,14 @@ const TradeDetailModal = ({
                 }`}>
                   {isWin ? '+' : ''}{formatCurrency(trade.result, tradeCurrency)}
                 </p>
-                {trade.resultInPoints != null && (
+                {trade.resultInPoints != null ? (
                   <p className={`text-sm font-mono ${
                     isWin ? 'text-emerald-400/70' : 'text-red-400/70'
                   }`}>
                     {trade.resultInPoints >= 0 ? '+' : ''}{trade.resultInPoints} pts
                   </p>
+                ) : trade.resultEdited && (
+                  <p className="text-sm font-mono text-slate-500 italic">pts: editado</p>
                 )}
                 <p className={`text-xs ${
                   isWin ? 'text-emerald-400/50' : 'text-red-400/50'
@@ -425,8 +427,10 @@ const TradeDetailModal = ({
                         {trade.avgExit != null && (
                           <span className="text-slate-400">Média Saída: <strong className="text-white font-mono">{trade.avgExit}</strong></span>
                         )}
-                        {trade.resultInPoints != null && (
+                        {trade.resultInPoints != null ? (
                           <span className="text-slate-400">Pontos: <strong className={`font-mono ${trade.resultInPoints >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{trade.resultInPoints >= 0 ? '+' : ''}{trade.resultInPoints}</strong></span>
+                        ) : trade.resultEdited && (
+                          <span className="text-slate-500 italic">Pontos: editado</span>
                         )}
                         <span className="text-slate-400">Resultado: <strong className={`font-mono ${isWin ? 'text-emerald-400' : 'text-red-400'}`}>{formatCurrency(trade.result, tradeCurrency)}</strong></span>
                       </div>

--- a/src/components/dashboard/PlanAuditModal.jsx
+++ b/src/components/dashboard/PlanAuditModal.jsx
@@ -1,0 +1,317 @@
+/**
+ * PlanAuditModal
+ * @version 1.0.0 (v1.19.1)
+ * @description Modal de auditoria bidirecional do plano.
+ *   Ida: PL do plano ← soma dos trades
+ *   Volta: Compliance dos trades ← parâmetros do plano (RO%, RR)
+ * 
+ * Fluxo: Abrir → Diagnosticar (leitura) → Saudável | Divergente → Corrigir (escrita)
+ */
+
+import { useState } from 'react';
+import {
+  ShieldCheck, AlertTriangle, CheckCircle2, ArrowRight,
+  RefreshCw, X, ChevronDown, ChevronUp, Loader2
+} from 'lucide-react';
+import { formatCurrencyDynamic } from '../../utils/currency';
+import DebugBadge from '../DebugBadge';
+
+const STATES = {
+  IDLE: 'idle',
+  DIAGNOSING: 'diagnosing',
+  HEALTHY: 'healthy',
+  DIVERGENT: 'divergent',
+  FIXING: 'fixing',
+  FIXED: 'fixed',
+};
+
+const Spinner = ({ message }) => (
+  <div className="flex flex-col items-center justify-center py-8 gap-3">
+    <Loader2 className="w-8 h-8 text-blue-400 animate-spin" />
+    {message && <p className="text-xs text-slate-500">{message}</p>}
+  </div>
+);
+
+const PLComparison = ({ pl, currency }) => {
+  const diff = pl.calculated - pl.current;
+  return (
+    <div className={`rounded-xl border p-4 ${pl.divergent ? 'border-amber-500/40 bg-amber-500/5' : 'border-emerald-500/30 bg-emerald-500/5'}`}>
+      <div className="flex items-center gap-2 mb-3">
+        {pl.divergent ? (
+          <AlertTriangle className="w-4 h-4 text-amber-400" />
+        ) : (
+          <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+        )}
+        <span className="text-xs font-bold uppercase tracking-wider text-slate-300">
+          PL do Plano {pl.divergent ? '— Divergente' : '— Confere'}
+        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="flex-1">
+          <span className="text-[10px] text-slate-500 uppercase block mb-0.5">PL Atual</span>
+          <span className={`text-lg font-mono font-bold ${pl.divergent ? 'text-amber-400' : 'text-slate-300'}`}>
+            {formatCurrencyDynamic(pl.current, currency)}
+          </span>
+        </div>
+        <ArrowRight className="w-4 h-4 text-slate-600" />
+        <div className="flex-1">
+          <span className="text-[10px] text-slate-500 uppercase block mb-0.5">PL Calculado (Trades)</span>
+          <span className="text-lg font-mono font-bold text-emerald-400">
+            {formatCurrencyDynamic(pl.calculated, currency)}
+          </span>
+        </div>
+      </div>
+      {pl.divergent && (
+        <div className="mt-2 text-xs text-amber-400/80 font-mono">
+          Diferença: {diff > 0 ? '+' : ''}{formatCurrencyDynamic(diff, currency)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const TradesDiagnostic = ({ trades, currency, expanded, onToggle }) => {
+  const allGood = trades.divergent === 0;
+  return (
+    <div className={`rounded-xl border p-4 ${allGood ? 'border-emerald-500/30 bg-emerald-500/5' : 'border-amber-500/40 bg-amber-500/5'}`}>
+      <div className="flex items-center justify-between cursor-pointer" onClick={onToggle}>
+        <div className="flex items-center gap-2">
+          {allGood ? (
+            <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+          ) : (
+            <AlertTriangle className="w-4 h-4 text-amber-400" />
+          )}
+          <span className="text-xs font-bold uppercase tracking-wider text-slate-300">
+            Compliance dos Trades
+            {allGood
+              ? ' — Todos atualizados'
+              : ` — ${trades.divergent} de ${trades.total} desatualizados`}
+          </span>
+        </div>
+        {!allGood && (
+          expanded ? <ChevronUp className="w-4 h-4 text-slate-500" /> : <ChevronDown className="w-4 h-4 text-slate-500" />
+        )}
+      </div>
+
+      {!allGood && expanded && (
+        <div className="mt-3 space-y-2">
+          <div className="grid grid-cols-[50px_70px_1fr_80px_80px] gap-2 text-[10px] text-slate-500 uppercase font-bold px-2">
+            <span>Data</span>
+            <span>Ativo</span>
+            <span>Motivo</span>
+            <span>RO Atual</span>
+            <span>RO Novo</span>
+          </div>
+          {trades.details.map((t, idx) => (
+            <div
+              key={t.id || idx}
+              className="grid grid-cols-[50px_70px_1fr_80px_80px] gap-2 items-center text-xs px-2 py-1.5 rounded-lg bg-slate-800/50 border border-slate-700/30"
+            >
+              <span className="text-slate-400 font-mono">{t.date}</span>
+              <span className="text-slate-300 font-bold">{t.ticker}</span>
+              <span className="text-amber-400/80">{t.reason}</span>
+              <span className="text-red-400 font-mono line-through">{t.oldRisk}</span>
+              <span className="text-emerald-400 font-mono">{t.newRisk}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const PlanAuditModal = ({
+  isOpen,
+  onClose,
+  planName,
+  currency = 'BRL',
+  onDiagnose,
+  onFix,
+}) => {
+  const [state, setState] = useState(STATES.IDLE);
+  const [data, setData] = useState(null);
+  const [expanded, setExpanded] = useState(true);
+  const [progressMsg, setProgressMsg] = useState('');
+
+  if (!isOpen) return null;
+
+  const hasDivergence = data && (data.pl.divergent || data.trades.divergent > 0);
+
+  const handleDiagnose = async () => {
+    setState(STATES.DIAGNOSING);
+    setProgressMsg('Analisando trades e compliance...');
+    try {
+      const result = await onDiagnose();
+      setData(result);
+      setState(result.pl.divergent || result.trades.divergent > 0
+        ? STATES.DIVERGENT
+        : STATES.HEALTHY
+      );
+    } catch (err) {
+      console.error('[PlanAuditModal] Erro diagnóstico:', err);
+      setState(STATES.IDLE);
+      setData(null);
+    }
+  };
+
+  const handleFix = async () => {
+    setState(STATES.FIXING);
+    setProgressMsg('Corrigindo divergências...');
+    try {
+      const report = await onFix();
+      // Re-diagnose to show updated state
+      setData({
+        pl: { current: report.newPl, calculated: report.newPl, divergent: false },
+        trades: { total: data?.trades?.total ?? 0, divergent: 0, details: [] },
+      });
+      setState(STATES.FIXED);
+    } catch (err) {
+      console.error('[PlanAuditModal] Erro correção:', err);
+      setState(STATES.DIVERGENT); // volta ao estado divergente
+    }
+  };
+
+  const handleClose = () => {
+    setState(STATES.IDLE);
+    setData(null);
+    setProgressMsg('');
+    setExpanded(true);
+    onClose();
+  };
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-slate-950/80 backdrop-blur-sm z-50"
+        onClick={handleClose}
+      />
+      {/* Modal */}
+      <div className="fixed inset-4 md:inset-8 lg:inset-12 z-[51] flex items-center justify-center pointer-events-none">
+        <div className="glass-card w-full max-w-lg pointer-events-auto flex flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 py-4 border-b border-slate-700/50">
+            <div className="flex items-center gap-3">
+              <div className={`w-9 h-9 rounded-xl flex items-center justify-center ${
+                state === STATES.HEALTHY || state === STATES.FIXED
+                  ? 'bg-emerald-500/15 border border-emerald-500/30'
+                  : state === STATES.DIVERGENT
+                  ? 'bg-amber-500/15 border border-amber-500/30'
+                  : 'bg-slate-700/50 border border-slate-600/30'
+              }`}>
+                <ShieldCheck className={`w-5 h-5 ${
+                  state === STATES.HEALTHY || state === STATES.FIXED
+                    ? 'text-emerald-400'
+                    : state === STATES.DIVERGENT
+                    ? 'text-amber-400'
+                    : 'text-slate-400'
+                }`} />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-slate-200">Auditoria & Saúde</h3>
+                <p className="text-xs text-slate-500">{planName}</p>
+              </div>
+            </div>
+            <button onClick={handleClose} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-700/50 transition-colors">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="px-5 py-4 space-y-3 max-h-[60vh] overflow-y-auto">
+            {state === STATES.IDLE && (
+              <div className="text-center py-6">
+                <ShieldCheck className="w-12 h-12 text-slate-600 mx-auto mb-3" />
+                <p className="text-sm text-slate-400 mb-1">Verificar integridade do plano</p>
+                <p className="text-xs text-slate-600">Compara PL e compliance contra os trades registrados</p>
+              </div>
+            )}
+
+            {(state === STATES.DIAGNOSING || state === STATES.FIXING) && (
+              <Spinner message={progressMsg} />
+            )}
+
+            {state === STATES.HEALTHY && data && (
+              <>
+                <div className="flex items-center gap-2 p-3 rounded-xl bg-emerald-500/10 border border-emerald-500/20">
+                  <CheckCircle2 className="w-5 h-5 text-emerald-400 flex-shrink-0" />
+                  <p className="text-sm text-emerald-300">Plano saudável. PL e compliance conferem.</p>
+                </div>
+                <PLComparison pl={data.pl} currency={currency} />
+                <TradesDiagnostic trades={data.trades} currency={currency} expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+              </>
+            )}
+
+            {state === STATES.FIXED && data && (
+              <>
+                <div className="flex items-center gap-2 p-3 rounded-xl bg-emerald-500/10 border border-emerald-500/20">
+                  <CheckCircle2 className="w-5 h-5 text-emerald-400 flex-shrink-0" />
+                  <p className="text-sm text-emerald-300">Divergências corrigidas. Plano saudável.</p>
+                </div>
+                <PLComparison pl={data.pl} currency={currency} />
+                <TradesDiagnostic trades={data.trades} currency={currency} expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+              </>
+            )}
+
+            {state === STATES.DIVERGENT && data && (
+              <>
+                <div className="flex items-center gap-2 p-3 rounded-xl bg-amber-500/10 border border-amber-500/20">
+                  <AlertTriangle className="w-5 h-5 text-amber-400 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm text-amber-300">Divergências encontradas</p>
+                    <p className="text-xs text-amber-400/60 mt-0.5">
+                      {data.pl.divergent && data.trades.divergent > 0
+                        ? 'PL e compliance desatualizados'
+                        : data.pl.divergent
+                        ? 'PL do plano divergente'
+                        : `${data.trades.divergent} trade(s) com compliance desatualizado`}
+                    </p>
+                  </div>
+                </div>
+                <PLComparison pl={data.pl} currency={currency} />
+                <TradesDiagnostic trades={data.trades} currency={currency} expanded={expanded} onToggle={() => setExpanded(!expanded)} />
+              </>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-2 px-5 py-3 border-t border-slate-700/50">
+            {state === STATES.IDLE && (
+              <>
+                <button onClick={handleClose} className="px-4 py-2 rounded-xl text-sm text-slate-400 hover:text-slate-300 hover:bg-slate-700/50 transition-colors">
+                  Cancelar
+                </button>
+                <button onClick={handleDiagnose} className="px-4 py-2 rounded-xl text-sm font-bold text-white bg-blue-600 hover:bg-blue-500 transition-colors flex items-center gap-2">
+                  <ShieldCheck className="w-4 h-4" />
+                  Diagnosticar
+                </button>
+              </>
+            )}
+
+            {(state === STATES.HEALTHY || state === STATES.FIXED) && (
+              <button onClick={handleClose} className="px-4 py-2 rounded-xl text-sm font-bold text-emerald-400 hover:bg-emerald-500/10 transition-colors">
+                Fechar
+              </button>
+            )}
+
+            {state === STATES.DIVERGENT && (
+              <>
+                <button onClick={handleClose} className="px-4 py-2 rounded-xl text-sm text-slate-400 hover:text-slate-300 hover:bg-slate-700/50 transition-colors">
+                  Ignorar
+                </button>
+                <button onClick={handleFix} className="px-4 py-2 rounded-xl text-sm font-bold text-white bg-amber-600 hover:bg-amber-500 transition-colors flex items-center gap-2">
+                  <RefreshCw className="w-4 h-4" />
+                  Corrigir Divergências
+                </button>
+              </>
+            )}
+          </div>
+
+          <DebugBadge component="PlanAuditModal" />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PlanAuditModal;

--- a/src/components/dashboard/PlanAuditModal.jsx
+++ b/src/components/dashboard/PlanAuditModal.jsx
@@ -159,15 +159,31 @@ const PlanAuditModal = ({
     setProgressMsg('Corrigindo divergências...');
     try {
       const report = await onFix();
-      // Re-diagnose to show updated state
+      if (!report) throw new Error('auditPlan não retornou relatório');
+      // Forçar estado FIXED — não re-diagnosticar porque o listener
+      // do useTrades pode não ter propagado ainda os novos valores
       setData({
         pl: { current: report.newPl, calculated: report.newPl, divergent: false },
-        trades: { total: data?.trades?.total ?? 0, divergent: 0, details: [] },
+        trades: {
+          total: data?.trades?.total ?? 0,
+          divergent: 0,
+          details: [],
+        },
+        fixReport: {
+          oldPl: report.oldPl,
+          newPl: report.newPl,
+          complianceUpdated: report.complianceUpdated,
+        },
       });
       setState(STATES.FIXED);
     } catch (err) {
       console.error('[PlanAuditModal] Erro correção:', err);
-      setState(STATES.DIVERGENT); // volta ao estado divergente
+      setProgressMsg(`Erro ao corrigir: ${err.message}`);
+      // Manter no estado FIXING por 2s para mostrar o erro, depois volta
+      setTimeout(() => {
+        setProgressMsg('');
+        setState(STATES.DIVERGENT);
+      }, 3000);
     }
   };
 
@@ -246,7 +262,14 @@ const PlanAuditModal = ({
               <>
                 <div className="flex items-center gap-2 p-3 rounded-xl bg-emerald-500/10 border border-emerald-500/20">
                   <CheckCircle2 className="w-5 h-5 text-emerald-400 flex-shrink-0" />
-                  <p className="text-sm text-emerald-300">Divergências corrigidas. Plano saudável.</p>
+                  <div>
+                    <p className="text-sm text-emerald-300">Divergências corrigidas. Plano saudável.</p>
+                    {data.fixReport && (
+                      <p className="text-xs text-emerald-400/60 mt-0.5">
+                        {data.fixReport.complianceUpdated} trade(s) recalculados
+                      </p>
+                    )}
+                  </div>
                 </div>
                 <PLComparison pl={data.pl} currency={currency} />
                 <TradesDiagnostic trades={data.trades} currency={currency} expanded={expanded} onToggle={() => setExpanded(!expanded)} />
@@ -275,7 +298,9 @@ const PlanAuditModal = ({
           </div>
 
           {/* Footer */}
-          <div className="flex justify-end gap-2 px-5 py-3 border-t border-slate-700/50">
+          <div className="flex items-center justify-between px-5 py-3 border-t border-slate-700/50">
+            <DebugBadge component="PlanAuditModal" />
+            <div className="flex gap-2">
             {state === STATES.IDLE && (
               <>
                 <button onClick={handleClose} className="px-4 py-2 rounded-xl text-sm text-slate-400 hover:text-slate-300 hover:bg-slate-700/50 transition-colors">
@@ -305,9 +330,8 @@ const PlanAuditModal = ({
                 </button>
               </>
             )}
+            </div>
           </div>
-
-          <DebugBadge component="PlanAuditModal" />
         </div>
       </div>
     </>

--- a/src/components/dashboard/PlanCardGrid.jsx
+++ b/src/components/dashboard/PlanCardGrid.jsx
@@ -1,7 +1,8 @@
 /**
  * PlanCardGrid
- * @version 2.0.0 (v1.16.0)
+ * @version 2.1.0 (v1.19.1)
  * @description Grid de cards de planos operacionais.
+ *   v2.1.0: Botão de auditoria (ShieldCheck) — recalcula PL + compliance cascata.
  *   v2.0.0: Integra planStateMachine para badges e sentiment icons.
  *   v1.0.0: Extraído do StudentDashboard (v1.15.0).
  *
@@ -15,7 +16,7 @@
 import {
   PlusCircle, Check, Settings, Trash2, RefreshCw, Calendar, ScrollText,
   Skull, Trophy, TrendingUp, TrendingDown, Smile, Frown, Meh,
-  AlertTriangle, Activity
+  AlertTriangle, Activity, ShieldCheck
 } from 'lucide-react';
 import { formatCurrencyDynamic } from '../../utils/currency';
 import { calculatePeriodPnL, calculateCyclePnL } from '../../utils/planCalculations';
@@ -86,6 +87,7 @@ const PlanCardGrid = ({
   onEditPlan,
   onDeletePlan,
   onCreatePlan,
+  onAuditPlan,
 }) => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
@@ -133,8 +135,11 @@ const PlanCardGrid = ({
               <button onClick={(e) => { e.stopPropagation(); onOpenLedger(plan); }} className="p-1.5 rounded-lg text-slate-400 hover:text-purple-400 hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100" title="Extrato Emocional"><ScrollText className="w-4 h-4" /></button>
               {!viewAs && (
                 <>
-                  <button onClick={(e) => { e.stopPropagation(); onEditPlan(plan); }} className="p-1.5 rounded-lg text-slate-400 hover:text-white hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100"><Settings className="w-4 h-4" /></button>
-                  <button onClick={(e) => onDeletePlan(e, plan.id)} className="p-1.5 rounded-lg text-slate-400 hover:text-red-400 hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100"><Trash2 className="w-4 h-4" /></button>
+                  <button onClick={(e) => { e.stopPropagation(); onEditPlan(plan); }} className="p-1.5 rounded-lg text-slate-400 hover:text-white hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100" title="Editar Plano"><Settings className="w-4 h-4" /></button>
+                  <button onClick={(e) => onDeletePlan(e, plan.id)} className="p-1.5 rounded-lg text-slate-400 hover:text-red-400 hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100" title="Excluir Plano"><Trash2 className="w-4 h-4" /></button>
+                  {onAuditPlan && (
+                    <button onClick={(e) => { e.stopPropagation(); onAuditPlan(plan.id); }} className="p-1.5 rounded-lg text-slate-400 hover:text-emerald-400 hover:bg-slate-700 transition-colors opacity-0 group-hover:opacity-100" title="Auditoria & Saúde"><ShieldCheck className="w-4 h-4" /></button>
+                  )}
                 </>
               )}
             </div>

--- a/src/components/extract/ExtractCycleCard.jsx
+++ b/src/components/extract/ExtractCycleCard.jsx
@@ -65,6 +65,14 @@ const ExtractCycleCard = ({
   const resultPct = startPL > 0 ? (cycleSummary.totalPnL / startPL) * 100 : 0;
   const critical = isCriticalStatus(cycleState.status);
 
+  // B9: Gauge mostra dados do período selecionado, ou ciclo se nenhum selecionado
+  const selectedPeriodState = selectedPeriod && selectedPeriod !== 'CICLO'
+    ? cycleState.periods.get(selectedPeriod)
+    : null;
+  const gaugeSummary = selectedPeriodState ? selectedPeriodState.summary : cycleSummary;
+  const gaugeStatus = selectedPeriodState ? selectedPeriodState.status : cycleState.status;
+  const gaugeLabel = selectedPeriodState ? fmtPeriodLabel(selectedPeriod, operationPeriod) : 'Ciclo';
+
   return (
     <div className="flex flex-col h-full">
       {/* Header + resultado */}
@@ -72,7 +80,7 @@ const ExtractCycleCard = ({
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-1.5">
             <Target className="w-3.5 h-3.5 text-purple-400" />
-            <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">Ciclo</span>
+            <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">{gaugeLabel}</span>
           </div>
           <div className="flex items-center gap-2 text-[10px] text-slate-500 font-mono">
             <span>{cycleSummary.tradesCount}t</span>
@@ -91,12 +99,12 @@ const ExtractCycleCard = ({
           </div>
         )}
 
-        {/* Velocímetro */}
+        {/* Velocímetro — segue o período selecionado */}
         <GaugeChart
-          pnl={cycleSummary.totalPnL}
-          goalVal={cycleSummary.goalVal}
-          stopVal={cycleSummary.stopVal}
-          status={cycleState.status}
+          pnl={gaugeSummary.totalPnL}
+          goalVal={gaugeSummary.goalVal}
+          stopVal={gaugeSummary.stopVal}
+          status={gaugeStatus}
           fmt={fmt}
         />
       </div>

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -1,19 +1,17 @@
 /**
  * ExtractTable
- * @version 4.0.0 (v1.19.3)
- * @description Tabela do extrato com colunas de sanity check (RO, RR, Emoção)
- *   e marcação visual para POST_GOAL/POST_STOP.
+ * @version 4.1.0 (v1.19.3)
+ * @description Tabela compacta do extrato — redesenhada para caber em telas de mentoria.
+ *   v4.1.0: Grid compactado — emoção só emoji (tooltip nome), status+feedback fundidos,
+ *           padding reduzido, side como superscript, RO sem texto "S/Stop" (só ícone).
  *   v4.0.0: Coluna Status Feedback (OPEN/REVIEWED/QUESTION/CLOSED), RR com 2 casas decimais (C3).
  *   v3.0.0: RR assumido com badge "(assumido)", botão feedback por trade (B4 — Issue #71/#73).
- *   v2.0.0: Coluna Evento agora mostra eventos emocionais e compliance inline
- *           (TILT, REVENGE, NO_STOP, RO_FORA, RR_FORA) além dos eventos de state machine.
- *   v1.0.0: Apenas eventos de state machine (GOAL_HIT, STOP_HIT, POST_GOAL, POST_STOP).
  *   Ordem: cronológica (mais antigo no topo).
  */
 
 import {
   Trophy, Skull, ShieldAlert, ShieldOff, Scale,
-  Flame, Zap, AlertTriangle, MessageSquare,
+  Flame, Zap, AlertTriangle,
   CircleDot, CheckCircle2, HelpCircle, CheckCheck
 } from 'lucide-react';
 import { PERIOD_STATES } from '../../utils/planStateMachine';
@@ -62,7 +60,7 @@ const getTradeInlineEvents = (row, emotionalEvents) => {
     events.push({ icon: null, color: 'text-red-500/70', label: 'Violação', small: true });
   }
 
-  // 1b. Cycle events (se este trade causou cycle goal/stop) — cor diferenciada
+  // 1b. Cycle events
   if (row.cycleEvent === 'CYCLE_GOAL_HIT') {
     events.push({ icon: Trophy, color: 'text-yellow-400', label: 'META!', sublabel: 'Ciclo' });
   } else if (row.cycleEvent === 'CYCLE_STOP_HIT') {
@@ -72,15 +70,12 @@ const getTradeInlineEvents = (row, emotionalEvents) => {
   // 2. Emotional events (TILT, REVENGE matched by tradeId or proximity)
   if (emotionalEvents) {
     const tradeEmotionalEvents = emotionalEvents.filter(e => {
-      // Match por tradeId direto se disponível
       if (e.tradeId && e.tradeId === trade.id) return true;
-      // Match por data/hora (TILT/REVENGE detectados próximos ao trade)
       if (e.date === trade.date) return true;
       return false;
     });
     for (const ee of tradeEmotionalEvents) {
       if (ee.type === 'TILT_DETECTED' || ee.type === 'TILT') {
-        // Evitar duplicata se já adicionado
         if (!events.some(ev => ev.label === 'TILT')) {
           events.push({ icon: Flame, color: 'text-orange-400', label: 'TILT', small: true });
         }
@@ -127,35 +122,35 @@ const getFeedbackStatusConfig = (status) => {
  */
 const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEvents = [], planRiskInfo = null, onNavigateToFeedback = null }) => {
   const displayRows = rows;
+  // Colunas fixas: #, Data, Ativo, Emo, RO, RR, Resultado, Acumulado, Evento, Status = 10
+  const totalCols = 10;
 
   return (
     <div className="flex-1 overflow-auto">
       <table className="w-full text-sm text-left border-collapse">
         <thead className="bg-slate-800/80 text-[10px] uppercase text-slate-500 sticky top-0 z-10 font-bold tracking-wider">
           <tr>
-            <th className="p-3 w-10 text-center">#</th>
-            <th className="p-3">Data</th>
-            <th className="p-3">Ativo</th>
-            <th className="p-3">Emoção</th>
-            <th className="p-3 text-right">RO %</th>
-            <th className="p-3 text-right">RR</th>
-            <th className="p-3 text-right">Resultado</th>
-            <th className="p-3 text-right bg-slate-800/50">Acumulado</th>
-            <th className="p-3 text-center w-32">Evento</th>
-            <th className="p-3 text-center w-20">Status</th>
-            {onNavigateToFeedback && <th className="p-3 text-center w-10"></th>}
+            <th className="px-2 py-2 w-8 text-center">#</th>
+            <th className="px-2 py-2">Data</th>
+            <th className="px-2 py-2">Ativo</th>
+            <th className="px-2 py-2 text-center w-14">Emo</th>
+            <th className="px-2 py-2 text-right">RO</th>
+            <th className="px-2 py-2 text-right">RR</th>
+            <th className="px-2 py-2 text-right">Resultado</th>
+            <th className="px-2 py-2 text-right bg-slate-800/50">Acum.</th>
+            <th className="px-2 py-2 text-center">Evento</th>
+            <th className="px-2 py-2 text-center w-20">Status</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-800/50">
           {/* Saldo anterior — primeira linha quando há carry-over */}
           {carryOver !== 0 && displayRows.length > 0 && (
             <tr className="bg-slate-800/20 border-b-2 border-slate-700 border-dashed">
-              <td className="p-3 text-center text-slate-600 font-mono text-xs">—</td>
-              <td colSpan={onNavigateToFeedback ? 8 : 7} className="p-3 text-slate-500 italic text-xs">Saldo anterior (períodos anteriores)</td>
-              <td className={`p-3 text-right font-mono font-bold text-xs bg-slate-800/30 border-l border-slate-800 ${carryOver >= 0 ? 'text-emerald-400/60' : 'text-red-400/60'}`}>
+              <td className="px-2 py-2 text-center text-slate-600 font-mono text-xs">—</td>
+              <td colSpan={totalCols - 2} className="px-2 py-2 text-slate-500 italic text-xs">Saldo anterior (períodos anteriores)</td>
+              <td className={`px-2 py-2 text-right font-mono font-bold text-xs bg-slate-800/30 border-l border-slate-800 ${carryOver >= 0 ? 'text-emerald-400/60' : 'text-red-400/60'}`}>
                 {fmt(carryOver)}
               </td>
-              {onNavigateToFeedback && <td className="p-3"></td>}
             </tr>
           )}
           {displayRows.map((row) => {
@@ -166,12 +161,13 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
             // Emoção
             const emotionCfg = getEmotionConfig ? getEmotionConfig(trade.emotionEntry) : null;
             const emoji = emotionCfg?.emoji || '❓';
-            const emotionName = emotionCfg?.name || trade.emotionEntry || '-';
+            const emotionName = emotionCfg?.name || emotionCfg?.label || trade.emotionEntry || '-';
             const emotionCategory = emotionCfg?.analysisCategory || 'NEUTRAL';
 
             // Emoção de saída
             const exitCfg = getEmotionConfig ? getEmotionConfig(trade.emotionExit) : null;
             const exitEmoji = exitCfg?.emoji || '';
+            const exitName = exitCfg?.name || exitCfg?.label || trade.emotionExit || '';
 
             // Compliance
             const riskPercent = trade.riskPercent != null ? `${Number(trade.riskPercent).toFixed(1)}%` : '-';
@@ -187,7 +183,6 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
             if (trade.rrRatio != null) {
               rrDisplay = `${Number(trade.rrRatio).toFixed(2)}:1`;
             } else if (planRiskInfo && !trade.stopLoss) {
-              // Fallback: trades antigos sem rrRatio gravado
               const assumed = calculateAssumedRR({
                 result: trade.result ?? 0,
                 planPl: planRiskInfo.pl,
@@ -199,11 +194,14 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
                 rrDisplay = `${assumed.rrRatio.toFixed(2)}:1`;
               }
             }
-            // RR compliance: loss não é violação (B1)
             const rrNonCompliant = trade.compliance?.rrStatus === 'NAO_CONFORME';
 
             // Inline events
             const inlineEvents = getTradeInlineEvents(row, emotionalEvents);
+
+            // Feedback status
+            const fbCfg = getFeedbackStatusConfig(trade.status);
+            const FbIcon = fbCfg.icon;
 
             return (
               <tr
@@ -213,85 +211,85 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
                 }`}
               >
                 {/* # */}
-                <td className="p-3 text-center text-slate-600 font-mono text-xs">{row.tradeIndex + 1}</td>
+                <td className="px-2 py-1.5 text-center text-slate-600 font-mono text-xs">{row.tradeIndex + 1}</td>
 
                 {/* Data + Hora */}
-                <td className="p-3 text-slate-300">
-                  <span className="font-medium">{fmtDate(trade.date)}</span>
-                  <span className="text-[10px] text-slate-500 ml-1">{fmtTime(trade.entryTime)}</span>
+                <td className="px-2 py-1.5 text-slate-300 whitespace-nowrap">
+                  <span className="font-medium text-xs">{fmtDate(trade.date)}</span>
+                  <span className="text-[9px] text-slate-500 ml-1">{fmtTime(trade.entryTime)}</span>
                 </td>
 
-                {/* Ativo + Side */}
-                <td className="p-3">
-                  <span className="text-white font-bold">{trade.ticker}</span>
-                  <span className={`text-[10px] ml-1.5 px-1 py-0.5 rounded border ${
-                    trade.side === 'LONG' ? 'border-emerald-500/30 text-emerald-500' : 'border-red-500/30 text-red-500'
-                  }`}>{trade.side}</span>
+                {/* Ativo + Side (superscript compacto) */}
+                <td className="px-2 py-1.5 whitespace-nowrap">
+                  <span className="text-white font-bold text-xs">{trade.ticker}</span>
+                  <sup className={`text-[8px] ml-0.5 font-bold ${
+                    trade.side === 'LONG' ? 'text-emerald-500' : 'text-red-500'
+                  }`}>{trade.side === 'LONG' ? 'L' : 'S'}</sup>
                 </td>
 
-                {/* Emoção In → Out */}
-                <td className="p-3">
-                  <span className={`text-xs ${getEmotionColor(emotionCategory)}`}>
-                    {emoji} {emotionName}
+                {/* Emoção — só emojis, tooltip com nomes completos */}
+                <td className="px-2 py-1.5 text-center whitespace-nowrap">
+                  <span
+                    className={`cursor-default ${getEmotionColor(emotionCategory)}`}
+                    title={`Entrada: ${emotionName}${exitName ? ` → Saída: ${exitName}` : ''}`}
+                  >
+                    {emoji}{exitEmoji && <span className="text-[10px] text-slate-500">→{exitEmoji}</span>}
                   </span>
-                  {exitEmoji && (
-                    <span className="text-slate-500 text-[10px] ml-1">→ {exitEmoji}</span>
-                  )}
                 </td>
 
-                {/* RO % */}
-                <td className={`p-3 text-right font-mono text-xs ${roFora ? 'text-amber-400' : 'text-slate-400'}`}>
-                  <div className="flex items-center justify-end gap-1">
-                    {roFora && <ShieldOff className="w-3 h-3 text-amber-400" />}
+                {/* RO % — compacto, sem stop = só ícone (tooltip) */}
+                <td className={`px-2 py-1.5 text-right font-mono text-xs ${roFora ? 'text-amber-400' : 'text-slate-400'}`}>
+                  <div className="flex items-center justify-end gap-0.5">
+                    {roFora && <ShieldOff className="w-3 h-3 text-amber-400 flex-shrink-0" />}
                     {hasNoStop ? (
-                      <span className="text-red-400 flex items-center gap-0.5"><ShieldAlert className="w-3 h-3" /> S/Stop</span>
+                      <ShieldAlert className="w-3.5 h-3.5 text-red-400 flex-shrink-0" title="Trade sem stop loss" />
                     ) : riskPercent}
                   </div>
                 </td>
 
-                {/* RR — real ou assumido (B4) */}
-                <td className={`p-3 text-right font-mono text-xs ${rrFora || rrNonCompliant ? 'text-amber-400' : 'text-slate-400'}`}>
-                  <div className="flex items-center justify-end gap-1">
-                    {(rrFora || rrNonCompliant) && <Scale className="w-3 h-3 text-amber-400" />}
-                    {rrDisplay}
+                {/* RR — real ou assumido */}
+                <td className={`px-2 py-1.5 text-right font-mono text-xs ${rrFora || rrNonCompliant ? 'text-amber-400' : 'text-slate-400'}`}>
+                  <div className="flex items-center justify-end gap-0.5">
+                    {(rrFora || rrNonCompliant) && <Scale className="w-3 h-3 text-amber-400 flex-shrink-0" />}
+                    <span>{rrDisplay}</span>
                     {rrIsAssumed && (
-                      <span className="text-[8px] text-purple-400/70 ml-0.5" title="RR calculado sem stop loss, baseado no RO% do plano">(est.)</span>
+                      <span className="text-[7px] text-purple-400/70" title="RR estimado sem stop loss (baseado no RO% do plano)">*</span>
                     )}
                   </div>
                 </td>
 
                 {/* Resultado */}
-                <td className={`p-3 text-right font-mono font-bold ${row.result >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                <td className={`px-2 py-1.5 text-right font-mono font-bold text-xs ${row.result >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
                   {row.result > 0 ? '+' : ''}{fmt(row.result)}
                 </td>
 
                 {/* Acumulado */}
-                <td className={`p-3 text-right font-mono font-bold bg-slate-800/30 border-l border-slate-800 ${
+                <td className={`px-2 py-1.5 text-right font-mono font-bold text-xs bg-slate-800/30 border-l border-slate-800 ${
                   row.cumPnL >= 0 ? 'text-emerald-300' : 'text-red-300'
                 }`}>
                   {fmt(row.cumPnL)}
                 </td>
 
-                {/* Evento — agora mostra TUDO inline */}
-                <td className="p-3 text-center">
+                {/* Evento — inline events */}
+                <td className="px-2 py-1.5 text-center">
                   {inlineEvents.length === 0 && (
-                    <span className="text-slate-600 text-xs">-</span>
+                    <span className="text-slate-600 text-[10px]">-</span>
                   )}
                   {inlineEvents.length > 0 && (
-                    <div className="flex flex-wrap justify-center gap-1">
+                    <div className="flex flex-wrap justify-center gap-0.5">
                       {inlineEvents.map((evt, idx) => {
                         const Icon = evt.icon;
                         return (
                           <span
                             key={idx}
-                            className={`${evt.color} ${evt.small ? 'text-[9px]' : 'text-xs'} font-bold flex items-center gap-0.5 ${evt.small ? 'uppercase' : ''}`}
+                            className={`${evt.color} ${evt.small ? 'text-[8px]' : 'text-[10px]'} font-bold flex items-center gap-0.5 ${evt.small ? 'uppercase' : ''}`}
                             title={evt.sublabel ? `${evt.label} (${evt.sublabel})` : evt.label}
                           >
                             {Icon && <Icon className="w-3 h-3" />}
                             {evt.sublabel ? (
                               <span className="flex flex-col items-center leading-none">
                                 <span>{evt.label}</span>
-                                <span className="text-[7px] opacity-60">{evt.sublabel}</span>
+                                <span className="text-[6px] opacity-60">{evt.sublabel}</span>
                               </span>
                             ) : evt.label}
                           </span>
@@ -301,40 +299,32 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
                   )}
                 </td>
 
-                {/* Status Feedback (QA #14) */}
-                <td className="p-3 text-center">
-                  {(() => {
-                    const cfg = getFeedbackStatusConfig(trade.status);
-                    const Icon = cfg.icon;
-                    return (
-                      <span
-                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${cfg.color} ${cfg.bg}`}
-                        title={cfg.label}
-                      >
-                        <Icon className="w-3 h-3" />
-                        {cfg.label}
-                      </span>
-                    );
-                  })()}
-                </td>
-
-                {/* Feedback navigation (B4 — Issue #73) */}
-                {onNavigateToFeedback && (
-                  <td className="p-3 text-center">
+                {/* Status Feedback — badge clicável se onNavigateToFeedback */}
+                <td className="px-2 py-1.5 text-center">
+                  {onNavigateToFeedback ? (
                     <button
                       onClick={() => onNavigateToFeedback(trade)}
-                      className="p-1 rounded hover:bg-slate-700/50 text-slate-500 hover:text-blue-400 transition-colors"
-                      title="Ir para feedback"
+                      className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[9px] font-medium ${fbCfg.color} ${fbCfg.bg} hover:brightness-125 transition-all cursor-pointer`}
+                      title={`${fbCfg.label} — clique para feedback`}
                     >
-                      <MessageSquare className="w-3.5 h-3.5" />
+                      <FbIcon className="w-3 h-3" />
+                      {fbCfg.label}
                     </button>
-                  </td>
-                )}
+                  ) : (
+                    <span
+                      className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[9px] font-medium ${fbCfg.color} ${fbCfg.bg}`}
+                      title={fbCfg.label}
+                    >
+                      <FbIcon className="w-3 h-3" />
+                      {fbCfg.label}
+                    </span>
+                  )}
+                </td>
               </tr>
             );
           })}
           {displayRows.length === 0 && (
-            <tr><td colSpan={onNavigateToFeedback ? 11 : 10} className="p-12 text-center text-slate-500">Nenhum trade neste período.</td></tr>
+            <tr><td colSpan={totalCols} className="p-12 text-center text-slate-500">Nenhum trade neste período.</td></tr>
           )}
         </tbody>
       </table>

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -247,8 +247,12 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
                   </div>
                 </td>
 
-                {/* RR — real ou assumido */}
-                <td className={`px-2 py-1.5 text-right font-mono text-xs ${rrFora || rrNonCompliant ? 'text-amber-400' : 'text-slate-400'}`}>
+                {/* RR — real ou assumido. Azul se compliant, amber se non-compliant */}
+                <td className={`px-2 py-1.5 text-right font-mono text-xs ${
+                  rrFora || rrNonCompliant ? 'text-amber-400' 
+                  : (trade.rrRatio != null && trade.result > 0 && !rrNonCompliant) ? 'text-blue-400' 
+                  : 'text-slate-400'
+                }`}>
                   <div className="flex items-center justify-end gap-0.5">
                     {(rrFora || rrNonCompliant) && <Scale className="w-3 h-3 text-amber-400 flex-shrink-0" />}
                     <span>{rrDisplay}</span>

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -60,28 +60,14 @@ const getTradeInlineEvents = (row, emotionalEvents) => {
     events.push({ icon: null, color: 'text-red-500/70', label: 'Violação', small: true });
   }
 
-  // 1b. Cycle events (se este trade causou cycle goal/stop)
+  // 1b. Cycle events (se este trade causou cycle goal/stop) — cor diferenciada
   if (row.cycleEvent === 'CYCLE_GOAL_HIT') {
-    events.push({ icon: Trophy, color: 'text-emerald-300', label: 'META!', sublabel: 'Ciclo' });
+    events.push({ icon: Trophy, color: 'text-yellow-400', label: 'META!', sublabel: 'Ciclo' });
   } else if (row.cycleEvent === 'CYCLE_STOP_HIT') {
-    events.push({ icon: Skull, color: 'text-red-300', label: 'STOP!', sublabel: 'Ciclo' });
+    events.push({ icon: Skull, color: 'text-orange-400', label: 'STOP!', sublabel: 'Ciclo' });
   }
 
-  // 2. Compliance events
-  const hasNoStop = Array.isArray(trade.redFlags) && trade.redFlags.some(f =>
-    (typeof f === 'string' ? f : f.type) === 'TRADE_SEM_STOP'
-  );
-  if (hasNoStop) {
-    events.push({ icon: ShieldAlert, color: 'text-red-400', label: 'S/Stop', small: true });
-  }
-  if (trade.compliance?.roStatus === 'FORA_DO_PLANO') {
-    events.push({ icon: ShieldOff, color: 'text-amber-400', label: 'RO', small: true });
-  }
-  if (trade.compliance?.rrStatus === 'NAO_CONFORME') {
-    events.push({ icon: Scale, color: 'text-amber-400', label: 'RR', small: true });
-  }
-
-  // 3. Emotional events (TILT, REVENGE matched by tradeId or proximity)
+  // 2. Emotional events (TILT, REVENGE matched by tradeId or proximity)
   if (emotionalEvents) {
     const tradeEmotionalEvents = emotionalEvents.filter(e => {
       // Match por tradeId direto se disponível
@@ -177,14 +163,13 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
             const roFora = trade.compliance?.roStatus === 'FORA_DO_PLANO';
             const rrFora = trade.compliance?.rrStatus === 'NAO_CONFORME';
 
-            // RR: real (do trade) ou assumido (calculado via B2)
+            // RR: real (do trade) ou assumido (DEC-007: gravado no trade pela CF)
             let rrDisplay = '-';
-            let rrIsAssumed = false;
-            let rrAssumedNonCompliant = false;
+            let rrIsAssumed = trade.rrAssumed === true;
             if (trade.rrRatio != null) {
               rrDisplay = `${Number(trade.rrRatio).toFixed(1)}:1`;
             } else if (planRiskInfo && !trade.stopLoss) {
-              // Sem stop → calcular RR assumido via DEC-005
+              // Fallback: trades antigos sem rrRatio gravado
               const assumed = calculateAssumedRR({
                 result: trade.result ?? 0,
                 planPl: planRiskInfo.pl,
@@ -194,9 +179,10 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
               if (assumed) {
                 rrIsAssumed = true;
                 rrDisplay = `${assumed.rrRatio.toFixed(1)}:1`;
-                rrAssumedNonCompliant = !assumed.isCompliant;
               }
             }
+            // RR compliance: loss não é violação (B1)
+            const rrNonCompliant = trade.compliance?.rrStatus === 'NAO_CONFORME';
 
             // Inline events
             const inlineEvents = getTradeInlineEvents(row, emotionalEvents);
@@ -246,9 +232,9 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
                 </td>
 
                 {/* RR — real ou assumido (B4) */}
-                <td className={`p-3 text-right font-mono text-xs ${rrFora || rrAssumedNonCompliant ? 'text-amber-400' : 'text-slate-400'}`}>
+                <td className={`p-3 text-right font-mono text-xs ${rrFora || rrNonCompliant ? 'text-amber-400' : 'text-slate-400'}`}>
                   <div className="flex items-center justify-end gap-1">
-                    {(rrFora || rrAssumedNonCompliant) && <Scale className="w-3 h-3 text-amber-400" />}
+                    {(rrFora || rrNonCompliant) && <Scale className="w-3 h-3 text-amber-400" />}
                     {rrDisplay}
                     {rrIsAssumed && (
                       <span className="text-[8px] text-purple-400/70 ml-0.5" title="RR calculado sem stop loss, baseado no RO% do plano">(est.)</span>

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -1,8 +1,9 @@
 /**
  * ExtractTable
- * @version 3.0.0 (v1.19.0)
+ * @version 4.0.0 (v1.19.3)
  * @description Tabela do extrato com colunas de sanity check (RO, RR, Emoção)
  *   e marcação visual para POST_GOAL/POST_STOP.
+ *   v4.0.0: Coluna Status Feedback (OPEN/REVIEWED/QUESTION/CLOSED), RR com 2 casas decimais (C3).
  *   v3.0.0: RR assumido com badge "(assumido)", botão feedback por trade (B4 — Issue #71/#73).
  *   v2.0.0: Coluna Evento agora mostra eventos emocionais e compliance inline
  *           (TILT, REVENGE, NO_STOP, RO_FORA, RR_FORA) além dos eventos de state machine.
@@ -12,7 +13,8 @@
 
 import {
   Trophy, Skull, ShieldAlert, ShieldOff, Scale,
-  Flame, Zap, AlertTriangle, MessageSquare
+  Flame, Zap, AlertTriangle, MessageSquare,
+  CircleDot, CheckCircle2, HelpCircle, CheckCheck
 } from 'lucide-react';
 import { PERIOD_STATES } from '../../utils/planStateMachine';
 import { calculateAssumedRR } from '../../utils/tradeCalculations';
@@ -99,6 +101,21 @@ const getTradeInlineEvents = (row, emotionalEvents) => {
   return events;
 };
 
+/** Badge de status do feedback do trade. */
+const getFeedbackStatusConfig = (status) => {
+  switch (status) {
+    case 'REVIEWED':
+      return { icon: CheckCircle2, color: 'text-emerald-400', label: 'Revisado', bg: 'bg-emerald-500/10' };
+    case 'QUESTION':
+      return { icon: HelpCircle, color: 'text-amber-400', label: 'Dúvida', bg: 'bg-amber-500/10' };
+    case 'CLOSED':
+      return { icon: CheckCheck, color: 'text-slate-500', label: 'Fechado', bg: 'bg-slate-500/10' };
+    case 'OPEN':
+    default:
+      return { icon: CircleDot, color: 'text-slate-500', label: 'Pendente', bg: 'bg-slate-500/5' };
+  }
+};
+
 /**
  * @param {Array} rows - Rows da state machine (cada row tem .trade, .periodEvent, .cumPnL, .result)
  * @param {Function} fmt - formatCurrencyDynamic parcial
@@ -125,6 +142,7 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
             <th className="p-3 text-right">Resultado</th>
             <th className="p-3 text-right bg-slate-800/50">Acumulado</th>
             <th className="p-3 text-center w-32">Evento</th>
+            <th className="p-3 text-center w-20">Status</th>
             {onNavigateToFeedback && <th className="p-3 text-center w-10"></th>}
           </tr>
         </thead>
@@ -133,7 +151,7 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
           {carryOver !== 0 && displayRows.length > 0 && (
             <tr className="bg-slate-800/20 border-b-2 border-slate-700 border-dashed">
               <td className="p-3 text-center text-slate-600 font-mono text-xs">—</td>
-              <td colSpan={onNavigateToFeedback ? 7 : 6} className="p-3 text-slate-500 italic text-xs">Saldo anterior (períodos anteriores)</td>
+              <td colSpan={onNavigateToFeedback ? 8 : 7} className="p-3 text-slate-500 italic text-xs">Saldo anterior (períodos anteriores)</td>
               <td className={`p-3 text-right font-mono font-bold text-xs bg-slate-800/30 border-l border-slate-800 ${carryOver >= 0 ? 'text-emerald-400/60' : 'text-red-400/60'}`}>
                 {fmt(carryOver)}
               </td>
@@ -167,7 +185,7 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
             let rrDisplay = '-';
             let rrIsAssumed = trade.rrAssumed === true;
             if (trade.rrRatio != null) {
-              rrDisplay = `${Number(trade.rrRatio).toFixed(1)}:1`;
+              rrDisplay = `${Number(trade.rrRatio).toFixed(2)}:1`;
             } else if (planRiskInfo && !trade.stopLoss) {
               // Fallback: trades antigos sem rrRatio gravado
               const assumed = calculateAssumedRR({
@@ -178,7 +196,7 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
               });
               if (assumed) {
                 rrIsAssumed = true;
-                rrDisplay = `${assumed.rrRatio.toFixed(1)}:1`;
+                rrDisplay = `${assumed.rrRatio.toFixed(2)}:1`;
               }
             }
             // RR compliance: loss não é violação (B1)
@@ -283,6 +301,23 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
                   )}
                 </td>
 
+                {/* Status Feedback (QA #14) */}
+                <td className="p-3 text-center">
+                  {(() => {
+                    const cfg = getFeedbackStatusConfig(trade.status);
+                    const Icon = cfg.icon;
+                    return (
+                      <span
+                        className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${cfg.color} ${cfg.bg}`}
+                        title={cfg.label}
+                      >
+                        <Icon className="w-3 h-3" />
+                        {cfg.label}
+                      </span>
+                    );
+                  })()}
+                </td>
+
                 {/* Feedback navigation (B4 — Issue #73) */}
                 {onNavigateToFeedback && (
                   <td className="p-3 text-center">
@@ -299,7 +334,7 @@ const ExtractTable = ({ rows, fmt, getEmotionConfig, carryOver = 0, emotionalEve
             );
           })}
           {displayRows.length === 0 && (
-            <tr><td colSpan={onNavigateToFeedback ? 10 : 9} className="p-12 text-center text-slate-500">Nenhum trade neste período.</td></tr>
+            <tr><td colSpan={onNavigateToFeedback ? 11 : 10} className="p-12 text-center text-slate-500">Nenhum trade neste período.</td></tr>
           )}
         </tbody>
       </table>

--- a/src/hooks/useCsvStaging.js
+++ b/src/hooks/useCsvStaging.js
@@ -1,9 +1,13 @@
 /**
  * useCsvStaging
- * @version 1.0.0 (v1.18.0)
+ * @version 1.1.0 (v1.19.1)
  * @description Hook para gerenciar trades em staging (collection csvStagingTrades).
  *   Trades importados via CSV ficam aqui até serem "ativados" — momento em que
  *   são passados para addTrade (useTrades) e deletados do staging.
+ *
+ * CHANGELOG:
+ * - 1.1.0: C2 (v1.19.1) — activateTrade busca tickerRule do master data (tickers collection)
+ *   quando staging não possui tickerRule, usando exchange+symbol lookup.
  *
  * PRINCÍPIO: csvStagingTrades é 100% isolada de trades/movements/CFs.
  *   Nenhuma Cloud Function observa esta collection.
@@ -271,6 +275,33 @@ const useCsvStaging = (overrideStudentId = null) => {
     if (!stagingTrade?.planId) throw new Error('Trade sem plano associado');
     if (!addTradeFn) throw new Error('addTrade function não fornecida');
 
+    // C2 (v1.19.1): Buscar tickerRule do master data se não presente no staging
+    let tickerRule = stagingTrade.tickerRule ?? null;
+    if (!tickerRule && stagingTrade.ticker && stagingTrade.exchange) {
+      try {
+        const tickerSnap = await getDocs(
+          query(
+            collection(db, 'tickers'),
+            where('symbol', '==', stagingTrade.ticker),
+            where('exchange', '==', stagingTrade.exchange)
+          )
+        );
+        if (!tickerSnap.empty) {
+          const tickerDoc = tickerSnap.docs[0].data();
+          if (tickerDoc.tickSize && tickerDoc.tickValue) {
+            tickerRule = {
+              tickSize: tickerDoc.tickSize,
+              tickValue: tickerDoc.tickValue,
+              pointValue: tickerDoc.pointValue ?? null,
+            };
+            console.log(`[useCsvStaging] tickerRule resolvido via master data: ${stagingTrade.ticker}@${stagingTrade.exchange}`, tickerRule);
+          }
+        }
+      } catch (err) {
+        console.warn(`[useCsvStaging] Falha ao buscar tickerRule: ${err.message}`);
+      }
+    }
+
     // Montar tradeData no formato que addTrade espera
     const tradeData = {
       planId: stagingTrade.planId,
@@ -290,8 +321,8 @@ const useCsvStaging = (overrideStudentId = null) => {
       // Metadados de origem
       importSource: stagingTrade.importSource ?? 'csv',
       importBatchId: stagingTrade.importBatchId ?? null,
-      // tickerRule se disponível
-      tickerRule: stagingTrade.tickerRule ?? null,
+      // C2: tickerRule resolvido (staging ou master data lookup)
+      tickerRule,
     };
 
     // Chamar addTrade legado — ele resolve planId→accountId, calcula result,

--- a/src/hooks/usePlans.js
+++ b/src/hooks/usePlans.js
@@ -341,9 +341,9 @@ export const usePlans = (overrideStudentId = null) => {
         || currentRisk != null && newRisk == null
         || (currentRisk != null && newRisk != null && Math.abs(currentRisk - newRisk) > 0.01);
 
-      // Comparar rrRatio (null-safe, respeita rrAssumed)
+      // Comparar rrRatio (null-safe — DEC-007: calculateTradeCompliance now returns RR for all trades)
       const currentRR = trade.rrRatio;
-      const newRR = (trade.rrAssumed && fresh.rrRatio == null) ? currentRR : fresh.rrRatio;
+      const newRR = fresh.rrRatio;
       const rrChanged = currentRR == null && newRR != null
         || currentRR != null && newRR == null
         || (currentRR != null && newRR != null && Math.abs(currentRR - newRR) > 0.01);
@@ -364,6 +364,8 @@ export const usePlans = (overrideStudentId = null) => {
         let reason = 'Compliance recalculado';
         if (!trade.stopLoss && currentRisk === 100) {
           reason = 'DEC-006: risco retroativo';
+        } else if (rrChanged && fresh.rrAssumed) {
+          reason = 'DEC-007: RR assumido recalculado';
         } else if (riskChanged) {
           reason = 'RO% recalculado';
         } else if (rrChanged) {

--- a/src/hooks/usePlans.js
+++ b/src/hooks/usePlans.js
@@ -28,6 +28,7 @@ import {
 import { getFunctions, httpsCallable } from 'firebase/functions';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
+import { calculateTradeCompliance } from '../utils/compliance';
 
 /** Campos do plano que afetam compliance — mudança dispara recálculo */
 const RISK_FIELDS = ['riskPerOperation', 'rrTarget', 'periodStop', 'cycleStop'];
@@ -306,9 +307,90 @@ export const usePlans = (overrideStudentId = null) => {
   }, [plans]);
 
   /**
-   * B1 (v1.19.0): Auditoria de plano
-   * (a) Recalcula currentPL somando result de todos os trades do plano
-   * (b) Recalcula compliance de todos os trades em cascata via callable
+   * v1.19.1: Diagnóstico bidirecional de plano (leitura, sem escrita)
+   * Ida:   PL do plano ← soma dos trades (detecta PL divergente)
+   * Volta: Compliance dos trades ← parâmetros do plano (detecta trades desatualizados)
+   * 
+   * @param {string} planId
+   * @param {Array} localTrades - trades já carregados no hook (evita query extra)
+   * @returns {{ pl: { current, calculated, divergent }, trades: { total, divergent, details[] } }}
+   */
+  const diagnosePlan = useCallback((planId, localTrades = []) => {
+    const plan = plans.find(p => p.id === planId);
+    if (!plan) throw new Error('Plano não encontrado no cache local');
+
+    const planTrades = localTrades.filter(t => t.planId === planId);
+    const basePl = Number(plan.pl) || 0;
+    const currentPl = Number(plan.currentPl ?? plan.pl) || 0;
+
+    // === Ida: PL calculado a partir dos trades ===
+    const totalResult = planTrades.reduce((sum, t) => sum + (Number(t.result) || 0), 0);
+    const calculatedPl = Math.round((basePl + totalResult) * 100) / 100;
+    const plDivergent = Math.abs(currentPl - calculatedPl) > 0.01; // tolerância centavo
+
+    // === Volta: Compliance dos trades vs parâmetros do plano ===
+    const divergentTrades = [];
+
+    for (const trade of planTrades) {
+      const fresh = calculateTradeCompliance(trade, plan);
+      const currentRisk = trade.riskPercent;
+      const newRisk = fresh.riskPercent;
+
+      // Comparar riskPercent (null-safe)
+      const riskChanged = currentRisk == null && newRisk != null
+        || currentRisk != null && newRisk == null
+        || (currentRisk != null && newRisk != null && Math.abs(currentRisk - newRisk) > 0.01);
+
+      // Comparar rrRatio (null-safe, respeita rrAssumed)
+      const currentRR = trade.rrRatio;
+      const newRR = (trade.rrAssumed && fresh.rrRatio == null) ? currentRR : fresh.rrRatio;
+      const rrChanged = currentRR == null && newRR != null
+        || currentRR != null && newRR == null
+        || (currentRR != null && newRR != null && Math.abs(currentRR - newRR) > 0.01);
+
+      // Comparar compliance status
+      const roChanged = (trade.compliance?.roStatus ?? 'CONFORME') !== fresh.compliance.roStatus;
+      const rrStatusChanged = (trade.compliance?.rrStatus ?? 'CONFORME') !== fresh.compliance.rrStatus;
+
+      if (riskChanged || rrChanged || roChanged || rrStatusChanged) {
+        // Formatar data do trade
+        let dateStr = '-';
+        if (trade.entryTime) {
+          const d = trade.entryTime?.toDate ? trade.entryTime.toDate() : new Date(trade.entryTime);
+          dateStr = d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
+        }
+
+        // Determinar motivo
+        let reason = 'Compliance recalculado';
+        if (!trade.stopLoss && currentRisk === 100) {
+          reason = 'DEC-006: risco retroativo';
+        } else if (riskChanged) {
+          reason = 'RO% recalculado';
+        } else if (rrChanged) {
+          reason = 'RR recalculado';
+        }
+
+        divergentTrades.push({
+          id: trade.id,
+          date: dateStr,
+          ticker: trade.ticker || '-',
+          oldRisk: currentRisk != null ? `${currentRisk.toFixed(1)}%` : 'N/A',
+          newRisk: newRisk != null ? `${newRisk.toFixed(1)}%` : 'N/A',
+          reason,
+        });
+      }
+    }
+
+    return {
+      pl: { current: currentPl, calculated: calculatedPl, divergent: plDivergent },
+      trades: { total: planTrades.length, divergent: divergentTrades.length, details: divergentTrades },
+    };
+  }, [plans]);
+
+  /**
+   * v1.19.1: Auditoria de plano — delega tudo à callable recalculateCompliance (admin SDK)
+   * A callable agora faz: (a) recálculo de PL + (b) recálculo de compliance
+   * Sem escrita direta do frontend — bypassa Firestore Rules.
    * 
    * @param {string} planId
    * @param {Function} [onProgress] - callback({ step, message })
@@ -317,57 +399,30 @@ export const usePlans = (overrideStudentId = null) => {
   const auditPlan = useCallback(async (planId, onProgress) => {
     if (!planId) throw new Error('planId obrigatório');
 
-    const report = { oldPl: 0, newPl: 0, plRecalculated: false, complianceUpdated: 0 };
-
     try {
-      // (a) Recalcular currentPL a partir dos trades
-      onProgress?.({ step: 1, message: 'Buscando trades do plano...' });
-
-      const planRef = doc(db, 'plans', planId);
-      const tradesSnap = await getDocs(
-        query(collection(db, 'trades'), where('planId', '==', planId))
-      );
-
-      const totalResult = tradesSnap.docs.reduce((sum, d) => {
-        return sum + (Number(d.data().result) || 0);
-      }, 0);
-
-      // Buscar PL base (inicial) do plano
-      const plan = plans.find(p => p.id === planId);
-      if (!plan) throw new Error('Plano não encontrado no cache local');
-
-      const basePl = Number(plan.pl) || 0;
-      const newCurrentPl = Math.round((basePl + totalResult) * 100) / 100;
-      report.oldPl = Number(plan.currentPl ?? plan.pl) || 0;
-      report.newPl = newCurrentPl;
-
-      onProgress?.({ step: 2, message: `PL: ${report.oldPl.toFixed(2)} → ${newCurrentPl.toFixed(2)} (${tradesSnap.size} trades)` });
-
-      await updateDoc(planRef, {
-        currentPl: newCurrentPl,
-        updatedAt: serverTimestamp(),
-      });
-      report.plRecalculated = true;
-
-      // (b) Recalcular compliance em cascata
-      onProgress?.({ step: 3, message: 'Recalculando compliance...' });
+      onProgress?.({ step: 1, message: 'Recalculando PL e compliance via servidor...' });
 
       const functions = getFunctions();
       const recalc = httpsCallable(functions, 'recalculateCompliance');
-      const result = await recalc({ planId });
-      report.complianceUpdated = result.data.updated || 0;
+      const result = await recalc({ planId, recalcPl: true });
 
-      onProgress?.({ step: 4, message: `Auditoria concluída: ${report.complianceUpdated} trades recalculados` });
+      const report = {
+        oldPl: result.data.oldPl ?? 0,
+        newPl: result.data.newPl ?? 0,
+        plRecalculated: result.data.plRecalculated ?? false,
+        complianceUpdated: result.data.updated ?? 0,
+      };
+
+      onProgress?.({ step: 2, message: `Auditoria concluída: PL ${report.oldPl.toFixed(2)} → ${report.newPl.toFixed(2)}, ${report.complianceUpdated} trades` });
 
       console.log(`[usePlans] auditPlan ${planId}: PL ${report.oldPl} → ${report.newPl}, compliance ${report.complianceUpdated} trades`);
 
+      return report;
     } catch (err) {
       console.error('[usePlans] Erro auditPlan:', err);
       throw err;
     }
-
-    return report;
-  }, [plans]);
+  }, []);
 
   /**
    * Validar trade contra plano
@@ -430,6 +485,7 @@ export const usePlans = (overrideStudentId = null) => {
     updatePlan,
     deletePlan,
     auditPlan,
+    diagnosePlan,
     getPlansByAccount,
     getPlansByStudent,
     getPlanById,

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -280,7 +280,7 @@ export const useTrades = (overrideStudentId = null) => {
         stopLoss,
         resultCalculated: Math.round(result * 100) / 100,
         result: effectiveResult,
-        resultInPoints,
+        resultInPoints: (tradeData.resultOverride != null) ? null : resultInPoints,
         resultEdited: tradeData.resultOverride != null,
         resultPercent: calculateResultPercent(side, entry, exit),
         rrRatio,
@@ -417,6 +417,7 @@ export const useTrades = (overrideStudentId = null) => {
         if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
           updateData.result = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
           updateData.resultEdited = true;
+          updateData.resultInPoints = null; // C5: pontos não representam o override
         } else {
           updateData.result = calc.result;
           updateData.resultEdited = false;
@@ -445,6 +446,7 @@ export const useTrades = (overrideStudentId = null) => {
           const overrideVal = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
           updateData.result = overrideVal;
           updateData.resultEdited = true;
+          updateData.resultInPoints = null; // C5: pontos não representam o override
           newResult = overrideVal;
         } else {
           updateData.result = Math.round(newResult * 100) / 100;

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -386,14 +386,15 @@ export const useTrades = (overrideStudentId = null) => {
       let newResult = currentTrade.result;
 
       if (updates.entry !== undefined || updates.exit !== undefined || updates.qty !== undefined || updates.side !== undefined) {
+        const rawDiff = side === 'LONG' ? exit - entry : entry - exit;
         if (tickerRule?.tickSize && tickerRule?.tickValue) {
-          const rawDiff = side === 'LONG' ? exit - entry : entry - exit;
           newResult = (rawDiff / tickerRule.tickSize) * tickerRule.tickValue * qty;
         } else {
           newResult = calculateTradeResult(side, entry, exit, qty);
         }
         updateData.resultCalculated = Math.round(newResult * 100) / 100;
         updateData.resultPercent = calculateResultPercent(side, entry, exit);
+        updateData.resultInPoints = Math.round(rawDiff * 100) / 100;
         updateData.entry = entry; updateData.exit = exit; updateData.qty = qty;
       }
 

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -258,11 +258,11 @@ export const useTrades = (overrideStudentId = null) => {
           rrRatio = Math.round((effectiveResult / (risk * (tradeData.tickerRule?.pointValue || 1) * qty)) * 100) / 100;
         }
       } else {
-        // RR assumido: baseado no RO$ do plano (DEC-005)
+        // RR assumido: baseado no RO$ do plano (DEC-007: usa plan.pl = capital base)
         const planData = planSnap.data();
         const assumed = calculateAssumedRR({
           result: effectiveResult,
-          planPl: Number(planData.currentPl ?? planData.pl) || 0,
+          planPl: Number(planData.pl) || 0,
           planRiskPerOperation: Number(planData.riskPerOperation) || 0,
           planRrTarget: Number(planData.rrTarget) || 0,
         });
@@ -409,6 +409,56 @@ export const useTrades = (overrideStudentId = null) => {
       }
 
       await updateDoc(tradeRef, updateData);
+
+      // C-RR3 (DEC-007): Recalcular RR quando campos relevantes mudam
+      // A CF onTradeUpdated também recalcula, mas fazemos aqui para feedback imediato
+      const resultChanged = Math.abs((updateData.result ?? currentTrade.result) - (currentTrade.result || 0)) > 0.01;
+      const stopChanged = updates.stopLoss !== undefined;
+      const priceChanged = updates.entry !== undefined || updates.exit !== undefined || updates.qty !== undefined;
+      
+      if (resultChanged || stopChanged || priceChanged) {
+        const effectiveStop = updateData.stopLoss !== undefined ? updateData.stopLoss : currentTrade.stopLoss;
+        const effectiveEntry = entry;
+        const effectiveResult = updateData.result ?? currentTrade.result;
+        const effectiveQty = qty;
+        
+        let newRrRatio = null;
+        let newRrAssumed = false;
+        
+        if (effectiveStop != null && effectiveStop !== 0 && effectiveEntry) {
+          // RR real: baseado no stop loss efetivo
+          const risk = Math.abs(effectiveEntry - effectiveStop);
+          if (risk > 0) {
+            const pointValue = (updates.tickerRule || currentTrade.tickerRule)?.pointValue || 1;
+            newRrRatio = Math.round((effectiveResult / (risk * pointValue * effectiveQty)) * 100) / 100;
+          }
+        } else {
+          // RR assumido: buscar plano para calcular (DEC-007: usa plan.pl)
+          try {
+            const planId = currentTrade.planId;
+            if (planId) {
+              const planSnap = await getDoc(doc(db, 'plans', planId));
+              if (planSnap.exists()) {
+                const planData = planSnap.data();
+                const assumed = calculateAssumedRR({
+                  result: effectiveResult,
+                  planPl: Number(planData.pl) || 0,
+                  planRiskPerOperation: Number(planData.riskPerOperation) || 0,
+                  planRrTarget: Number(planData.rrTarget) || 0,
+                });
+                if (assumed) {
+                  newRrRatio = assumed.rrRatio;
+                  newRrAssumed = true;
+                }
+              }
+            }
+          } catch (rrErr) {
+            console.warn('[useTrades] updateTrade: erro recalculando RR assumido:', rrErr);
+          }
+        }
+        
+        await updateDoc(tradeRef, { rrRatio: newRrRatio, rrAssumed: newRrAssumed });
+      }
 
       // Sanitizar newResult para uso no movement
       const effectiveUpdateResult = Math.round(newResult * 100) / 100;

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -386,56 +386,112 @@ export const useTrades = (overrideStudentId = null) => {
 
       let newResult = currentTrade.result;
 
-      if (updates.entry !== undefined || updates.exit !== undefined || updates.qty !== undefined || updates.side !== undefined) {
-        const rawDiff = side === 'LONG' ? exit - entry : entry - exit;
-        if (tickerRule?.tickSize && tickerRule?.tickValue) {
-          newResult = (rawDiff / tickerRule.tickSize) * tickerRule.tickValue * qty;
-        } else {
-          newResult = calculateTradeResult(side, entry, exit, qty);
+      // === PARCIAIS SÃO A FONTE DA VERDADE ===
+      // Quando _partials existe, TODO o recálculo vem delas. Campos entry/exit/qty/result são derivados.
+      if (_partials && _partials.length > 0) {
+        // 1. Substituir subcollection
+        const oldPartials = await getDocs(collection(db, 'trades', tradeId, 'partials'));
+        await Promise.all(oldPartials.docs.map(d => deleteDoc(d.ref)));
+
+        const partialsRef = collection(db, 'trades', tradeId, 'partials');
+        for (const partial of _partials) {
+          await addDoc(partialsRef, {
+            seq: partial.seq,
+            type: partial.type,
+            price: parseFloat(partial.price),
+            qty: parseFloat(partial.qty),
+            dateTime: partial.dateTime || new Date().toISOString(),
+            notes: partial.notes || '',
+            createdAt: serverTimestamp()
+          });
         }
-        updateData.resultCalculated = Math.round(newResult * 100) / 100;
-        updateData.resultPercent = calculateResultPercent(side, entry, exit);
-        updateData.resultInPoints = Math.round(rawDiff * 100) / 100;
-        updateData.entry = entry; updateData.exit = exit; updateData.qty = qty;
-      }
 
-      // Aplicar override se presente, garantindo número puro
-      if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
-        const overrideVal = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
-        updateData.result = overrideVal;
-        updateData.resultEdited = true;
-        newResult = overrideVal;  // movement usa o efetivo
+        // 2. Recalcular tudo a partir das parciais
+        const calc = calculateFromPartials({
+          side,
+          partials: _partials.map(p => ({ ...p, price: parseFloat(p.price), qty: parseFloat(p.qty) })),
+          tickerRule: tickerRule || null
+        });
+
+        // 3. Campos derivados — única fonte
+        updateData.hasPartials = true;
+        updateData.partialsCount = _partials.length;
+        updateData.avgEntry = calc.avgEntry;
+        updateData.avgExit = calc.avgExit;
+        updateData.entry = calc.avgEntry;
+        updateData.exit = calc.avgExit;
+        updateData.qty = calc.realizedQty;
+        updateData.totalQty = calc.realizedQty;
+        updateData.resultCalculated = calc.result;
+        updateData.resultInPoints = calc.resultInPoints;
+        updateData.entryTime = calc.entryTime || currentTrade.entryTime;
+        updateData.exitTime = calc.exitTime || currentTrade.exitTime;
+        updateData.date = calc.entryTime ? calc.entryTime.split('T')[0] : currentTrade.date;
+        updateData.resultPercent = calc.avgEntry > 0 ? calculateResultPercent(side, calc.avgEntry, calc.avgExit) : 0;
+
+        // Override de resultado (se presente)
+        if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
+          updateData.result = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
+          updateData.resultEdited = true;
+        } else {
+          updateData.result = calc.result;
+          updateData.resultEdited = false;
+        }
+
+        newResult = updateData.result;
+        console.log(`[useTrades] updateTrade via parciais: ${_partials.length} legs, result=${calc.result}`);
+
       } else {
-        updateData.result = Math.round(newResult * 100) / 100;
-        updateData.resultEdited = false;
+        // Caminho legado: sem parciais, recálculo direto dos campos
+        if (updates.entry !== undefined || updates.exit !== undefined || updates.qty !== undefined || updates.side !== undefined) {
+          const rawDiff = side === 'LONG' ? exit - entry : entry - exit;
+          if (tickerRule?.tickSize && tickerRule?.tickValue) {
+            newResult = (rawDiff / tickerRule.tickSize) * tickerRule.tickValue * qty;
+          } else {
+            newResult = calculateTradeResult(side, entry, exit, qty);
+          }
+          updateData.resultCalculated = Math.round(newResult * 100) / 100;
+          updateData.resultPercent = calculateResultPercent(side, entry, exit);
+          updateData.resultInPoints = Math.round(rawDiff * 100) / 100;
+          updateData.entry = entry; updateData.exit = exit; updateData.qty = qty;
+        }
+
+        // Aplicar override se presente
+        if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
+          const overrideVal = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
+          updateData.result = overrideVal;
+          updateData.resultEdited = true;
+          newResult = overrideVal;
+        } else {
+          updateData.result = Math.round(newResult * 100) / 100;
+          updateData.resultEdited = false;
+        }
       }
 
+      // Write único do trade pai
       await updateDoc(tradeRef, updateData);
 
-      // C-RR3 (DEC-007): Recalcular RR quando campos relevantes mudam
-      // A CF onTradeUpdated também recalcula, mas fazemos aqui para feedback imediato
+      // C-RR3 (DEC-007): Recalcular RR
       const resultChanged = Math.abs((updateData.result ?? currentTrade.result) - (currentTrade.result || 0)) > 0.01;
       const stopChanged = updates.stopLoss !== undefined;
-      const priceChanged = updates.entry !== undefined || updates.exit !== undefined || updates.qty !== undefined;
+      const priceChanged = updates.entry !== undefined || updates.exit !== undefined || updates.qty !== undefined || _partials?.length > 0;
       
       if (resultChanged || stopChanged || priceChanged) {
         const effectiveStop = updateData.stopLoss !== undefined ? updateData.stopLoss : currentTrade.stopLoss;
-        const effectiveEntry = entry;
+        const effectiveEntry = parseFloat(updateData.entry ?? currentTrade.entry);
         const effectiveResult = updateData.result ?? currentTrade.result;
-        const effectiveQty = qty;
+        const effectiveQty = parseFloat(updateData.qty ?? currentTrade.qty);
         
         let newRrRatio = null;
         let newRrAssumed = false;
         
         if (effectiveStop != null && effectiveStop !== 0 && effectiveEntry) {
-          // RR real: baseado no stop loss efetivo
           const risk = Math.abs(effectiveEntry - effectiveStop);
           if (risk > 0) {
             const pointValue = (updates.tickerRule || currentTrade.tickerRule)?.pointValue || 1;
             newRrRatio = Math.round((effectiveResult / (risk * pointValue * effectiveQty)) * 100) / 100;
           }
         } else {
-          // RR assumido: buscar plano para calcular (DEC-007: usa plan.pl)
           try {
             const planId = currentTrade.planId;
             if (planId) {
@@ -460,69 +516,6 @@ export const useTrades = (overrideStudentId = null) => {
         }
         
         await updateDoc(tradeRef, { rrRatio: newRrRatio, rrAssumed: newRrAssumed });
-      }
-
-      // B3: Se parciais foram enviadas, substituir subcollection e recalcular
-      if (updates._partials && updates._partials.length > 0) {
-        // Deletar parciais antigas
-        const oldPartials = await getDocs(collection(db, 'trades', tradeId, 'partials'));
-        await Promise.all(oldPartials.docs.map(d => deleteDoc(d.ref)));
-
-        // Gravar novas parciais
-        const partialsRef = collection(db, 'trades', tradeId, 'partials');
-        for (const partial of updates._partials) {
-          await addDoc(partialsRef, {
-            seq: partial.seq,
-            type: partial.type,
-            price: parseFloat(partial.price),
-            qty: parseFloat(partial.qty),
-            dateTime: partial.dateTime || new Date().toISOString(),
-            notes: partial.notes || '',
-            createdAt: serverTimestamp()
-          });
-        }
-
-        // Recalcular trade a partir das novas parciais
-        const calc = calculateFromPartials({
-          side,
-          partials: updates._partials.map(p => ({ ...p, price: parseFloat(p.price), qty: parseFloat(p.qty) })),
-          tickerRule: tickerRule || null
-        });
-
-        // Sobrescrever campos derivados
-        const recalcData = {
-          hasPartials: true,
-          partialsCount: updates._partials.length,
-          avgEntry: calc.avgEntry,
-          avgExit: calc.avgExit,
-          entry: calc.avgEntry,
-          exit: calc.avgExit,
-          qty: calc.realizedQty,
-          totalQty: calc.realizedQty,
-          resultCalculated: calc.result,
-          result: calc.result,
-          resultInPoints: calc.resultInPoints,
-          resultEdited: false,
-          entryTime: calc.entryTime || currentTrade.entryTime,
-          exitTime: calc.exitTime || currentTrade.exitTime,
-          date: calc.entryTime ? calc.entryTime.split('T')[0] : currentTrade.date,
-          resultPercent: calc.avgEntry > 0 ? calculateResultPercent(side, calc.avgEntry, calc.avgExit) : 0,
-          updatedAt: serverTimestamp()
-        };
-
-        // Aplicar override se presente
-        if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
-          recalcData.result = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
-          recalcData.resultEdited = true;
-        }
-
-        await updateDoc(tradeRef, recalcData);
-        newResult = recalcData.result;
-
-        // Atualizar para RR e movement
-        Object.assign(updateData, recalcData);
-
-        console.log(`[useTrades] updateTrade: ${updates._partials.length} parciais substituídas, result=${calc.result}`);
       }
 
       // Sanitizar newResult para uso no movement

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -362,7 +362,8 @@ export const useTrades = (overrideStudentId = null) => {
       if (!tradeSnap.exists()) throw new Error('Trade não encontrado');
       
       const currentTrade = tradeSnap.data();
-      const updateData = { ...updates, updatedAt: serverTimestamp() };
+      const { _partials, ...cleanUpdates } = updates;
+      const updateData = { ...cleanUpdates, updatedAt: serverTimestamp() };
 
       const newEntryTime = updates.entryTime || currentTrade.entryTime;
       const newExitTime = updates.exitTime || currentTrade.exitTime;
@@ -459,6 +460,69 @@ export const useTrades = (overrideStudentId = null) => {
         }
         
         await updateDoc(tradeRef, { rrRatio: newRrRatio, rrAssumed: newRrAssumed });
+      }
+
+      // B3: Se parciais foram enviadas, substituir subcollection e recalcular
+      if (updates._partials && updates._partials.length > 0) {
+        // Deletar parciais antigas
+        const oldPartials = await getDocs(collection(db, 'trades', tradeId, 'partials'));
+        await Promise.all(oldPartials.docs.map(d => deleteDoc(d.ref)));
+
+        // Gravar novas parciais
+        const partialsRef = collection(db, 'trades', tradeId, 'partials');
+        for (const partial of updates._partials) {
+          await addDoc(partialsRef, {
+            seq: partial.seq,
+            type: partial.type,
+            price: parseFloat(partial.price),
+            qty: parseFloat(partial.qty),
+            dateTime: partial.dateTime || new Date().toISOString(),
+            notes: partial.notes || '',
+            createdAt: serverTimestamp()
+          });
+        }
+
+        // Recalcular trade a partir das novas parciais
+        const calc = calculateFromPartials({
+          side,
+          partials: updates._partials.map(p => ({ ...p, price: parseFloat(p.price), qty: parseFloat(p.qty) })),
+          tickerRule: tickerRule || null
+        });
+
+        // Sobrescrever campos derivados
+        const recalcData = {
+          hasPartials: true,
+          partialsCount: updates._partials.length,
+          avgEntry: calc.avgEntry,
+          avgExit: calc.avgExit,
+          entry: calc.avgEntry,
+          exit: calc.avgExit,
+          qty: calc.realizedQty,
+          totalQty: calc.realizedQty,
+          resultCalculated: calc.result,
+          result: calc.result,
+          resultInPoints: calc.resultInPoints,
+          resultEdited: false,
+          entryTime: calc.entryTime || currentTrade.entryTime,
+          exitTime: calc.exitTime || currentTrade.exitTime,
+          date: calc.entryTime ? calc.entryTime.split('T')[0] : currentTrade.date,
+          resultPercent: calc.avgEntry > 0 ? calculateResultPercent(side, calc.avgEntry, calc.avgExit) : 0,
+          updatedAt: serverTimestamp()
+        };
+
+        // Aplicar override se presente
+        if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
+          recalcData.result = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
+          recalcData.resultEdited = true;
+        }
+
+        await updateDoc(tradeRef, recalcData);
+        newResult = recalcData.result;
+
+        // Atualizar para RR e movement
+        Object.assign(updateData, recalcData);
+
+        console.log(`[useTrades] updateTrade: ${updates._partials.length} parciais substituídas, result=${calc.result}`);
       }
 
       // Sanitizar newResult para uso no movement

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -389,31 +389,16 @@ export const useTrades = (overrideStudentId = null) => {
       // === PARCIAIS SÃO A FONTE DA VERDADE ===
       // Quando _partials existe, TODO o recálculo vem delas. Campos entry/exit/qty/result são derivados.
       if (_partials && _partials.length > 0) {
-        // 1. Substituir subcollection
-        const oldPartials = await getDocs(collection(db, 'trades', tradeId, 'partials'));
-        await Promise.all(oldPartials.docs.map(d => deleteDoc(d.ref)));
-
-        const partialsRef = collection(db, 'trades', tradeId, 'partials');
-        for (const partial of _partials) {
-          await addDoc(partialsRef, {
-            seq: partial.seq,
-            type: partial.type,
-            price: parseFloat(partial.price),
-            qty: parseFloat(partial.qty),
-            dateTime: partial.dateTime || new Date().toISOString(),
-            notes: partial.notes || '',
-            createdAt: serverTimestamp()
-          });
-        }
-
-        // 2. Recalcular tudo a partir das parciais
+        // Recalcular a partir das parciais
+        const parsedPartials = _partials.map(p => ({ ...p, price: parseFloat(p.price), qty: parseFloat(p.qty) }));
         const calc = calculateFromPartials({
           side,
-          partials: _partials.map(p => ({ ...p, price: parseFloat(p.price), qty: parseFloat(p.qty) })),
+          partials: parsedPartials,
           tickerRule: tickerRule || null
         });
 
-        // 3. Campos derivados — única fonte
+        // Gravar parciais e campos derivados no documento
+        updateData._partials = parsedPartials;
         updateData.hasPartials = true;
         updateData.partialsCount = _partials.length;
         updateData.avgEntry = calc.avgEntry;
@@ -429,7 +414,6 @@ export const useTrades = (overrideStudentId = null) => {
         updateData.date = calc.entryTime ? calc.entryTime.split('T')[0] : currentTrade.date;
         updateData.resultPercent = calc.avgEntry > 0 ? calculateResultPercent(side, calc.avgEntry, calc.avgExit) : 0;
 
-        // Override de resultado (se presente)
         if (updates.resultOverride != null && !isNaN(parseFloat(updates.resultOverride))) {
           updateData.result = Math.round(parseFloat(updates.resultOverride) * 100) / 100;
           updateData.resultEdited = true;

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -203,8 +203,13 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
         );
       })()}
 
-      {/* Red Flags */}
-      {trade.redFlags && Array.isArray(trade.redFlags) && trade.redFlags.length > 0 && (
+      {/* Red Flags — ou indicador de processamento se CF ainda não respondeu */}
+      {trade.compliance === undefined && trade.riskPercent === undefined ? (
+        <div className="bg-slate-800/50 border border-slate-700/30 rounded-xl p-3 flex items-center gap-2">
+          <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
+          <span className="text-xs text-slate-400">Processando compliance...</span>
+        </div>
+      ) : trade.redFlags && Array.isArray(trade.redFlags) && trade.redFlags.length > 0 ? (
         <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-3">
           <div className="flex items-center gap-2 text-amber-400 mb-2">
             <AlertTriangle className="w-4 h-4" />
@@ -216,7 +221,7 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
             ))}
           </div>
         </div>
-      )}
+      ) : null}
 
       {/* Parciais — exibe quando trade tem dados carregados */}
       {trade._loadedPartials?.length > 0 && (

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -257,7 +257,7 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
               <div className="px-3 py-2 bg-slate-800/50 border-t border-slate-700/50 flex flex-wrap gap-3 text-xs">
                 {trade.avgEntry != null && <span className="text-slate-400">Média Entrada: <strong className="text-white font-mono">{trade.avgEntry}</strong></span>}
                 {trade.avgExit != null && <span className="text-slate-400">Média Saída: <strong className="text-white font-mono">{trade.avgExit}</strong></span>}
-                {trade.resultInPoints != null && <span className="text-slate-400">Pontos: <strong className={`font-mono ${trade.resultInPoints >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{trade.resultInPoints >= 0 ? '+' : ''}{trade.resultInPoints}</strong></span>}
+                {trade.resultInPoints != null ? <span className="text-slate-400">Pontos: <strong className={`font-mono ${trade.resultInPoints >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{trade.resultInPoints >= 0 ? '+' : ''}{trade.resultInPoints}</strong></span> : trade.resultEdited && <span className="text-slate-500 italic">Pontos: editado</span>}
               </div>
             )}
           </div>

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -161,6 +161,7 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
           rrCalc = movePts / riskPts;
         }
         const rrRatio = trade.rrRatio || trade.rr || rrCalc;
+        const isRrAssumed = trade.rrAssumed === true;
         
         // Resultado % sobre PL (usa planPl se disponível via _planPl prop)
         const planPl = Number(trade._planPl) || 0;
@@ -187,6 +188,9 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
               <div className={`${rrRatio >= 1 ? 'bg-blue-500/5 border-blue-500/20' : 'bg-amber-500/5 border-amber-500/20'} border rounded-xl p-3 text-center`}>
                 <span className="text-[10px] text-slate-500 uppercase tracking-wider block mb-1">RR</span>
                 <span className={`font-mono font-bold ${rrRatio >= 1 ? 'text-blue-400' : 'text-amber-400'}`}>{Number(rrRatio).toFixed(2)}:1</span>
+                {isRrAssumed && (
+                  <span className="text-[9px] text-purple-400/70 block mt-0.5" title="RR calculado sem stop loss, baseado no RO% do plano">(est.)</span>
+                )}
               </div>
             )}
             {resultPercentPl != null && (

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -38,6 +38,7 @@ import Loading from '../components/Loading';
 import SwotAnalysis from '../components/SwotAnalysis';
 import PlanManagementModal from '../components/PlanManagementModal';
 import PlanExtractModal from '../components/PlanExtractModal';
+import PlanAuditModal from '../components/dashboard/PlanAuditModal';
 import PlanLedgerExtract from '../components/PlanLedgerExtract';
 import DebugBadge from '../components/DebugBadge';
 
@@ -71,7 +72,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
   // === Data hooks ===
   const { trades, loading: tradesLoading, addTrade, updateTrade, deleteTrade, setSuspendListener } = useTrades(overrideStudentId);
   const { accounts, loading: accountsLoading, addAccount } = useAccounts(overrideStudentId);
-  const { plans, loading: plansLoading, addPlan, updatePlan, deletePlan } = usePlans(overrideStudentId);
+  const { plans, loading: plansLoading, addPlan, updatePlan, deletePlan, auditPlan, diagnosePlan } = usePlans(overrideStudentId);
 
   // Master data (emotions, tickers) + setups
   const { emotions, tickers: masterTickers } = useMasterData();
@@ -96,6 +97,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
   const [selectedPlanId, setSelectedPlanId] = useState(null);
   const [extractPlan, setExtractPlan] = useState(null);
   const [ledgerPlan, setLedgerPlan] = useState(null);
+  const [auditPlanId, setAuditPlanId] = useState(null);
   const [calendarSelectedDate, setCalendarSelectedDate] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [wizardComplete, setWizardComplete] = useState(false);
@@ -226,6 +228,22 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
     }
   };
 
+  const handleAuditPlan = (planId) => {
+    setAuditPlanId(planId);
+  };
+
+  const handleDiagnosePlan = () => {
+    if (!auditPlanId) return null;
+    return diagnosePlan(auditPlanId, trades);
+  };
+
+  const handleFixPlan = async () => {
+    if (!auditPlanId) return null;
+    return await auditPlan(auditPlanId, (progress) => {
+      console.log(`[Audit] Step ${progress.step}: ${progress.message}`);
+    });
+  };
+
   // === Loading / Empty states ===
   if (isLoading) return <Loading fullScreen text="Carregando..." />;
 
@@ -291,6 +309,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
         onEditPlan={(plan) => { setEditingPlan(plan); setShowPlanModal(true); }}
         onDeletePlan={handleDeletePlan}
         onCreatePlan={() => { setEditingPlan(null); setShowPlanModal(true); }}
+        onAuditPlan={handleAuditPlan}
       />
 
       {/* Filtros */}
@@ -388,6 +407,25 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
       <PlanManagementModal isOpen={showPlanModal} onClose={() => { setShowPlanModal(false); setEditingPlan(null); }} onSubmit={handleSavePlan} editingPlan={editingPlan} isSubmitting={isSubmitting} defaultAccountId={filters.accountId !== 'all' ? filters.accountId : undefined} />
       {extractPlan && (<PlanExtractModal isOpen={!!extractPlan} onClose={() => setExtractPlan(null)} plan={extractPlan} trades={trades.filter(t => t.planId === extractPlan.id)} />)}
       {ledgerPlan && (<PlanLedgerExtract plan={ledgerPlan} trades={trades.filter(t => t.planId === ledgerPlan.id)} onClose={() => setLedgerPlan(null)} currency={getPlanCurrency(ledgerPlan, accounts)} onNavigateToFeedback={onNavigateToFeedback ? (trade) => { setLedgerPlan(null); onNavigateToFeedback(trade); } : null} />)}
+
+      {/* Auditoria de Plano */}
+      {auditPlanId && (() => {
+        const auditPlanObj = plans.find(p => p.id === auditPlanId);
+        const auditCurrency = auditPlanObj ? getPlanCurrency(auditPlanObj, accounts) : 'BRL';
+        const auditPlanName = auditPlanObj
+          ? `${auditPlanObj.name} · ${auditPlanObj.operationPeriod || 'Diário'} · ${auditPlanObj.adjustmentCycle || 'Mensal'}`
+          : '';
+        return (
+          <PlanAuditModal
+            isOpen={!!auditPlanId}
+            onClose={() => setAuditPlanId(null)}
+            planName={auditPlanName}
+            currency={auditCurrency}
+            onDiagnose={handleDiagnosePlan}
+            onFix={handleFixPlan}
+          />
+        );
+      })()}
 
       {/* CSV Import Modais */}
       {showCsvWizard && (

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -16,7 +16,7 @@
  * - 1.0.6: View As Student suporte
  */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Wallet, X, Activity, Upload } from 'lucide-react';
 
 // Componentes extraídos
@@ -64,8 +64,10 @@ import { formatCurrencyDynamic, getPlanCurrency } from '../utils/currency';
 /**
  * @param {Object} viewAs - Dados do aluno sendo visualizado (quando mentor usa View As)
  * @param {Function} onNavigateToFeedback - Callback para navegar para a tela de feedback
+ * @param {string|null} returnToPlanId - PlanId do extrato a reabrir ao voltar do feedback
+ * @param {Function} onReturnConsumed - Callback para limpar o returnToPlanId após consumir
  */
-const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
+const StudentDashboard = ({ viewAs = null, onNavigateToFeedback, returnToPlanId = null, onReturnConsumed }) => {
   const { user } = useAuth();
   const overrideStudentId = viewAs?.uid || null;
 
@@ -103,6 +105,17 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
   const [wizardComplete, setWizardComplete] = useState(false);
   const [accountTypeFilter, setAccountTypeFilter] = useState('all');
   const [showCsvWizard, setShowCsvWizard] = useState(false);
+
+  // Reabrir extrato ao voltar do feedback
+  useEffect(() => {
+    if (returnToPlanId && !plansLoading && plans.length > 0) {
+      const plan = plans.find(p => p.id === returnToPlanId);
+      if (plan) {
+        setLedgerPlan(plan);
+      }
+      onReturnConsumed?.();
+    }
+  }, [returnToPlanId, plansLoading, plans]);
   const [showCsvManager, setShowCsvManager] = useState(false);
 
   const isLoading = tradesLoading || accountsLoading || plansLoading;
@@ -406,7 +419,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback }) => {
       <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} onViewFeedbackHistory={handleViewFeedbackHistory} />
       <PlanManagementModal isOpen={showPlanModal} onClose={() => { setShowPlanModal(false); setEditingPlan(null); }} onSubmit={handleSavePlan} editingPlan={editingPlan} isSubmitting={isSubmitting} defaultAccountId={filters.accountId !== 'all' ? filters.accountId : undefined} />
       {extractPlan && (<PlanExtractModal isOpen={!!extractPlan} onClose={() => setExtractPlan(null)} plan={extractPlan} trades={trades.filter(t => t.planId === extractPlan.id)} />)}
-      {ledgerPlan && (<PlanLedgerExtract plan={ledgerPlan} trades={trades.filter(t => t.planId === ledgerPlan.id)} onClose={() => setLedgerPlan(null)} currency={getPlanCurrency(ledgerPlan, accounts)} onNavigateToFeedback={onNavigateToFeedback ? (trade) => { setLedgerPlan(null); onNavigateToFeedback(trade); } : null} />)}
+      {ledgerPlan && (<PlanLedgerExtract plan={ledgerPlan} trades={trades.filter(t => t.planId === ledgerPlan.id)} onClose={() => setLedgerPlan(null)} currency={getPlanCurrency(ledgerPlan, accounts)} onNavigateToFeedback={onNavigateToFeedback ?? null} />)}
 
       {/* Auditoria de Plano */}
       {auditPlanId && (() => {

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -64,7 +64,7 @@ import { formatCurrencyDynamic, getPlanCurrency } from '../utils/currency';
 /**
  * @param {Object} viewAs - Dados do aluno sendo visualizado (quando mentor usa View As)
  * @param {Function} onNavigateToFeedback - Callback para navegar para a tela de feedback
- * @param {string|null} returnToPlanId - PlanId do extrato a reabrir ao voltar do feedback
+ * @param {string|null} returnToPlanId - PlanId do extrato a reabrir ao voltar do feedback (só quando veio do extrato)
  * @param {Function} onReturnConsumed - Callback para limpar o returnToPlanId após consumir
  */
 const StudentDashboard = ({ viewAs = null, onNavigateToFeedback, returnToPlanId = null, onReturnConsumed }) => {
@@ -105,18 +105,16 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback, returnToPlanId 
   const [wizardComplete, setWizardComplete] = useState(false);
   const [accountTypeFilter, setAccountTypeFilter] = useState('all');
   const [showCsvWizard, setShowCsvWizard] = useState(false);
+  const [showCsvManager, setShowCsvManager] = useState(false);
 
-  // Reabrir extrato ao voltar do feedback
+  // Reabrir extrato ao voltar do feedback (só quando veio do extrato — _fromLedgerPlanId)
   useEffect(() => {
     if (returnToPlanId && !plansLoading && plans.length > 0) {
       const plan = plans.find(p => p.id === returnToPlanId);
-      if (plan) {
-        setLedgerPlan(plan);
-      }
+      if (plan) setLedgerPlan(plan);
       onReturnConsumed?.();
     }
   }, [returnToPlanId, plansLoading, plans]);
-  const [showCsvManager, setShowCsvManager] = useState(false);
 
   const isLoading = tradesLoading || accountsLoading || plansLoading;
 
@@ -419,7 +417,7 @@ const StudentDashboard = ({ viewAs = null, onNavigateToFeedback, returnToPlanId 
       <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} onViewFeedbackHistory={handleViewFeedbackHistory} />
       <PlanManagementModal isOpen={showPlanModal} onClose={() => { setShowPlanModal(false); setEditingPlan(null); }} onSubmit={handleSavePlan} editingPlan={editingPlan} isSubmitting={isSubmitting} defaultAccountId={filters.accountId !== 'all' ? filters.accountId : undefined} />
       {extractPlan && (<PlanExtractModal isOpen={!!extractPlan} onClose={() => setExtractPlan(null)} plan={extractPlan} trades={trades.filter(t => t.planId === extractPlan.id)} />)}
-      {ledgerPlan && (<PlanLedgerExtract plan={ledgerPlan} trades={trades.filter(t => t.planId === ledgerPlan.id)} onClose={() => setLedgerPlan(null)} currency={getPlanCurrency(ledgerPlan, accounts)} onNavigateToFeedback={onNavigateToFeedback ?? null} />)}
+      {ledgerPlan && (<PlanLedgerExtract plan={ledgerPlan} trades={trades.filter(t => t.planId === ledgerPlan.id)} onClose={() => setLedgerPlan(null)} currency={getPlanCurrency(ledgerPlan, accounts)} onNavigateToFeedback={onNavigateToFeedback ? (trade) => onNavigateToFeedback({ ...trade, _fromLedgerPlanId: ledgerPlan.id }) : null} />)}
 
       {/* Auditoria de Plano */}
       {auditPlanId && (() => {

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -214,21 +214,16 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
           trades={filteredTrades} 
           plans={plans}
           onViewTrade={setViewingTrade} 
-          onEditTrade={async (t) => { 
-            // Sempre carregar parciais da subcollection antes de editar
-            try {
-              const partials = await getPartials(t.id);
-              setEditingTrade({ ...t, _partials: partials.length > 0 ? partials : [
+          onEditTrade={(t) => { 
+            // _partials já está no documento do trade (campo array)
+            // Se não existir, criar parciais a partir de entry/exit
+            if (!t._partials || t._partials.length === 0) {
+              t = { ...t, _partials: [
                 { type: 'ENTRY', price: t.entry, qty: t.qty, dateTime: t.entryTime, seq: 1 },
                 { type: 'EXIT', price: t.exit, qty: t.qty, dateTime: t.exitTime, seq: 2 }
-              ]});
-            } catch (err) {
-              console.warn('[TradesJournal] Erro ao carregar parciais, usando entry/exit:', err);
-              setEditingTrade({ ...t, _partials: [
-                { type: 'ENTRY', price: t.entry, qty: t.qty, dateTime: t.entryTime, seq: 1 },
-                { type: 'EXIT', price: t.exit, qty: t.qty, dateTime: t.exitTime, seq: 2 }
-              ]});
+              ]};
             }
+            setEditingTrade(t); 
             setShowAddModal(true); 
           }} 
           onDeleteTrade={async (trade) => { try { await deleteTrade(trade.id, trade.htfUrl, trade.ltfUrl); } catch (err) { console.error(err); } }} 

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -214,7 +214,23 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
           trades={filteredTrades} 
           plans={plans}
           onViewTrade={setViewingTrade} 
-          onEditTrade={(t) => { setEditingTrade(t); setShowAddModal(true); }} 
+          onEditTrade={async (t) => { 
+            // Sempre carregar parciais da subcollection antes de editar
+            try {
+              const partials = await getPartials(t.id);
+              setEditingTrade({ ...t, _partials: partials.length > 0 ? partials : [
+                { type: 'ENTRY', price: t.entry, qty: t.qty, dateTime: t.entryTime, seq: 1 },
+                { type: 'EXIT', price: t.exit, qty: t.qty, dateTime: t.exitTime, seq: 2 }
+              ]});
+            } catch (err) {
+              console.warn('[TradesJournal] Erro ao carregar parciais, usando entry/exit:', err);
+              setEditingTrade({ ...t, _partials: [
+                { type: 'ENTRY', price: t.entry, qty: t.qty, dateTime: t.entryTime, seq: 1 },
+                { type: 'EXIT', price: t.exit, qty: t.qty, dateTime: t.exitTime, seq: 2 }
+              ]});
+            }
+            setShowAddModal(true); 
+          }} 
           onDeleteTrade={async (trade) => { try { await deleteTrade(trade.id, trade.htfUrl, trade.ltfUrl); } catch (err) { console.error(err); } }} 
         />
         {filteredTrades.length === 0 && (

--- a/src/utils/compliance.js
+++ b/src/utils/compliance.js
@@ -1,12 +1,16 @@
 /**
  * Trade Compliance — Cálculos puros
- * @version 1.0.0
+ * @version 2.0.0 (v1.19.1)
  * 
  * Lógica extraída de functions/index.js (calculateTradeCompliance)
  * para permitir testes unitários no frontend.
  * 
  * IMPORTANTE: Manter sincronizado com functions/index.js.
  * TODO: Fase futura — unificar em módulo shared.
+ * 
+ * CHANGELOG:
+ * - 2.0.0 (v1.19.1): DEC-006 — RO sem stop: loss → risco retroativo, win → N/A, breakeven → 0
+ * - 1.0.0 (v1.17.0): Extração inicial, sem stop = 100% (substituído por DEC-006)
  */
 
 /**
@@ -25,16 +29,19 @@ export const RED_FLAG_TYPES = {
  * Calcula compliance do trade contra o plano
  * Risco Operacional (RO) e Razão Risco-Retorno (RR)
  * 
- * Sem stopLoss → riskPercent = 100 (todo o PL em risco)
- * RR: prefere takeProfit se disponível, fallback para resultado efetivo
+ * === DEC-006 (v1.19.1): Lógica sem stop ===
+ * - Com stop: risco = (distância / tickSize) * tickValue * qty / planPl * 100
+ * - Sem stop + loss: risco retroativo = |result| / planPl * 100
+ * - Sem stop + win:  riskPercent = null (N/A — impossível inferir risco)
+ * - Sem stop + breakeven (result = 0): riskPercent = 0
  * 
  * @param {Object} trade - { entry, stopLoss, takeProfit, qty, result, tickerRule: { tickSize, tickValue } }
  * @param {Object} plan - { currentPl, pl, riskPerOperation, rrTarget }
- * @returns {{ riskPercent: number, rrRatio: number|null, compliance: { roStatus: string, rrStatus: string } }}
+ * @returns {{ riskPercent: number|null, rrRatio: number|null, compliance: { roStatus: string, rrStatus: string } }}
  */
 export const calculateTradeCompliance = (trade, plan) => {
   const result = { 
-    riskPercent: 0, 
+    riskPercent: null, 
     rrRatio: null, 
     compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' } 
   };
@@ -50,14 +57,25 @@ export const calculateTradeCompliance = (trade, plan) => {
     const tickSize = trade.tickerRule?.tickSize || 1;
     const tickValue = trade.tickerRule?.tickValue || 1;
     const distanceInPoints = Math.abs(trade.entry - trade.stopLoss);
-    const riskAmount = (distanceInPoints / tickSize) * tickValue * trade.qty;
+    const riskAmount = (distanceInPoints / tickSize) * tickValue * (trade.qty ?? 1);
     result.riskPercent = (riskAmount / planPl) * 100;
   } else {
-    // Sem stop: 100% do PL em risco (pior cenário)
-    result.riskPercent = 100;
+    // DEC-006: Sem stop — risco retroativo baseado no resultado
+    const tradeResult = trade.result ?? 0;
+    if (tradeResult < 0) {
+      // Loss: risco materializado = |result| / planPl
+      result.riskPercent = (Math.abs(tradeResult) / planPl) * 100;
+    } else if (tradeResult === 0) {
+      // Breakeven: sem materialização de risco
+      result.riskPercent = 0;
+    } else {
+      // Win: impossível inferir risco sem stop — N/A
+      result.riskPercent = null;
+    }
   }
   
-  if (plan.riskPerOperation && result.riskPercent > plan.riskPerOperation) {
+  // RO compliance: só avalia se riskPercent é numérico
+  if (result.riskPercent != null && plan.riskPerOperation && result.riskPercent > plan.riskPerOperation) {
     result.compliance.roStatus = 'FORA_DO_PLANO';
   }
   
@@ -73,7 +91,7 @@ export const calculateTradeCompliance = (trade, plan) => {
         // Via resultado efetivo (realizado) — converter result R$ para pontos
         const tickSize = trade.tickerRule?.tickSize || 1;
         const tickValue = trade.tickerRule?.tickValue || 1;
-        const resultInPoints = (trade.result / (tickValue * trade.qty)) * tickSize;
+        const resultInPoints = (trade.result / (tickValue * (trade.qty ?? 1))) * tickSize;
         result.rrRatio = resultInPoints / risk;
       }
       
@@ -90,6 +108,10 @@ export const calculateTradeCompliance = (trade, plan) => {
  * Gera lista de red flags de compliance para um trade
  * Usado para reconstruir flags após recálculo.
  * 
+ * DEC-006 (v1.19.1): Red flag NO_STOP continua existindo (trade sem stop É uma violação
+ * de disciplina), mas a mensagem é contextualizada e NÃO implica risco de 100%.
+ * A flag RISK_EXCEEDED só é gerada quando riskPercent é numérico.
+ * 
  * @param {Object} trade - Trade com dados completos
  * @param {Object} plan - Plano vinculado
  * @param {Object} complianceResult - Resultado de calculateTradeCompliance
@@ -99,14 +121,24 @@ export const generateComplianceRedFlags = (trade, plan, complianceResult) => {
   const flags = [];
   
   if (!trade.stopLoss) {
+    // DEC-006: Mensagem contextualizada — não afirma mais "risco ilimitado"
+    const tradeResult = trade.result ?? 0;
+    let noStopMessage = 'Trade sem stop loss definido';
+    if (tradeResult < 0 && complianceResult.riskPercent != null) {
+      noStopMessage += ` — risco retroativo: ${complianceResult.riskPercent.toFixed(1)}%`;
+    } else if (tradeResult > 0) {
+      noStopMessage += ' — risco não mensurado (win sem stop)';
+    }
+    
     flags.push({ 
       type: RED_FLAG_TYPES.NO_STOP, 
-      message: 'Trade sem stop loss definido — risco ilimitado', 
+      message: noStopMessage, 
       timestamp: new Date().toISOString() 
     });
   }
   
-  if (complianceResult.compliance.roStatus === 'FORA_DO_PLANO') {
+  // RISK_EXCEEDED: só quando riskPercent é numérico (com stop ou loss retroativo)
+  if (complianceResult.riskPercent != null && complianceResult.compliance.roStatus === 'FORA_DO_PLANO') {
     flags.push({ 
       type: RED_FLAG_TYPES.RISK_EXCEEDED, 
       message: `Risco ${complianceResult.riskPercent.toFixed(1)}% excede máximo do plano (${plan.riskPerOperation}%)`, 

--- a/src/utils/compliance.js
+++ b/src/utils/compliance.js
@@ -177,7 +177,7 @@ export const generateComplianceRedFlags = (trade, plan, complianceResult) => {
   if (complianceResult.compliance.rrStatus === 'NAO_CONFORME' && complianceResult.rrRatio != null) {
     flags.push({ 
       type: RED_FLAG_TYPES.RR_BELOW_MINIMUM, 
-      message: `RR ${complianceResult.rrRatio.toFixed(1)}x abaixo do mínimo (${plan.rrTarget}x)`, 
+      message: `RR ${complianceResult.rrRatio.toFixed(2)}x abaixo do mínimo (${plan.rrTarget}x)`, 
       timestamp: new Date().toISOString() 
     });
   }

--- a/src/utils/compliance.js
+++ b/src/utils/compliance.js
@@ -1,6 +1,6 @@
 /**
  * Trade Compliance — Cálculos puros
- * @version 2.0.0 (v1.19.1)
+ * @version 3.0.0 (v1.19.2)
  * 
  * Lógica extraída de functions/index.js (calculateTradeCompliance)
  * para permitir testes unitários no frontend.
@@ -9,6 +9,9 @@
  * TODO: Fase futura — unificar em módulo shared.
  * 
  * CHANGELOG:
+ * - 3.0.0 (v1.19.2): DEC-007 — RR assumido integrado no calculateTradeCompliance.
+ *   Trades sem stop agora calculam rrRatio via plan.pl (capital base) × RO%.
+ *   Guard C4 removido — CF e frontend recalculam RR assumido em todos os pontos.
  * - 2.0.0 (v1.19.1): DEC-006 — RO sem stop: loss → risco retroativo, win → N/A, breakeven → 0
  * - 1.0.0 (v1.17.0): Extração inicial, sem stop = 100% (substituído por DEC-006)
  */
@@ -35,14 +38,21 @@ export const RED_FLAG_TYPES = {
  * - Sem stop + win:  riskPercent = null (N/A — impossível inferir risco)
  * - Sem stop + breakeven (result = 0): riskPercent = 0
  * 
+ * === DEC-007 (v1.19.2): RR assumido para trades sem stop ===
+ * Quando trade não tem stop, calcula RR assumido:
+ *   RO$ = plan.pl (capital base) × plan.riskPerOperation / 100
+ *   rrRatio = result / RO$
+ * Usa plan.pl (não currentPl) porque o risco é definido sobre o capital alocado ao ciclo.
+ * 
  * @param {Object} trade - { entry, stopLoss, takeProfit, qty, result, tickerRule: { tickSize, tickValue } }
  * @param {Object} plan - { currentPl, pl, riskPerOperation, rrTarget }
- * @returns {{ riskPercent: number|null, rrRatio: number|null, compliance: { roStatus: string, rrStatus: string } }}
+ * @returns {{ riskPercent: number|null, rrRatio: number|null, rrAssumed: boolean, compliance: { roStatus: string, rrStatus: string } }}
  */
 export const calculateTradeCompliance = (trade, plan) => {
   const result = { 
     riskPercent: null, 
-    rrRatio: null, 
+    rrRatio: null,
+    rrAssumed: false,
     compliance: { roStatus: 'CONFORME', rrStatus: 'CONFORME' } 
   };
   
@@ -81,6 +91,7 @@ export const calculateTradeCompliance = (trade, plan) => {
   
   // === Razão Risco-Retorno (RR) ===
   if (trade.stopLoss && trade.entry) {
+    // COM stop: RR real baseado na distância do stop
     const risk = Math.abs(trade.entry - trade.stopLoss);
     if (risk > 0) {
       if (trade.takeProfit) {
@@ -94,11 +105,22 @@ export const calculateTradeCompliance = (trade, plan) => {
         const resultInPoints = (trade.result / (tickValue * (trade.qty ?? 1))) * tickSize;
         result.rrRatio = resultInPoints / risk;
       }
-      
-      if (result.rrRatio != null && plan.rrTarget && result.rrRatio < plan.rrTarget) {
-        result.compliance.rrStatus = 'NAO_CONFORME';
-      }
     }
+  } else {
+    // DEC-007: SEM stop — RR assumido via plan.pl (capital base) × RO%
+    const basePl = Number(plan.pl) || 0;
+    const roPercent = Number(plan.riskPerOperation) || 0;
+    if (basePl > 0 && roPercent > 0) {
+      const roAmount = basePl * (roPercent / 100);
+      const tradeResult = trade.result ?? 0;
+      result.rrRatio = Math.round((tradeResult / roAmount) * 100) / 100;
+      result.rrAssumed = true;
+    }
+  }
+
+  // RR compliance: avalia se rrRatio é numérico
+  if (result.rrRatio != null && plan.rrTarget && result.rrRatio < plan.rrTarget) {
+    result.compliance.rrStatus = 'NAO_CONFORME';
   }
   
   return result;

--- a/src/utils/compliance.js
+++ b/src/utils/compliance.js
@@ -118,8 +118,14 @@ export const calculateTradeCompliance = (trade, plan) => {
     }
   }
 
-  // RR compliance: avalia se rrRatio é numérico
-  if (result.rrRatio != null && plan.rrTarget && result.rrRatio < plan.rrTarget) {
+  // RR compliance: 
+  // - Com takeProfit: sempre avalia (métrica planejada, independe do resultado)
+  // - Sem takeProfit + win (result > 0): avalia (win que não atingiu alvo)
+  // - Sem takeProfit + loss/breakeven (result <= 0): NÃO avalia (perder 1R é o risco planejado)
+  const tradeResultForRR = trade.result ?? 0;
+  const hasPlannedRR = !!(trade.takeProfit || trade.stopLoss && trade.takeProfit);
+  const shouldEvaluateRR = hasPlannedRR || tradeResultForRR > 0;
+  if (result.rrRatio != null && plan.rrTarget && shouldEvaluateRR && result.rrRatio < plan.rrTarget) {
     result.compliance.rrStatus = 'NAO_CONFORME';
   }
   

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.19.1: DEC-006 compliance sem stop (C1-C5), guard rrAssumed (C4), CSV tickerRule (C2), botão auditoria, PlanAuditModal diagnóstico bidirecional
  * - 1.19.0: RR assumido (B2), PlanLedgerExtract RO/RR + feedback nav (B4), P&L contextual (B5) (#71/#73)
  * - 1.18.2: Fix locale pt-BR para todas as moedas (DEC-004)
  * - 1.18.1: Inferência direção CSV (DEC-003), parseNumericValue, Step 2 redesign, ticker validation
@@ -12,10 +13,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.19.0',
-  build: '20260309',
-  display: 'v1.19.0',
-  full: '1.19.0+20260309',
+  version: '1.19.1',
+  build: '20260310',
+  display: 'v1.19.1',
+  full: '1.19.1+20260310',
 };
 export default VERSION;
 export { VERSION };

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.19.2: DEC-007 RR assumido integrado em calculateTradeCompliance (plan.pl base), guard C4 removido, updateTrade recalcula RR, diagnosePlan detecta rrAssumed stale
  * - 1.19.1: DEC-006 compliance sem stop (C1-C5), guard rrAssumed (C4), CSV tickerRule (C2), botão auditoria, PlanAuditModal diagnóstico bidirecional
  * - 1.19.0: RR assumido (B2), PlanLedgerExtract RO/RR + feedback nav (B4), P&L contextual (B5) (#71/#73)
  * - 1.18.2: Fix locale pt-BR para todas as moedas (DEC-004)
@@ -13,10 +14,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.19.1',
-  build: '20260310',
-  display: 'v1.19.1',
-  full: '1.19.1+20260310',
+  version: '1.19.2',
+  build: '20260311',
+  display: 'v1.19.2',
+  full: '1.19.2+20260311',
 };
 export default VERSION;
 export { VERSION };

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.19.3: C3 (RR 2 casas decimais), C5 (resultInPoints null em override), coluna Status Feedback no ExtractTable
  * - 1.19.2: DEC-007 RR assumido integrado em calculateTradeCompliance (plan.pl base), guard C4 removido, updateTrade recalcula RR, diagnosePlan detecta rrAssumed stale
  * - 1.19.1: DEC-006 compliance sem stop (C1-C5), guard rrAssumed (C4), CSV tickerRule (C2), botão auditoria, PlanAuditModal diagnóstico bidirecional
  * - 1.19.0: RR assumido (B2), PlanLedgerExtract RO/RR + feedback nav (B4), P&L contextual (B5) (#71/#73)
@@ -14,10 +15,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.19.2',
-  build: '20260311',
-  display: 'v1.19.2',
-  full: '1.19.2+20260311',
+  version: '1.19.3',
+  build: '20260312',
+  display: 'v1.19.3',
+  full: '1.19.3+20260312',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
**Body:**
```
Fecha #78

## Resumo
Epic de 5 sub-tasks corrigindo compliance de trades sem stop loss.

### v1.19.1 (sessão 10/03)
- C1: RO% sem stop — risco retroativo (DEC-006)
- C2: CSV Import tickerRule lookup
- Botão auditoria + PlanAuditModal

### v1.19.2 (sessão 11/03)
- DEC-007: RR assumido via plan.pl (capital base)
- Guard C4 removido
- updateTrade recalcula RR
- diagnosePlan detecta stale

### v1.19.3 (sessão 12/03)
- C3: RR exibido com 2 casas decimais
- C5: resultInPoints null em override ("editado")
- ExtractTable v4.1 — grid compacto, status feedback
- Navegação feedback ida/volta contextual
- RR compliant em azul

## Testes
394 passando, 17 suites, zero regressão

## CF pendente
`firebase deploy --only functions` (v1.9.0)