### PR TITLE
feat: Badge notificação REVIEWED no Sidebar do aluno (v1.19.7)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -96,6 +96,16 @@ const AppContent = () => {
     }
   }, [isMentor, viewingAsStudent, allTrades, getTradesAwaitingFeedback]);
 
+  // Badge para aluno: trades revisados pelo mentor que o aluno ainda não trabalhou
+  const unreviewedFeedbackCount = useMemo(() => {
+    if (isMentor() && !viewingAsStudent) return 0;
+    try {
+      return (allTrades || []).filter(t => t.status === 'REVIEWED').length;
+    } catch (e) {
+      return 0;
+    }
+  }, [isMentor, viewingAsStudent, allTrades]);
+
   const studentsNeedingAttention = useMemo(() => {
     if (!isMentor() || viewingAsStudent) return 0;
     try {
@@ -270,6 +280,7 @@ const AppContent = () => {
         onToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
         pendingFeedback={pendingFeedbackCount}
         studentsNeedingAttention={studentsNeedingAttention}
+        unreviewedFeedback={unreviewedFeedbackCount}
       />
 
       {/* Conteúdo principal */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,6 +75,7 @@ const AppContent = () => {
   // Hooks
   const { 
     addTrade, 
+    trades,
     getTradesAwaitingFeedback, 
     getTradesGroupedByStudent, 
     allTrades,
@@ -97,14 +98,15 @@ const AppContent = () => {
   }, [isMentor, viewingAsStudent, allTrades, getTradesAwaitingFeedback]);
 
   // Badge para aluno: trades revisados pelo mentor que o aluno ainda não trabalhou
+  // Nota: usa `trades` (não `allTrades`) porque no student mode o listener só popula `trades`
   const unreviewedFeedbackCount = useMemo(() => {
     if (isMentor() && !viewingAsStudent) return 0;
     try {
-      return (allTrades || []).filter(t => t.status === 'REVIEWED').length;
+      return (trades || []).filter(t => t.status === 'REVIEWED').length;
     } catch (e) {
       return 0;
     }
-  }, [isMentor, viewingAsStudent, allTrades]);
+  }, [isMentor, viewingAsStudent, trades]);
 
   const studentsNeedingAttention = useMemo(() => {
     if (!isMentor() || viewingAsStudent) return 0;

--- a/src/__tests__/utils/v1197-sidebar-badge.test.js
+++ b/src/__tests__/utils/v1197-sidebar-badge.test.js
@@ -1,0 +1,73 @@
+/**
+ * v1197-sidebar-badge.test.js
+ * Testes para badge de revisões não trabalhadas (REVIEWED) no Sidebar do aluno
+ * @version 1.19.7
+ */
+import { describe, it, expect } from 'vitest';
+
+// Simula a lógica do useMemo de unreviewedFeedbackCount do App.jsx
+function countUnreviewedFeedback(allTrades, isMentor, viewingAsStudent) {
+  if (isMentor && !viewingAsStudent) return 0;
+  try {
+    return (allTrades || []).filter(t => t.status === 'REVIEWED').length;
+  } catch (e) {
+    return 0;
+  }
+}
+
+describe('unreviewedFeedbackCount', () => {
+  it('conta trades REVIEWED para aluno', () => {
+    const trades = [
+      { id: '1', status: 'OPEN' },
+      { id: '2', status: 'REVIEWED' },
+      { id: '3', status: 'REVIEWED' },
+      { id: '4', status: 'CLOSED' },
+    ];
+    expect(countUnreviewedFeedback(trades, false, false)).toBe(2);
+  });
+
+  it('retorna 0 quando nenhum trade REVIEWED', () => {
+    const trades = [
+      { id: '1', status: 'OPEN' },
+      { id: '2', status: 'CLOSED' },
+      { id: '3', status: 'QUESTION' },
+    ];
+    expect(countUnreviewedFeedback(trades, false, false)).toBe(0);
+  });
+
+  it('retorna 0 para mentor (nao eh badge do mentor)', () => {
+    const trades = [
+      { id: '1', status: 'REVIEWED' },
+      { id: '2', status: 'REVIEWED' },
+    ];
+    expect(countUnreviewedFeedback(trades, true, false)).toBe(0);
+  });
+
+  it('conta REVIEWED quando mentor em viewAsStudent', () => {
+    const trades = [
+      { id: '1', status: 'REVIEWED' },
+      { id: '2', status: 'OPEN' },
+    ];
+    expect(countUnreviewedFeedback(trades, true, true)).toBe(1);
+  });
+
+  it('nao conta QUESTION como nao trabalhado', () => {
+    const trades = [
+      { id: '1', status: 'QUESTION' },
+      { id: '2', status: 'REVIEWED' },
+    ];
+    expect(countUnreviewedFeedback(trades, false, false)).toBe(1);
+  });
+
+  it('retorna 0 com allTrades null', () => {
+    expect(countUnreviewedFeedback(null, false, false)).toBe(0);
+  });
+
+  it('retorna 0 com allTrades undefined', () => {
+    expect(countUnreviewedFeedback(undefined, false, false)).toBe(0);
+  });
+
+  it('retorna 0 com array vazio', () => {
+    expect(countUnreviewedFeedback([], false, false)).toBe(0);
+  });
+});

--- a/src/__tests__/utils/v1197-sidebar-badge.test.js
+++ b/src/__tests__/utils/v1197-sidebar-badge.test.js
@@ -2,14 +2,17 @@
  * v1197-sidebar-badge.test.js
  * Testes para badge de revisões não trabalhadas (REVIEWED) no Sidebar do aluno
  * @version 1.19.7
+ * 
+ * Nota: usa `trades` (não `allTrades`) porque no student mode o listener
+ * do useTrades só popula `trades` — `allTrades` fica vazio.
  */
 import { describe, it, expect } from 'vitest';
 
 // Simula a lógica do useMemo de unreviewedFeedbackCount do App.jsx
-function countUnreviewedFeedback(allTrades, isMentor, viewingAsStudent) {
+function countUnreviewedFeedback(trades, isMentor, viewingAsStudent) {
   if (isMentor && !viewingAsStudent) return 0;
   try {
-    return (allTrades || []).filter(t => t.status === 'REVIEWED').length;
+    return (trades || []).filter(t => t.status === 'REVIEWED').length;
   } catch (e) {
     return 0;
   }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,9 +1,10 @@
 /**
  * Sidebar
- * @version 1.2.0
- * @description Menu lateral com navegação, versão, badge alertas emocionais
+ * @version 1.3.0
+ * @description Menu lateral com navegação, versão, badges alertas emocionais e feedback aluno
  * 
  * CHANGELOG:
+ * - 1.3.0: Badge de revisões não trabalhadas (REVIEWED) no menu do aluno
  * - 1.2.0: Badge de alertas emocionais no menu mentor — Fase 1.5.0
  * - 1.1.0: Adicionado item "Feedback" no menu do aluno
  */
@@ -34,14 +35,21 @@ const Sidebar = ({
   onToggle,
   pendingFeedback = 0,
   studentsNeedingAttention = 0,
-  emotionalAlerts = 0
+  emotionalAlerts = 0,
+  unreviewedFeedback = 0
 }) => {
   const { user, logout, isMentor } = useAuth();
 
   // Menu do Aluno
   const studentMenuItems = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { id: 'feedback', label: 'Feedback', icon: MessageSquare },
+    { 
+      id: 'feedback', 
+      label: 'Feedback', 
+      icon: MessageSquare,
+      badge: unreviewedFeedback > 0 ? unreviewedFeedback : null,
+      badgeColor: 'green'
+    },
     { id: 'journal', label: 'Diário', icon: BookOpen },
     { id: 'accounts', label: 'Contas', icon: Wallet },
   ];
@@ -142,6 +150,8 @@ const Sidebar = ({
                         ? 'bg-red-500/20 text-red-400' 
                         : item.badgeColor === 'purple'
                         ? 'bg-purple-500/20 text-purple-400'
+                        : item.badgeColor === 'green'
+                        ? 'bg-emerald-500/20 text-emerald-400'
                         : 'bg-blue-500/20 text-blue-400'
                     }`}>
                       {item.badge}

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.19.7: Badge de notificação no Sidebar do aluno — trades REVIEWED não trabalhados
  * - 1.19.6: Payoff com semaforo de saude do edge, layout reorganizado, semaforo RO bidirecional, cor PL Atual tricolor, diagnostico assimetria
  * - 1.19.5: Layout agrupado 3 paineis (Financeiro/Desempenho/Plano vs Resultado), tooltips diagnosticos, NaN guards
  * - 1.19.4: DEC-009 — riskPercent usa plan.pl (capital base) como denominador, não currentPl
@@ -18,10 +19,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.19.6',
-  build: '20260318',
-  display: 'v1.19.6',
-  full: '1.19.6+20260318',
+  version: '1.19.7',
+  build: '20260319',
+  display: 'v1.19.7',
+  full: '1.19.7+20260319',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Resumo
Badge de notificação no item "Feedback" do Sidebar quando o aluno tem trades
revisados pelo mentor (status REVIEWED) que ainda não foram trabalhados.

## Motivação
Aluno não tinha indicação visual de que existiam revisões pendentes de leitura.
Precisava navegar até a tela de Feedback para descobrir.

## Alterações

### App.jsx
- Novo `useMemo` `unreviewedFeedbackCount`: filtra `trades` por `status === 'REVIEWED'`
- Usa `trades` (não `allTrades`) porque no student mode o listener só popula `trades`
- Prop `unreviewedFeedback` passada ao Sidebar

### Sidebar.jsx v1.3.0
- Nova prop `unreviewedFeedback`
- Badge emerald (verde) no item "Feedback" do menu do aluno
- Cor `green` adicionada ao badge renderer (alongside red/purple/blue)

### version.js
- v1.19.7+20260319

### Testes
- 8 novos testes (v1197-sidebar-badge.test.js)
- 471 testes totais (22 suites), zero regressão

## Impacto
- Collections: nenhuma
- Cloud Functions: nenhuma
- Hooks/listeners: nenhum novo (usa `trades` existente)
- PL/compliance/emotional: zero
- Cálculo client-side puro

## Nota técnica
`allTrades` não é populado no student mode do `useTrades` — apenas `trades`.
Inconsistência documentada como dívida técnica futura.