### PR TITLE
feat: layout 3 paineis agrupados + tooltips diagnosticos + Assimetria de Risco + EV (v1.19.5)

### DIFF
--- a/CHANGELOG-v1_19_5-entry.md
+++ b/CHANGELOG-v1_19_5-entry.md
@@ -1,0 +1,24 @@
+## [1.19.5] - 2026-03-15
+
+### Adicionado
+- **Layout agrupado 3 paineis no dashboard:** MetricsCards v4.1.0 reorganiza 7 cards em 3 paineis tematicos — Financeiro (Saldo, P&L, Expectancy, Drawdown, PF), Assimetria de Risco (WR, WR Planejado, Risco W/L, RO medio), EV (EV esperado vs EV real, gap, perda acumulada). Grid responsivo lg:grid-cols-3.
+- **Tooltips diagnosticos dinamicos:** Cada painel tem botao (i) que abre tooltip com conclusoes geradas com base nos dados reais — ex: "Acerta 80% mas so 20% atingem o alvo — ansiedade de saida", "Causa principal: sizing inconsistente". Novo util `metricsInsights.js` com 3 geradores (financial, performance, planVsResult).
+- **Trades sem stop assumem RO$ do plano:** `calculateRiskAsymmetry` agora atribui `plan.riskPerOperation` como risco para trades sem `riskPercent` (sem stop loss). Elimina "N/D" e "0.00x" no card de assimetria.
+- **Numero de trades no card EV:** Exibe contagem ao lado de "Perda acumulada" para o mentor fechar a conta mentalmente.
+
+### Corrigido
+- **NaN guards em dashboardMetrics.js:** `Number()` + `isNaN()` + `isFinite()` em todos os inputs de `calculateRiskAsymmetry`. Previne "NaNx" e "NaN%" em planos com dados incompletos.
+- **NaN guards em MetricsCards.jsx:** Helper `safe()` com fallback "-" em todos os `.toFixed()` da UI.
+- **Sinal do EV leakage:** 90% de perda agora mostra "90%" (nao "-90%").
+- **Tooltips nativos restaurados:** `title` attributes de Drawdown (data pior vale), Profit Factor (trades sem violacoes), Win Rate (WR planejado detalhado) que foram perdidos na refatoracao v1.19.4.
+
+### Modificado
+- `MetricsCards.jsx` v4.1.0: Rewrite completo — 3 paineis, tooltips diagnosticos, NaN guards
+- `metricsInsights.js` (novo): getFinancialInsights, getPerformanceInsights, getPlanVsResultInsights
+- `dashboardMetrics.js`: NaN guards + trades sem stop assumem RO$
+- `riskAsymmetry.test.js`: Teste atualizado para nova semantica (assume RO$ em vez de ignorar)
+- `version.js`: v1.19.5+20260315
+
+### Testes
+- 15 novos testes `metricsInsights.test.js`: insights financeiros (expectancy +/-, drawdown, PF), desempenho (ansiedade saida, sizing critico/consistente, compliance), plano vs resultado (leakage critico, superando, diagnostico causas combinadas)
+- `riskAsymmetry.test.js`: 1 teste atualizado (sem stop assume RO$)

--- a/src/__tests__/utils/metricsInsights.test.js
+++ b/src/__tests__/utils/metricsInsights.test.js
@@ -1,0 +1,196 @@
+/**
+ * Tests: metricsInsights -- v1.19.5
+ * @description Testa gerador de conclusoes diagnosticas para tooltips
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getFinancialInsights, getPerformanceInsights, getPlanVsResultInsights } from '../../utils/metricsInsights';
+
+describe('getFinancialInsights', () => {
+
+  it('expectancy positivo -> insight success', () => {
+    const insights = getFinancialInsights({
+      stats: { totalPL: 5000, winRate: 60, profitFactor: 1.5 },
+      drawdown: 2,
+      maxDrawdownData: { maxDD: 500, maxDDPercent: 2.5 },
+      evLeakage: { evReal: 664 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.severity === 'success' && i.text.includes('positivo'))).toBe(true);
+  });
+
+  it('expectancy negativo -> insight danger', () => {
+    const insights = getFinancialInsights({
+      stats: { totalPL: -2000, winRate: 30, profitFactor: 0.5 },
+      drawdown: 8,
+      maxDrawdownData: { maxDD: 3000, maxDDPercent: 8 },
+      evLeakage: { evReal: -150 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('negativo'))).toBe(true);
+  });
+
+  it('drawdown alto -> insight danger', () => {
+    const insights = getFinancialInsights({
+      stats: { totalPL: 1000, winRate: 55, profitFactor: 1.2 },
+      drawdown: 12,
+      maxDrawdownData: { maxDD: 5000, maxDDPercent: 12 },
+      evLeakage: { evReal: 100 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('Drawdown'))).toBe(true);
+  });
+
+  it('profit factor < 1 -> insight danger', () => {
+    const insights = getFinancialInsights({
+      stats: { totalPL: -500, winRate: 40, profitFactor: 0.7 },
+      drawdown: 3,
+      maxDrawdownData: { maxDD: 200, maxDDPercent: 3 },
+      evLeakage: { evReal: -50 },
+      currency: 'USD'
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('Profit Factor'))).toBe(true);
+  });
+
+  it('tudo ok -> insight info parametros', () => {
+    const insights = getFinancialInsights({
+      stats: { totalPL: 1000, winRate: 55, profitFactor: 1.5 },
+      drawdown: 2,
+      maxDrawdownData: { maxDD: 100, maxDDPercent: 2 },
+      evLeakage: null,
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.text.includes('parametros'))).toBe(true);
+  });
+
+  it('stats null -> retorna vazio', () => {
+    const insights = getFinancialInsights({ stats: null, drawdown: 0, maxDrawdownData: {}, evLeakage: null, currency: 'BRL' });
+    expect(insights).toEqual([]);
+  });
+});
+
+describe('getPerformanceInsights', () => {
+
+  it('WR alto + WR planejado baixo -> ansiedade de saida', () => {
+    const insights = getPerformanceInsights({
+      stats: { winRate: 80 },
+      winRatePlanned: { rate: 20, gap: 60, disciplinedWins: 2, eligible: 10 },
+      riskAsymmetry: null,
+      complianceRate: null
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('ansiedade'))).toBe(true);
+  });
+
+  it('sizing critico < 0.4 -> insight danger', () => {
+    const insights = getPerformanceInsights({
+      stats: { winRate: 60 },
+      winRatePlanned: null,
+      riskAsymmetry: { asymmetryRatio: 0.1, avgRoEfficiency: 50, winsCount: 5 },
+      complianceRate: null
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('Sizing critico'))).toBe(true);
+  });
+
+  it('sizing consistente -> insight success', () => {
+    const insights = getPerformanceInsights({
+      stats: { winRate: 60 },
+      winRatePlanned: { rate: 55, gap: 5 },
+      riskAsymmetry: { asymmetryRatio: 1.0, avgRoEfficiency: 80, winsCount: 10 },
+      complianceRate: { rate: 90, violations: 1, total: 10 }
+    });
+
+    expect(insights.some(i => i.severity === 'success')).toBe(true);
+  });
+
+  it('wins sem stop -> warning', () => {
+    const insights = getPerformanceInsights({
+      stats: { winRate: 60 },
+      winRatePlanned: null,
+      riskAsymmetry: { asymmetryRatio: null, avgRoEfficiency: 50, winsCount: 0 },
+      complianceRate: null
+    });
+
+    expect(insights.some(i => i.text.includes('sem stop'))).toBe(true);
+  });
+
+  it('compliance baixa -> danger', () => {
+    const insights = getPerformanceInsights({
+      stats: { winRate: 50 },
+      winRatePlanned: null,
+      riskAsymmetry: null,
+      complianceRate: { rate: 40, violations: 6, total: 10, compliant: 4 }
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('violacoes'))).toBe(true);
+  });
+});
+
+describe('getPlanVsResultInsights', () => {
+
+  it('leakage > 60% -> critico com valor perdido', () => {
+    const insights = getPlanVsResultInsights({
+      evLeakage: { leakage: 80, totalLeakage: 5000, evTheoretical: 1000, evReal: 200 },
+      riskAsymmetry: null,
+      winRatePlanned: null,
+      stats: { winRate: 50 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.severity === 'danger' && i.text.includes('critica'))).toBe(true);
+  });
+
+  it('leakage < 0 -> superando', () => {
+    const insights = getPlanVsResultInsights({
+      evLeakage: { leakage: -20, totalLeakage: -1000, evTheoretical: 500, evReal: 600 },
+      riskAsymmetry: null,
+      winRatePlanned: null,
+      stats: { winRate: 70 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.severity === 'success' && i.text.includes('Superando'))).toBe(true);
+  });
+
+  it('leakage com ansiedade + sizing -> diagnostica ambas causas', () => {
+    const insights = getPlanVsResultInsights({
+      evLeakage: { leakage: 50, totalLeakage: 3000, evTheoretical: 800, evReal: 400 },
+      riskAsymmetry: { asymmetryRatio: 0.3 },
+      winRatePlanned: { rate: 30, gap: 40 },
+      stats: { winRate: 70 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.text.includes('saida antecipada') && i.text.includes('sizing'))).toBe(true);
+  });
+
+  it('leakage com so ansiedade -> diagnostica causa unica', () => {
+    const insights = getPlanVsResultInsights({
+      evLeakage: { leakage: 40, totalLeakage: 2000, evTheoretical: 600, evReal: 360 },
+      riskAsymmetry: { asymmetryRatio: 0.9 },
+      winRatePlanned: { rate: 30, gap: 30 },
+      stats: { winRate: 60 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.text.includes('saida antecipada') && !i.text.includes('sizing'))).toBe(true);
+  });
+
+  it('sem dados -> insight info', () => {
+    const insights = getPlanVsResultInsights({
+      evLeakage: null,
+      riskAsymmetry: null,
+      winRatePlanned: null,
+      stats: { winRate: 50 },
+      currency: 'BRL'
+    });
+
+    expect(insights.some(i => i.text.includes('insuficientes'))).toBe(true);
+  });
+});

--- a/src/__tests__/utils/riskAsymmetry.test.js
+++ b/src/__tests__/utils/riskAsymmetry.test.js
@@ -108,17 +108,19 @@ describe('calculateRiskAsymmetry', () => {
     expect(result.asymmetryRatio).toBeNull();  // avgRiskLosses = 0, divisao por zero
   });
 
-  it('trades sem riskPercent sao ignorados', () => {
+  it('trades sem riskPercent assumem RO$ do plano', () => {
     const trades = [
-      { planId: 'plan1', result: 2000, riskPercent: 0.5 },    // incluido
-      { planId: 'plan1', result: 1000, riskPercent: null },    // ignorado (win sem stop)
-      { planId: 'plan1', result: -500, riskPercent: 0.25 },    // incluido
+      { planId: 'plan1', result: 2000, riskPercent: 0.5 },    // win, risco R$1000
+      { planId: 'plan1', result: 1000, riskPercent: null },    // win sem stop -> assume RO$ = R$1000
+      { planId: 'plan1', result: -500, riskPercent: 0.25 },    // loss, risco R$500
     ];
 
     const result = calculateRiskAsymmetry(trades, [basePlan]);
 
-    expect(result.winsCount).toBe(1);   // so 1 win com riskPercent
+    expect(result.winsCount).toBe(2);   // ambos wins incluidos
     expect(result.lossesCount).toBe(1);
+    // avgRiskWins = (1000 + 1000) / 2 = 1000
+    expect(result.avgRiskWins).toBe(1000);
   });
 
   it('trades sem planId valido sao ignorados', () => {

--- a/src/components/dashboard/MetricsCards.jsx
+++ b/src/components/dashboard/MetricsCards.jsx
@@ -1,95 +1,67 @@
 /**
  * MetricsCards
- * @version 3.0.0 (v1.19.4)
- * @description Cards de métricas do StudentDashboard (Saldo, P&L, WR, PF, DD, Eficiência do Risco).
- *   v3.0.0: Card "Eficiência do Risco" — Risk Asymmetry W/L + RO Efficiency.
- *   v2.0.0: P&L contextual — label dinâmico (B5 — Issue #71).
- *   v1.0.0: Extraído do StudentDashboard para modularização.
- *   Suporta multi-moeda: quando dominantCurrency é null, exibe breakdown por moeda.
+ * @version 4.1.0 (v1.19.5)
+ * @description Paineis agrupados de metricas do StudentDashboard.
+ *   v4.1.0: 3 paineis em linha unica, tooltips nativos restaurados, EV com explicacao semantica.
+ *   v4.0.0: Layout 3 paineis + tooltips diagnosticos + NaN guards.
+ *   v3.0.0: Cards Risk Asymmetry + EV Leakage (7 cards).
+ *   v2.0.0: P&L contextual (B5 - Issue #71).
+ *   v1.0.0: Extraido do StudentDashboard.
  */
 
-import { DollarSign, Target, TrendingDown, Wallet, Activity, Shield, Info } from 'lucide-react';
-import { useState } from 'react';
+import { DollarSign, Target, BarChart3, Info } from 'lucide-react';
+import { useState, useMemo } from 'react';
 import { formatPercent } from '../../utils/calculations';
 import { formatCurrencyDynamic } from '../../utils/currency';
+import { getFinancialInsights, getPerformanceInsights, getPlanVsResultInsights } from '../../utils/metricsInsights';
 import DebugBadge from '../DebugBadge';
 
-/**
- * Classifica o Risk Asymmetry ratio em faixas de severidade.
- * @param {number|null} ratio
- * @returns {{ label: string, color: string, bgColor: string }}
- */
+const safe = (v, d = 0) => (v != null && !isNaN(v) && isFinite(v)) ? v.toFixed(d) : '-';
+
 const getAsymmetryLevel = (ratio) => {
-  if (ratio == null) return { label: '-', color: 'text-slate-400', bgColor: 'bg-slate-500/20' };
-  if (ratio >= 0.9 && ratio <= 1.1) return { label: 'Excelente', color: 'text-emerald-400', bgColor: 'bg-emerald-500/20' };
-  if (ratio >= 0.7) return { label: 'Bom', color: 'text-blue-400', bgColor: 'bg-blue-500/20' };
-  if (ratio >= 0.4) return { label: 'Atenção', color: 'text-amber-400', bgColor: 'bg-amber-500/20' };
-  return { label: 'Crítico', color: 'text-red-400', bgColor: 'bg-red-500/20' };
+  if (ratio == null || isNaN(ratio)) return { label: '-', color: 'text-slate-400' };
+  if (ratio >= 0.9 && ratio <= 1.1) return { label: 'Excelente', color: 'text-emerald-400' };
+  if (ratio >= 0.7) return { label: 'Bom', color: 'text-blue-400' };
+  if (ratio >= 0.4) return { label: 'Atencao', color: 'text-amber-400' };
+  return { label: 'Critico', color: 'text-red-400' };
 };
 
-/**
- * Tooltip de referência para Risk Asymmetry.
- */
-const RiskAsymmetryTooltip = ({ onClose }) => (
-  <div className="absolute top-full right-0 mt-2 w-72 bg-slate-800 border border-slate-700 rounded-lg p-4 shadow-xl z-50">
+const getLeakageLevel = (leakage) => {
+  if (leakage == null || isNaN(leakage)) return { label: '-', color: 'text-slate-400' };
+  if (leakage < 0) return { label: 'Superando', color: 'text-emerald-400' };
+  if (leakage <= 10) return { label: 'Excelente', color: 'text-emerald-400' };
+  if (leakage <= 30) return { label: 'Bom', color: 'text-blue-400' };
+  if (leakage <= 60) return { label: 'Atencao', color: 'text-amber-400' };
+  return { label: 'Critico', color: 'text-red-400' };
+};
+
+const sevDot = (s) => ({ success: 'bg-emerald-400', warning: 'bg-amber-400', danger: 'bg-red-400' }[s] || 'bg-slate-500');
+const sevText = (s) => ({ success: 'text-emerald-400', warning: 'text-amber-400', danger: 'text-red-400' }[s] || 'text-slate-400');
+
+const DiagnosticTooltip = ({ title, insights, onClose }) => (
+  <div className="absolute top-full right-0 mt-2 w-80 bg-slate-800 border border-slate-700 rounded-lg p-4 shadow-xl z-50">
     <div className="absolute -top-1.5 right-4 w-3 h-3 bg-slate-800 border-t border-l border-slate-700 rotate-45" />
-    <div className="flex justify-between items-start mb-2">
-      <p className="text-sm font-medium text-white">Risk asymmetry (W/L)</p>
-      <button onClick={onClose} className="text-slate-500 hover:text-slate-300 text-xs">✕</button>
+    <div className="flex justify-between items-start mb-3">
+      <p className="text-sm font-medium text-white">{title}</p>
+      <button onClick={onClose} className="text-slate-500 hover:text-slate-300 text-xs ml-2">&#x2715;</button>
     </div>
-    <p className="text-xs text-slate-400 mb-3 leading-relaxed">
-      Razão entre risco médio nos wins vs losses. Valores abaixo de 1.0 indicam que o aluno
-      arrisca menos quando acerta — corroendo o edge mesmo com WR e RR conformes.
-    </p>
-    <div className="space-y-1.5">
-      {[
-        { range: '0.9 – 1.1', label: 'Excelente', color: 'bg-emerald-400' },
-        { range: '0.7 – 0.9', label: 'Bom', color: 'bg-blue-400' },
-        { range: '0.4 – 0.7', label: 'Atenção', color: 'bg-amber-400' },
-        { range: '< 0.4', label: 'Crítico', color: 'bg-red-400' },
-      ].map(({ range, label, color }) => (
-        <div key={label} className="flex items-center gap-2 text-xs">
-          <div className={`w-2 h-2 rounded-full ${color}`} />
-          <span className="text-slate-500 w-16">{range}</span>
-          <span className="text-slate-300">{label}</span>
+    <div className="space-y-2">
+      {insights.map((ins, i) => (
+        <div key={i} className="flex items-start gap-2">
+          <div className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${sevDot(ins.severity)}`} />
+          <p className={`text-xs leading-relaxed ${sevText(ins.severity)}`}>{ins.text}</p>
         </div>
       ))}
-    </div>
-    <div className="mt-3 pt-3 border-t border-slate-700">
-      <p className="text-[10px] text-slate-500 leading-relaxed">
-        RO Eficiência: % médio do risco permitido efetivamente utilizado. 100% = usa todo o RO do plano em cada trade.
-      </p>
     </div>
   </div>
 );
 
-/**
- * Classifica o Eficiência do Plano em faixas de severidade.
- * @param {number|null} leakage - percentual (0-100+)
- * @returns {{ label: string, color: string, bgColor: string }}
- */
-const getLeakageLevel = (leakage) => {
-  if (leakage == null) return { label: '-', color: 'text-slate-400', bgColor: 'bg-slate-500/20' };
-  if (leakage < 0) return { label: 'Superando', color: 'text-emerald-400', bgColor: 'bg-emerald-500/20' };
-  if (leakage <= 10) return { label: 'Excelente', color: 'text-emerald-400', bgColor: 'bg-emerald-500/20' };
-  if (leakage <= 30) return { label: 'Bom', color: 'text-blue-400', bgColor: 'bg-blue-500/20' };
-  if (leakage <= 60) return { label: 'Atenção', color: 'text-amber-400', bgColor: 'bg-amber-500/20' };
-  return { label: 'Crítico', color: 'text-red-400', bgColor: 'bg-red-500/20' };
-};
+const InfoBtn = ({ name, openTooltip, toggle }) => (
+  <button onClick={() => toggle(name)} className="text-slate-600 hover:text-slate-400 transition-colors">
+    <Info className="w-4 h-4" />
+  </button>
+);
 
-/**
- * @param {Object} stats - Retorno de calculateStats
- * @param {number} aggregatedCurrentBalance
- * @param {string|null} dominantCurrency - null = moedas mistas
- * @param {Map} balancesByCurrency - Map<currency, {current, pnl, ...}>
- * @param {number} drawdown
- * @param {Object} maxDrawdownData - {maxDD, maxDDPercent, maxDDDate}
- * @param {Object|null} winRatePlanned - {rate, eligible, disciplinedWins, gap}
- * @param {Object|null} complianceRate - {rate, compliant, total, violations}
- * @param {Object|null} riskAsymmetry - {asymmetryRatio, avgRiskWins, avgRiskLosses, avgRoEfficiency, ...}
- * @param {Object|null} evLeakage - {evTheoretical, evReal, leakage, leakageAmount, totalLeakage, tradeCount}
- * @param {Object} plContext - { label, type } do P&L contextual (B5)
- */
 const MetricsCards = ({
   stats,
   aggregatedCurrentBalance,
@@ -103,256 +75,239 @@ const MetricsCards = ({
   evLeakage,
   plContext,
 }) => {
-  const [showTooltip, setShowTooltip] = useState(false);
-  const [showEvTooltip, setShowEvTooltip] = useState(false);
+  const [openTooltip, setOpenTooltip] = useState(null);
+  const toggle = (name) => setOpenTooltip(prev => prev === name ? null : name);
+
+  const cur = dominantCurrency || 'BRL';
   const asymLevel = getAsymmetryLevel(riskAsymmetry?.asymmetryRatio);
   const leakLevel = getLeakageLevel(evLeakage?.leakage);
 
+  const financialInsights = useMemo(() => getFinancialInsights({
+    stats, drawdown, maxDrawdownData, evLeakage, currency: cur
+  }), [stats, drawdown, maxDrawdownData, evLeakage, cur]);
+
+  const performanceInsights = useMemo(() => getPerformanceInsights({
+    stats, winRatePlanned, riskAsymmetry, complianceRate
+  }), [stats, winRatePlanned, riskAsymmetry, complianceRate]);
+
+  const planInsights = useMemo(() => getPlanVsResultInsights({
+    evLeakage, riskAsymmetry, winRatePlanned, stats, currency: cur
+  }), [evLeakage, riskAsymmetry, winRatePlanned, stats, cur]);
+
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 xl:grid-cols-7 gap-4 mb-6">
-      {/* Saldo Total */}
-      <div className="glass-card p-5 relative overflow-hidden">
-        <div className="w-10 h-10 rounded-lg flex items-center justify-center mb-2 bg-blue-500/20"><Wallet className="w-5 h-5 text-blue-400" /></div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Saldo Total</p>
-        {dominantCurrency ? (
-          <p className="text-xl lg:text-2xl font-bold text-white">{formatCurrencyDynamic(aggregatedCurrentBalance, dominantCurrency)}</p>
-        ) : (
-          <div className="space-y-1">
-            {[...balancesByCurrency.entries()].map(([cur, data]) => (
-              <p key={cur} className="text-lg font-bold text-white font-mono">
-                {formatCurrencyDynamic(data.current, cur)}
-              </p>
-            ))}
-          </div>
-        )}
-      </div>
+    <div className="space-y-4 mb-6">
 
-      {/* P&L Acumulado */}
-      <div className="glass-card p-5 relative overflow-hidden">
-        <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${stats.totalPL >= 0 ? 'bg-emerald-500/20' : 'bg-red-500/20'}`}><DollarSign className={`w-5 h-5 ${stats.totalPL >= 0 ? 'text-emerald-400' : 'text-red-400'}`} /></div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">{plContext?.label || 'P&L Acumulado'}</p>
-        {dominantCurrency ? (
-          <p className={`text-xl lg:text-2xl font-bold ${stats.totalPL >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{formatCurrencyDynamic(stats.totalPL, dominantCurrency)}</p>
-        ) : (
-          <div className="space-y-1">
-            {[...balancesByCurrency.entries()].map(([cur, data]) => (
-              <p key={cur} className={`text-lg font-bold font-mono ${data.pnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
-                {data.pnl >= 0 ? '+' : ''}{formatCurrencyDynamic(data.pnl, cur)}
-              </p>
-            ))}
-          </div>
-        )}
-      </div>
+      {/* === 3 paineis em linha === */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
 
-      {/* Win Rate */}
-      <div className="glass-card p-5 relative overflow-hidden">
-        <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${stats.winRate >= 50 ? 'bg-blue-500/20' : 'bg-amber-500/20'}`}><Target className={`w-5 h-5 ${stats.winRate >= 50 ? 'text-blue-400' : 'text-amber-400'}`} /></div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Win Rate</p>
-        <p className="text-xl lg:text-2xl font-bold text-white">{formatPercent(stats.winRate)}</p>
-        {winRatePlanned && (
-          <div className="mt-1.5 flex items-center gap-1.5" title={`WR Planejado: ${winRatePlanned.rate.toFixed(1)}% (${winRatePlanned.disciplinedWins}/${winRatePlanned.eligible} trades atingiram RR target)`}>
-            <span className="text-[11px] text-slate-500">Planejado:</span>
-            <span className={`text-xs font-bold font-mono ${winRatePlanned.rate >= stats.winRate ? 'text-emerald-400' : 'text-amber-400'}`}>{winRatePlanned.rate.toFixed(1)}%</span>
-            {winRatePlanned.gap > 0 && <span className="text-[11px] text-amber-400/70">↓{winRatePlanned.gap.toFixed(0)}%</span>}
-          </div>
-        )}
-      </div>
-
-      {/* Profit Factor */}
-      <div className="glass-card p-5 relative overflow-hidden">
-        <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${stats.profitFactor >= 1 ? 'bg-purple-500/20' : 'bg-red-500/20'}`}><Activity className={`w-5 h-5 ${stats.profitFactor >= 1 ? 'text-purple-400' : 'text-red-400'}`} /></div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Profit Factor</p>
-        <p className="text-xl lg:text-2xl font-bold text-white">{stats.profitFactor === Infinity ? '∞' : stats.profitFactor.toFixed(2)}</p>
-        {complianceRate && (
-          <div className="mt-1.5 flex items-center gap-1.5" title={`${complianceRate.compliant}/${complianceRate.total} trades sem violações`}>
-            <span className="text-[11px] text-slate-500">Conformidade:</span>
-            <span className={`text-xs font-bold font-mono ${complianceRate.rate >= 80 ? 'text-emerald-400' : complianceRate.rate >= 60 ? 'text-amber-400' : 'text-red-400'}`}>{complianceRate.rate.toFixed(0)}%</span>
-            {complianceRate.violations > 0 && <span className="text-[11px] text-red-400/70">({complianceRate.violations} ⚠️)</span>}
-          </div>
-        )}
-      </div>
-
-      {/* Drawdown */}
-      <div className="glass-card p-5 relative overflow-hidden">
-        <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${drawdown < 5 ? 'bg-emerald-500/20' : 'bg-red-500/20'}`}><TrendingDown className={`w-5 h-5 ${drawdown < 5 ? 'text-emerald-400' : 'text-red-400'}`} /></div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Drawdown</p>
-        <p className={`text-xl lg:text-2xl font-bold ${drawdown < 5 ? 'text-emerald-400' : 'text-red-400'}`}>-{drawdown.toFixed(1)}%</p>
-        {maxDrawdownData.maxDD > 0 && (
-          <div className="mt-1.5 space-y-0.5" title={maxDrawdownData.maxDDDate ? `Pior vale em ${maxDrawdownData.maxDDDate.split('-').reverse().join('/')}` : ''}>
-            <div className="flex items-center gap-1.5">
-              <span className="text-[11px] text-slate-500">Max DD:</span>
-              <span className="text-xs font-bold font-mono text-red-400">-{maxDrawdownData.maxDDPercent.toFixed(1)}%</span>
-              <span className="text-[11px] text-red-400/70">({formatCurrencyDynamic(-maxDrawdownData.maxDD, dominantCurrency || 'BRL')})</span>
+        {/* FINANCEIRO */}
+        <div className="glass-card p-5 relative">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-blue-400" />
+              <span className="text-xs text-slate-500 uppercase tracking-wider font-medium">Financeiro</span>
             </div>
-            {maxDrawdownData.maxDDDate && (
-              <span className="text-[11px] text-slate-600 font-mono">{maxDrawdownData.maxDDDate.split('-').reverse().join('/')}</span>
-            )}
+            <div className="relative">
+              <InfoBtn name="fin" openTooltip={openTooltip} toggle={toggle} />
+              {openTooltip === 'fin' && (
+                <DiagnosticTooltip title="Diagnostico financeiro" insights={financialInsights} onClose={() => setOpenTooltip(null)} />
+              )}
+            </div>
           </div>
-        )}
-      </div>
 
-      {/* Eficiência do Risco — v1.19.4 */}
-      <div className={`glass-card p-5 relative border ${riskAsymmetry ? (asymLevel.color === 'text-red-400' ? 'border-red-500/30' : asymLevel.color === 'text-amber-400' ? 'border-amber-500/30' : 'border-slate-700/50') : 'border-slate-700/50'}`}>
-        <div className="flex items-start justify-between">
-          <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${asymLevel.bgColor}`}>
-            <Shield className={`w-5 h-5 ${asymLevel.color}`} />
-          </div>
-          <div className="relative">
-            <button
-              onClick={() => setShowTooltip(!showTooltip)}
-              className="text-slate-600 hover:text-slate-400 transition-colors"
-            >
-              <Info className="w-4 h-4" />
-            </button>
-            {showTooltip && <RiskAsymmetryTooltip onClose={() => setShowTooltip(false)} />}
-          </div>
-        </div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Eficiência do Risco</p>
-        {riskAsymmetry ? (
-          <>
-            {riskAsymmetry.winsCount === 0 ? (
-              <>
-                <p className="text-xl lg:text-2xl font-bold text-slate-500">N/D</p>
-                <p className="text-[11px] text-slate-600 mt-1">Wins sem risco mensurável (sem stop loss)</p>
-                <div className="mt-1.5 space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-[11px] text-slate-500">RO médio:</span>
-                    <span className={`text-xs font-bold font-mono ${riskAsymmetry.avgRoEfficiency >= 60 ? 'text-emerald-400' : riskAsymmetry.avgRoEfficiency >= 30 ? 'text-amber-400' : 'text-red-400'}`}>
-                      {riskAsymmetry.avgRoEfficiency.toFixed(0)}%
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1.5 text-[11px]">
-                    <span className="text-slate-600">L:</span>
-                    <span className="font-mono text-red-400/80">{formatCurrencyDynamic(riskAsymmetry.avgRiskLosses, dominantCurrency || 'BRL')}</span>
-                  </div>
-                </div>
-              </>
-            ) : (
-              <>
-                <p className={`text-xl lg:text-2xl font-bold ${asymLevel.color}`}>
-                  {riskAsymmetry.asymmetryRatio != null ? `${riskAsymmetry.asymmetryRatio.toFixed(2)}x` : '-'}
-                </p>
-                <div className="mt-1.5 space-y-1">
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-[11px] text-slate-500">RO médio:</span>
-                    <span className={`text-xs font-bold font-mono ${riskAsymmetry.avgRoEfficiency >= 60 ? 'text-emerald-400' : riskAsymmetry.avgRoEfficiency >= 30 ? 'text-amber-400' : 'text-red-400'}`}>
-                      {riskAsymmetry.avgRoEfficiency.toFixed(0)}%
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1.5 text-[11px]">
-                    <span className="text-slate-600">W:</span>
-                    <span className="font-mono text-slate-400">{formatCurrencyDynamic(riskAsymmetry.avgRiskWins, dominantCurrency || 'BRL')}</span>
-                    <span className="text-slate-600">L:</span>
-                    <span className="font-mono text-red-400/80">{formatCurrencyDynamic(riskAsymmetry.avgRiskLosses, dominantCurrency || 'BRL')}</span>
-                  </div>
-                  {/* Barra de severidade */}
-                  <div className="flex items-center gap-1.5 mt-1">
-                    <div className="flex-1 h-1 rounded-full bg-slate-700/50 overflow-hidden">
-                      <div
-                        className={`h-full rounded-full ${asymLevel.color === 'text-emerald-400' ? 'bg-emerald-400' : asymLevel.color === 'text-blue-400' ? 'bg-blue-400' : asymLevel.color === 'text-amber-400' ? 'bg-amber-400' : 'bg-red-400'}`}
-                        style={{ width: `${Math.min(100, (riskAsymmetry.asymmetryRatio ?? 0) * 100)}%` }}
-                      />
-                    </div>
-                    <span className={`text-[9px] ${asymLevel.color}`}>{asymLevel.label}</span>
-                  </div>
-                </div>
-              </>
-            )}
-          </>
-        ) : (
-          <p className="text-xl font-bold text-slate-600">-</p>
-        )}
-      </div>
-
-      {/* Eficiência do Plano — v1.19.4 */}
-      <div className={`glass-card p-5 relative border ${evLeakage && evLeakage.leakage != null ? (leakLevel.color === 'text-red-400' ? 'border-red-500/30' : leakLevel.color === 'text-amber-400' ? 'border-amber-500/30' : 'border-slate-700/50') : 'border-slate-700/50'}`}>
-        <div className="flex items-start justify-between">
-          <div className={`w-10 h-10 rounded-lg flex items-center justify-center mb-2 ${leakLevel.bgColor}`}>
-            <TrendingDown className={`w-5 h-5 ${leakLevel.color}`} />
-          </div>
-          <div className="relative">
-            <button
-              onClick={() => setShowEvTooltip(!showEvTooltip)}
-              className="text-slate-600 hover:text-slate-400 transition-colors"
-            >
-              <Info className="w-4 h-4" />
-            </button>
-            {showEvTooltip && (
-              <div className="absolute top-full right-0 mt-2 w-72 bg-slate-800 border border-slate-700 rounded-lg p-4 shadow-xl z-50">
-                <div className="absolute -top-1.5 right-4 w-3 h-3 bg-slate-800 border-t border-l border-slate-700 rotate-45" />
-                <div className="flex justify-between items-start mb-2">
-                  <p className="text-sm font-medium text-white">Eficiência do Plano</p>
-                  <button onClick={() => setShowEvTooltip(false)} className="text-slate-500 hover:text-slate-300 text-xs">✕</button>
-                </div>
-                <p className="text-xs text-slate-400 mb-3 leading-relaxed">
-                  Quanto do edge esperado pelo plano se perde na execucao. Compara o EV teorico
-                  (baseado no WR real x RR alvo x RO do plano) com o resultado medio real.
-                </p>
-                <div className="space-y-1.5">
-                  {[
-                    { range: '< 0%', label: 'Superando', color: 'bg-emerald-400' },
-                    { range: '0 – 10%', label: 'Excelente', color: 'bg-emerald-400' },
-                    { range: '10 – 30%', label: 'Bom', color: 'bg-blue-400' },
-                    { range: '30 – 60%', label: 'Atencao', color: 'bg-amber-400' },
-                    { range: '> 60%', label: 'Critico', color: 'bg-red-400' },
-                  ].map(({ range, label, color }) => (
-                    <div key={label} className="flex items-center gap-2 text-xs">
-                      <div className={`w-2 h-2 rounded-full ${color}`} />
-                      <span className="text-slate-500 w-16">{range}</span>
-                      <span className="text-slate-300">{label}</span>
-                    </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+            {/* Saldo */}
+            <div>
+              <p className="text-[11px] text-slate-600 mb-1">Saldo</p>
+              {dominantCurrency ? (
+                <p className="text-lg font-bold text-white">{formatCurrencyDynamic(aggregatedCurrentBalance, dominantCurrency)}</p>
+              ) : (
+                <div className="space-y-0.5">
+                  {[...balancesByCurrency.entries()].map(([c, data]) => (
+                    <p key={c} className="text-base font-bold text-white font-mono">{formatCurrencyDynamic(data.current, c)}</p>
                   ))}
                 </div>
-                <div className="mt-3 pt-3 border-t border-slate-700">
-                  <p className="text-[10px] text-slate-500 leading-relaxed">
-                    EV Teorico = RO$ x (WR x RR_alvo - LossRate). Valores negativos indicam que o plano nao tem edge com o WR atual.
-                  </p>
+              )}
+            </div>
+
+            {/* P&L */}
+            <div>
+              <p className="text-[11px] text-slate-600 mb-1">{plContext?.label || 'P&L acumulado'}</p>
+              {dominantCurrency ? (
+                <p className={`text-lg font-bold ${stats.totalPL >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{formatCurrencyDynamic(stats.totalPL, dominantCurrency)}</p>
+              ) : (
+                <div className="space-y-0.5">
+                  {[...balancesByCurrency.entries()].map(([c, data]) => (
+                    <p key={c} className={`text-base font-bold font-mono ${data.pnl >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {data.pnl >= 0 ? '+' : ''}{formatCurrencyDynamic(data.pnl, c)}
+                    </p>
+                  ))}
                 </div>
-              </div>
-            )}
+              )}
+              {evLeakage?.evReal != null && !isNaN(evLeakage.evReal) && (
+                <p className="text-[11px] text-slate-500 mt-1">
+                  Expect: <span className={`font-mono ${evLeakage.evReal >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{formatCurrencyDynamic(evLeakage.evReal, cur)}/trade</span>
+                </p>
+              )}
+            </div>
+
+            {/* Drawdown */}
+            <div title={maxDrawdownData?.maxDDDate ? `Pior vale em ${maxDrawdownData.maxDDDate.split('-').reverse().join('/')}` : ''}>
+              <p className="text-[11px] text-slate-600 mb-1">Drawdown</p>
+              <p className={`text-lg font-bold ${drawdown < 5 ? 'text-emerald-400' : 'text-red-400'}`}>-{drawdown.toFixed(1)}%</p>
+              {maxDrawdownData.maxDD > 0 && (
+                <p className="text-[11px] text-slate-500 mt-1">
+                  Max: <span className="font-mono text-red-400">-{safe(maxDrawdownData.maxDDPercent, 1)}%</span>
+                  <span className="text-slate-600 ml-1">({formatCurrencyDynamic(-maxDrawdownData.maxDD, cur)})</span>
+                </p>
+              )}
+            </div>
+
+            {/* Profit Factor */}
+            <div title={complianceRate ? `${complianceRate.compliant}/${complianceRate.total} trades sem violacoes` : ''}>
+              <p className="text-[11px] text-slate-600 mb-1">Profit factor</p>
+              <p className="text-lg font-bold text-white">{stats.profitFactor === Infinity ? '\u221E' : safe(stats.profitFactor, 2)}</p>
+              {complianceRate && (
+                <p className="text-[11px] text-slate-500 mt-1">
+                  Conformidade: <span className={`font-mono ${complianceRate.rate >= 80 ? 'text-emerald-400' : complianceRate.rate >= 60 ? 'text-amber-400' : 'text-red-400'}`}>{safe(complianceRate.rate, 0)}%</span>
+                  {complianceRate.violations > 0 && <span className="text-red-400/70 ml-1">({complianceRate.violations})</span>}
+                </p>
+              )}
+            </div>
           </div>
         </div>
-        <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Eficiência do Plano</p>
-        {evLeakage && evLeakage.leakage != null ? (
-          <>
-            <p className={`text-xl lg:text-2xl font-bold ${leakLevel.color}`}>
-              {evLeakage.leakage <= 0 ? '+' : ''}{evLeakage.leakage <= 0 ? Math.abs(evLeakage.leakage).toFixed(0) : evLeakage.leakage.toFixed(0)}%
-            </p>
-            <div className="mt-1.5 space-y-1">
-              <div className="flex items-center gap-1.5">
-                <span className="text-[11px] text-slate-500">EV plan:</span>
-                <span className="text-xs font-bold font-mono text-slate-300">
-                  {formatCurrencyDynamic(evLeakage.evTheoretical, dominantCurrency || 'BRL')}/trade
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="text-[11px] text-slate-500">EV real:</span>
-                <span className={`text-xs font-bold font-mono ${evLeakage.evReal >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
-                  {formatCurrencyDynamic(evLeakage.evReal, dominantCurrency || 'BRL')}/trade
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="text-[11px] text-slate-500">Perda total:</span>
-                <span className={`text-xs font-bold font-mono ${evLeakage.totalLeakage > 0 ? 'text-red-400' : 'text-emerald-400'}`}>
-                  {formatCurrencyDynamic(-evLeakage.totalLeakage, dominantCurrency || 'BRL')}
-                </span>
-              </div>
-              {/* Barra de severidade */}
-              <div className="flex items-center gap-1.5 mt-1">
-                <div className="flex-1 h-1 rounded-full bg-slate-700/50 overflow-hidden">
-                  <div
-                    className={`h-full rounded-full ${leakLevel.color === 'text-emerald-400' ? 'bg-emerald-400' : leakLevel.color === 'text-blue-400' ? 'bg-blue-400' : leakLevel.color === 'text-amber-400' ? 'bg-amber-400' : 'bg-red-400'}`}
-                    style={{ width: `${Math.min(100, Math.max(5, 100 - (evLeakage.leakage ?? 0)))}%` }}
-                  />
-                </div>
-                <span className={`text-[9px] ${leakLevel.color}`}>{leakLevel.label}</span>
-              </div>
+
+        {/* DESEMPENHO */}
+        <div className="glass-card p-5 relative">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <Target className="w-4 h-4 text-purple-400" />
+              <span className="text-xs text-slate-500 uppercase tracking-wider font-medium">Assimetria de Risco</span>
             </div>
-          </>
-        ) : (
-          <p className="text-xl font-bold text-slate-600">-</p>
-        )}
+            <div className="relative">
+              <InfoBtn name="perf" openTooltip={openTooltip} toggle={toggle} />
+              {openTooltip === 'perf' && (
+                <DiagnosticTooltip title="Diagnostico de desempenho" insights={performanceInsights} onClose={() => setOpenTooltip(null)} />
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-x-4 gap-y-3">
+            {/* Win Rate */}
+            <div title={winRatePlanned ? `WR Planejado: ${safe(winRatePlanned.rate, 1)}% (${winRatePlanned.disciplinedWins}/${winRatePlanned.eligible} trades atingiram RR target)` : ''}>
+              <p className="text-[11px] text-slate-600 mb-1">Win rate</p>
+              <p className="text-lg font-bold text-white">{formatPercent(stats.winRate)}</p>
+              {winRatePlanned && (
+                <p className="text-[11px] text-slate-500 mt-1">
+                  Planejado: <span className={`font-mono ${winRatePlanned.rate >= stats.winRate ? 'text-emerald-400' : 'text-amber-400'}`}>{safe(winRatePlanned.rate, 1)}%</span>
+                  {winRatePlanned.gap > 0 && <span className="text-amber-400/70 ml-1">{'\u2193'}{safe(winRatePlanned.gap, 0)}%</span>}
+                </p>
+              )}
+            </div>
+
+            {/* Risco W/L */}
+            <div>
+              <p className="text-[11px] text-slate-600 mb-1">Risco W/L</p>
+              {riskAsymmetry && riskAsymmetry.winsCount > 0 ? (
+                <>
+                  <p className={`text-lg font-bold ${asymLevel.color}`}>{safe(riskAsymmetry.asymmetryRatio, 2)}x</p>
+                  <p className="text-[11px] text-slate-500 mt-1">
+                    W: <span className="font-mono text-slate-400">{formatCurrencyDynamic(riskAsymmetry.avgRiskWins, cur)}</span>
+                    {' '}L: <span className="font-mono text-red-400/80">{formatCurrencyDynamic(riskAsymmetry.avgRiskLosses, cur)}</span>
+                  </p>
+                </>
+              ) : riskAsymmetry && riskAsymmetry.winsCount === 0 ? (
+                <>
+                  <p className="text-lg font-bold text-slate-500">N/D</p>
+                  <p className="text-[11px] text-slate-600 mt-1">Wins sem stop</p>
+                </>
+              ) : (
+                <p className="text-lg font-bold text-slate-600">-</p>
+              )}
+            </div>
+          </div>
+
+          {/* RO medio */}
+          <div className="border-t border-slate-700/50 mt-3 pt-3">
+            <p className="text-[11px] text-slate-600 mb-2">RO medio</p>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 h-1.5 rounded-full bg-slate-700/50 overflow-hidden">
+                <div
+                  className={`h-full rounded-full ${riskAsymmetry && !isNaN(riskAsymmetry.avgRoEfficiency) && riskAsymmetry.avgRoEfficiency >= 60 ? 'bg-emerald-400' : riskAsymmetry && !isNaN(riskAsymmetry.avgRoEfficiency) && riskAsymmetry.avgRoEfficiency >= 30 ? 'bg-amber-400' : 'bg-red-400'}`}
+                  style={{ width: `${Math.min(100, Math.max(0, riskAsymmetry?.avgRoEfficiency ?? 0))}%` }}
+                />
+              </div>
+              <span className={`text-xs font-bold font-mono ${riskAsymmetry && !isNaN(riskAsymmetry.avgRoEfficiency) && riskAsymmetry.avgRoEfficiency >= 60 ? 'text-emerald-400' : riskAsymmetry && !isNaN(riskAsymmetry.avgRoEfficiency) && riskAsymmetry.avgRoEfficiency >= 30 ? 'text-amber-400' : 'text-red-400'}`}>
+                {riskAsymmetry ? safe(riskAsymmetry.avgRoEfficiency, 0) : '-'}%
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* EV — Plano vs Resultado */}
+        <div className={`glass-card p-5 relative border ${evLeakage && evLeakage.leakage != null ? (leakLevel.color === 'text-red-400' ? 'border-red-500/30' : leakLevel.color === 'text-amber-400' ? 'border-amber-500/30' : 'border-slate-700/50') : 'border-slate-700/50'}`}>
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-2">
+              <BarChart3 className={`w-4 h-4 ${leakLevel.color}`} />
+              <span className="text-xs text-slate-500 uppercase tracking-wider font-medium">EV</span>
+              {evLeakage?.leakage != null && !isNaN(evLeakage.leakage) && (
+                <span className={`text-xs font-bold ${leakLevel.color}`}>
+                  {evLeakage.leakage <= 0 ? `+${Math.abs(evLeakage.leakage).toFixed(0)}%` : `${evLeakage.leakage.toFixed(0)}% de perda`}
+                </span>
+              )}
+            </div>
+            <div className="relative">
+              <InfoBtn name="ev" openTooltip={openTooltip} toggle={toggle} />
+              {openTooltip === 'ev' && (
+                <DiagnosticTooltip title="EV" insights={planInsights} onClose={() => setOpenTooltip(null)} />
+              )}
+            </div>
+          </div>
+
+          {evLeakage && evLeakage.leakage != null ? (
+            <>
+              <div className="grid grid-cols-3 gap-2">
+                <div className="text-center p-2 rounded-lg bg-slate-800/50">
+                  <p className="text-[10px] text-slate-600 mb-1">EV esperado</p>
+                  <p className="text-base font-bold text-white">{formatCurrencyDynamic(evLeakage.evTheoretical, cur)}</p>
+                  <p className="text-[10px] text-slate-600">/trade</p>
+                </div>
+                <div className="text-center p-2 rounded-lg bg-slate-800/50">
+                  <p className="text-[10px] text-slate-600 mb-1">EV real</p>
+                  <p className={`text-base font-bold ${evLeakage.evReal >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>{formatCurrencyDynamic(evLeakage.evReal, cur)}</p>
+                  <p className="text-[10px] text-slate-600">/trade</p>
+                </div>
+                <div className="text-center p-2 rounded-lg bg-red-500/5 border border-red-500/10">
+                  <p className="text-[10px] text-slate-600 mb-1">Gap</p>
+                  <p className="text-base font-bold text-red-400">{formatCurrencyDynamic(evLeakage.evReal - evLeakage.evTheoretical, cur)}</p>
+                  <p className="text-[10px] text-slate-600">/trade</p>
+                </div>
+              </div>
+
+              <div className="mt-3 pt-3 border-t border-slate-700/50">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-[11px] text-slate-500">Perda acumulada <span className="text-slate-600">({evLeakage.tradeCount} trades)</span></span>
+                  <span className={`text-xs font-bold font-mono ${evLeakage.totalLeakage > 0 ? 'text-red-400' : 'text-emerald-400'}`}>
+                    {formatCurrencyDynamic(-evLeakage.totalLeakage, cur)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 h-1.5 rounded-full bg-slate-700/50 overflow-hidden">
+                    <div className="flex h-full">
+                      <div className="h-full bg-emerald-400" style={{ width: `${Math.min(100, Math.max(0, 100 - (evLeakage.leakage ?? 0)))}%` }} />
+                      <div className="h-full bg-red-400" style={{ width: `${Math.min(100, Math.max(0, evLeakage.leakage ?? 0))}%` }} />
+                    </div>
+                  </div>
+                  <span className="text-[10px] text-slate-500">{safe(100 - evLeakage.leakage, 0)}% capturado</span>
+                </div>
+              </div>
+            </>
+          ) : (
+            <p className="text-sm text-slate-600">Dados insuficientes</p>
+          )}
+        </div>
       </div>
+
       <DebugBadge component="MetricsCards" />
     </div>
   );

--- a/src/utils/dashboardMetrics.js
+++ b/src/utils/dashboardMetrics.js
@@ -139,13 +139,25 @@ export const calculateRiskAsymmetry = (trades, plans) => {
 
   for (const trade of trades) {
     const plan = plansMap[trade.planId];
-    if (!plan || !plan.pl || !plan.riskPerOperation) continue;
-    if (trade.riskPercent == null) continue;
+    if (!plan) continue;
 
-    const riskAmount = (trade.riskPercent / 100) * plan.pl;
-    const roPlanned = (plan.riskPerOperation / 100) * plan.pl;
+    const planPl = Number(plan.pl) || 0;
+    const planRo = Number(plan.riskPerOperation) || 0;
+    if (planPl <= 0 || planRo <= 0) continue;
 
-    if (roPlanned > 0) {
+    // Se trade sem riskPercent (sem stop), assume RO$ do plano como risco
+    let rp;
+    if (trade.riskPercent == null) {
+      rp = planRo; // assume risco maximo do plano
+    } else {
+      rp = Number(trade.riskPercent);
+      if (isNaN(rp)) continue;
+    }
+
+    const riskAmount = (rp / 100) * planPl;
+    const roPlanned = (planRo / 100) * planPl;
+
+    if (roPlanned > 0 && isFinite(riskAmount / roPlanned)) {
       roEfficiencies.push(riskAmount / roPlanned);
     }
 

--- a/src/utils/metricsInsights.js
+++ b/src/utils/metricsInsights.js
@@ -1,0 +1,209 @@
+/**
+ * metricsInsights.js -- Gerador de conclusoes diagnosticas para KPIs
+ * @version 1.0.0 (v1.19.5)
+ * 
+ * Gera textos acionaveis para tooltips dos paineis de metricas.
+ * Cada funcao recebe os dados e retorna um array de insights com severidade.
+ * 
+ * Insights sao contextuais: a mesma metrica gera textos diferentes
+ * dependendo da combinacao com outras metricas.
+ */
+
+/**
+ * Gera insights do painel Financeiro.
+ * @param {Object} params
+ * @param {Object} params.stats - { totalPL, winRate, profitFactor, totalTrades }
+ * @param {number} params.drawdown
+ * @param {Object} params.maxDrawdownData - { maxDD, maxDDPercent }
+ * @param {Object|null} params.evLeakage - { evReal }
+ * @param {string} params.currency
+ * @returns {Array<{ text: string, severity: 'success'|'info'|'warning'|'danger' }>}
+ */
+export const getFinancialInsights = ({ stats, drawdown, maxDrawdownData, evLeakage, currency }) => {
+  const insights = [];
+  if (!stats) return insights;
+
+  const cur = currency || 'BRL';
+  const expectancy = evLeakage?.evReal;
+
+  if (expectancy != null && !isNaN(expectancy)) {
+    if (expectancy > 0) {
+      insights.push({ text: `Resultado medio positivo: ${fmt(expectancy, cur)}/trade`, severity: 'success' });
+    } else if (expectancy < 0) {
+      insights.push({ text: `Resultado medio negativo: ${fmt(expectancy, cur)}/trade -- sistema sem vantagem no periodo`, severity: 'danger' });
+    } else {
+      insights.push({ text: 'Resultado medio zero -- breakeven no periodo', severity: 'warning' });
+    }
+  }
+
+  if (stats.profitFactor != null && stats.profitFactor !== Infinity) {
+    if (stats.profitFactor < 1) {
+      insights.push({ text: `Profit Factor ${stats.profitFactor.toFixed(2)} -- perde mais do que ganha em valor absoluto`, severity: 'danger' });
+    } else if (stats.profitFactor >= 2) {
+      insights.push({ text: `Profit Factor ${stats.profitFactor.toFixed(2)} -- boa relacao ganho/perda`, severity: 'success' });
+    }
+  }
+
+  if (drawdown > 10) {
+    insights.push({ text: `Drawdown ${drawdown.toFixed(1)}% -- capital em risco significativo`, severity: 'danger' });
+  } else if (drawdown > 5) {
+    insights.push({ text: `Drawdown ${drawdown.toFixed(1)}% -- monitorar de perto`, severity: 'warning' });
+  }
+
+  if (maxDrawdownData?.maxDDPercent > 15) {
+    insights.push({ text: `Max Drawdown historico de ${maxDrawdownData.maxDDPercent.toFixed(1)}% -- revisar gestao de risco`, severity: 'danger' });
+  }
+
+  if (insights.length === 0) {
+    insights.push({ text: 'Metricas financeiras dentro dos parametros', severity: 'info' });
+  }
+
+  return insights;
+};
+
+/**
+ * Gera insights do painel Desempenho.
+ * @param {Object} params
+ * @param {Object} params.stats - { winRate }
+ * @param {Object|null} params.winRatePlanned - { rate, gap }
+ * @param {Object|null} params.riskAsymmetry - { asymmetryRatio, avgRoEfficiency, winsCount }
+ * @param {Object|null} params.complianceRate - { rate, violations }
+ * @returns {Array<{ text: string, severity: 'success'|'info'|'warning'|'danger' }>}
+ */
+export const getPerformanceInsights = ({ stats, winRatePlanned, riskAsymmetry, complianceRate }) => {
+  const insights = [];
+  if (!stats) return insights;
+
+  if (winRatePlanned && stats.winRate > 0) {
+    const gap = stats.winRate - winRatePlanned.rate;
+    if (gap > 30) {
+      insights.push({ 
+        text: `Acerta ${stats.winRate.toFixed(0)}% mas so ${winRatePlanned.rate.toFixed(0)}% atingem o alvo -- ansiedade de saida em ${gap.toFixed(0)}% dos wins`, 
+        severity: 'danger' 
+      });
+    } else if (gap > 15) {
+      insights.push({ 
+        text: `WR Planejado ${winRatePlanned.rate.toFixed(0)}% vs WR ${stats.winRate.toFixed(0)}% -- saida antecipada em parte dos wins`, 
+        severity: 'warning' 
+      });
+    } else if (gap <= 5) {
+      insights.push({ text: 'Wins consistentes com o alvo do plano', severity: 'success' });
+    }
+  }
+
+  if (riskAsymmetry && riskAsymmetry.asymmetryRatio != null && !isNaN(riskAsymmetry.asymmetryRatio)) {
+    const ratio = riskAsymmetry.asymmetryRatio;
+    if (ratio < 0.4) {
+      insights.push({ 
+        text: `Sizing critico: arrisca ${((1 - ratio) * 100).toFixed(0)}% menos nos wins que nos losses -- comportamento destrutivo`, 
+        severity: 'danger' 
+      });
+    } else if (ratio < 0.7) {
+      insights.push({ 
+        text: `Sizing inconsistente: arrisca ${((1 - ratio) * 100).toFixed(0)}% menos nos wins`, 
+        severity: 'warning' 
+      });
+    } else if (ratio >= 0.9 && ratio <= 1.1) {
+      insights.push({ text: 'Sizing consistente entre wins e losses', severity: 'success' });
+    }
+  }
+
+  if (riskAsymmetry && !isNaN(riskAsymmetry.avgRoEfficiency)) {
+    if (riskAsymmetry.avgRoEfficiency < 30) {
+      insights.push({ 
+        text: `Utiliza apenas ${riskAsymmetry.avgRoEfficiency.toFixed(0)}% do risco permitido -- opera muito abaixo da capacidade do plano`, 
+        severity: 'warning' 
+      });
+    }
+  }
+
+  if (riskAsymmetry && riskAsymmetry.winsCount === 0) {
+    insights.push({ text: 'Wins sem stop loss -- impossivel medir risco nos acertos', severity: 'warning' });
+  }
+
+  if (complianceRate && complianceRate.rate < 60) {
+    insights.push({ 
+      text: `${complianceRate.violations} violacoes em ${complianceRate.total} trades -- disciplina comprometida`, 
+      severity: 'danger' 
+    });
+  }
+
+  if (insights.length === 0) {
+    insights.push({ text: 'Desempenho operacional dentro dos parametros', severity: 'info' });
+  }
+
+  return insights;
+};
+
+/**
+ * Gera insights do painel Plano vs Resultado.
+ * @param {Object} params
+ * @param {Object|null} params.evLeakage - { evTheoretical, evReal, leakage, totalLeakage }
+ * @param {Object|null} params.riskAsymmetry - { asymmetryRatio }
+ * @param {Object|null} params.winRatePlanned - { rate, gap }
+ * @param {Object} params.stats - { winRate }
+ * @param {string} params.currency
+ * @returns {Array<{ text: string, severity: 'success'|'info'|'warning'|'danger' }>}
+ */
+export const getPlanVsResultInsights = ({ evLeakage, riskAsymmetry, winRatePlanned, stats, currency }) => {
+  const insights = [];
+  const cur = currency || 'BRL';
+
+  if (!evLeakage || evLeakage.leakage == null) {
+    insights.push({ text: 'Dados insuficientes para avaliar aderencia ao plano', severity: 'info' });
+    return insights;
+  }
+
+  const lk = evLeakage.leakage;
+
+  if (lk < 0) {
+    insights.push({ text: `Superando o plano -- entregando ${Math.abs(lk).toFixed(0)}% acima do esperado`, severity: 'success' });
+  } else if (lk <= 10) {
+    insights.push({ text: 'Execucao aderente ao plano', severity: 'success' });
+  } else if (lk <= 30) {
+    insights.push({ text: `Perda de ${lk.toFixed(0)}% do potencial do plano`, severity: 'info' });
+  } else if (lk <= 60) {
+    insights.push({ 
+      text: `Captura apenas ${(100 - lk).toFixed(0)}% do potencial -- ${fmt(-evLeakage.totalLeakage, cur)} perdidos no periodo`, 
+      severity: 'warning' 
+    });
+  } else {
+    insights.push({ 
+      text: `Perda critica: ${lk.toFixed(0)}% do potencial desperdicado -- ${fmt(-evLeakage.totalLeakage, cur)} perdidos`, 
+      severity: 'danger' 
+    });
+  }
+
+  // Diagnostico da causa principal
+  if (lk > 15) {
+    const hasAnxiety = winRatePlanned && stats && (stats.winRate - winRatePlanned.rate) > 20;
+    const hasSizing = riskAsymmetry && riskAsymmetry.asymmetryRatio != null && riskAsymmetry.asymmetryRatio < 0.7;
+
+    if (hasAnxiety && hasSizing) {
+      insights.push({ text: 'Causa: saida antecipada nos wins + sizing inconsistente', severity: 'warning' });
+    } else if (hasAnxiety) {
+      insights.push({ text: 'Causa principal: saida antecipada -- wins nao atingem o alvo RR', severity: 'warning' });
+    } else if (hasSizing) {
+      insights.push({ text: 'Causa principal: sizing -- arrisca menos nos wins que nos losses', severity: 'warning' });
+    }
+  }
+
+  return insights;
+};
+
+/**
+ * Helper: formata moeda de forma compacta.
+ */
+const fmt = (value, currency) => {
+  if (value == null || isNaN(value)) return '-';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : value > 0 ? '+' : '';
+  const sym = currency === 'USD' ? 'US$' : currency === 'EUR' ? 'EUR' : 'R$';
+  return `${sign}${sym} ${abs.toLocaleString('pt-BR', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+};
+
+export default {
+  getFinancialInsights,
+  getPerformanceInsights,
+  getPlanVsResultInsights,
+};

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.19.5: Layout agrupado 3 paineis (Financeiro/Desempenho/Plano vs Resultado), tooltips diagnosticos, NaN guards
  * - 1.19.4: DEC-009 — riskPercent usa plan.pl (capital base) como denominador, não currentPl
  * - 1.19.3: C3 (RR 2 casas decimais), C5 (resultInPoints null em override), coluna Status Feedback no ExtractTable
  * - 1.19.2: DEC-007 RR assumido integrado em calculateTradeCompliance (plan.pl base), guard C4 removido, updateTrade recalcula RR, diagnosePlan detecta rrAssumed stale
@@ -16,10 +17,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.19.4',
-  build: '20260313',
-  display: 'v1.19.4',
-  full: '1.19.4+20260313',
+  version: '1.19.5',
+  build: '20260315',
+  display: 'v1.19.5',
+  full: '1.19.5+20260315',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## v1.19.5 — Layout agrupado MetricsCards + tooltips diagnósticos

### Modificado
- MetricsCards v4.1.0: 7 cards → 3 painéis (Financeiro / Assimetria de Risco / EV)
- Tooltips diagnósticos dinâmicos por painel (conclusões acionáveis para mentoria)
- NaN guards em dashboardMetrics.js + MetricsCards.jsx
- Trades sem stop assumem RO$ do plano como risco (elimina N/D e 0.00x)
- Número de trades visível no card EV

### Adicionado
- metricsInsights.js — gerador de conclusões dinâmicas

### Arquivos
- src/components/dashboard/MetricsCards.jsx
- src/utils/dashboardMetrics.js
- src/utils/metricsInsights.js (novo)
- src/__tests__/utils/riskAsymmetry.test.js
- src/version.js