### PR TITLE
debt: Node.js 20→22 + firebase-functions SDK 4.5→5.1 (#96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Aplica-se a:
 
 - Todas CFs com Claude API requerem: `secrets: ['ANTHROPIC_API_KEY']`
 - **Debt crítico:** `onTradeCreated` dispara em trades IMPORTED, corrompendo PL
-- **Debt crítico:** Node.js 20 depreca 30/04/2026 (DT-016) + firebase-functions SDK 4.9.0 → ≥5.1.0 (DT-028)
+- ~~**Debt crítico:** Node.js 20 depreca 30/04/2026 (DT-016) + firebase-functions SDK 4.9.0 → ≥5.1.0 (DT-028)~~ RESOLVIDO v1.22.0 — Node.js 22 + SDK 5.1
 
 | Function | Trigger | Responsabilidade |
 |----------|---------|-----------------|
@@ -251,8 +251,8 @@ Issues-chave: #100 (epic self-service), #96 (Node 20→22), #3 (Aluno Dashboard 
 
 | ID | Descrição | Prioridade | Deadline |
 |----|-----------|-----------|----------|
-| DT-016 | **Node.js 20 depreca** | **CRÍTICA** | **30/04/2026** |
-| DT-028 | **firebase-functions SDK 4.9.0 → ≥5.1.0** | **CRÍTICA** | **30/04/2026** |
+| ~~DT-016~~ | ~~Node.js 20 depreca~~ RESOLVIDO v1.22.0 | ~~CRÍTICA~~ | ~~30/04/2026~~ |
+| ~~DT-028~~ | ~~firebase-functions SDK 4.5.0 → ≥5.1.0~~ RESOLVIDO v1.22.0 | ~~CRÍTICA~~ | ~~30/04/2026~~ |
 | DT-002 | Cycle transitions sem fechamento formal | ALTA | — |
 | DT-027 | Rename externo UI "Acompanhamento 2.0" → "Espelho" | ALTA | Antes da comunicação |
 | DT-012 | Mentor não consegue editar feedback já enviado | MÉDIA | — |

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -57,7 +57,7 @@ Cada entrada deve conter: ID sequencial, descrição, issue de origem, data e ho
 
 | Ferramenta | Versão | Uso |
 |-----------|--------|-----|
-| Node.js | 20.x (migrar para 22 — DT-016) | Runtime local + Cloud Functions |
+| Node.js | 22.x (migrado de 20 — DT-016 resolvido v1.22.0) | Runtime local + Cloud Functions |
 | Firebase CLI | latest | Deploy de CFs e Firestore rules |
 | GitHub CLI (`gh`) | 2.86.0 | Gestão de issues, PRs e milestones via script |
 | PowerShell | Windows | Shell padrão — commits em linha única obrigatório |
@@ -566,14 +566,14 @@ Claude afirma algo sobre fluxo de dados, origem de campos ou estado de implement
 | DT-011 | Templates CSV vazam entre alunos (sem filtro por studentId) | MÉDIA | — | — |
 | DT-012 | Mentor não consegue editar feedback já enviado | MÉDIA | — | #91 |
 | DT-015 | recalculateCompliance não usa writeBatch (não atômico) | BAIXA | — | — |
-| DT-016 | **Cloud Functions Node.js 20 depreca 30/04/2026** | **CRÍTICA** | **30/04/2026** | — |
+| DT-016 | ~~Cloud Functions Node.js 20 depreca 30/04/2026~~ RESOLVIDO v1.22.0 | **CRÍTICA** | **30/04/2026** | #96 |
 | DT-018 | FeedbackPage não reflete edições de trade em tempo real | BAIXA | — | — |
 | DT-020 | Teclas seta alteram valores em campos de preço/qty no modal de parciais | MÉDIA | — | — |
 | DT-022 | CF scheduled limpeza diária csvStagingTrades (23h) não implementada | MÉDIA | — | — |
 | DT-025 | Campos `hasPartials`/`partialsCount` legados nos documentos de trades | BAIXA | — | — |
 | DT-026 | ~~stageDiagnosis não gerado pelo Re-processar IA — só por handleProbingComplete~~ RESOLVIDO v1.21.4 | BAIXA | — | — |
 | DT-027 | Rename externo: title, logo, textos UI de "Acompanhamento 2.0" para "Espelho" | ALTA | Antes da comunicação ao grupo | #100 |
-| DT-028 | firebase-functions SDK 4.9.0 → migrar para ≥5.1.0 (companion de DT-016) | **CRÍTICA** | **30/04/2026** | — |
+| DT-028 | ~~firebase-functions SDK 4.9.0 → migrar para ≥5.1.0 (companion de DT-016)~~ RESOLVIDO v1.22.0 | **CRÍTICA** | **30/04/2026** | #96 |
 | DT-029 | ~~useProbing não rehydratava savedQuestions do Firestore — aluno em loop no aprofundamento~~ RESOLVIDO v1.21.5 | ALTA | — | #92 |
 
 ---
@@ -582,6 +582,19 @@ Claude afirma algo sobre fluxo de dados, origem de campos ou estado de implement
 
 > Histórico de versões. Formato: [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 > Adicionar entradas no topo. Nunca editar entradas antigas.
+
+### [1.22.0] - 01/04/2026
+**Issue:** #96 (debt: Node.js 20→22 Cloud Functions)
+#### Alterado
+- `functions/package.json`: `engines.node` de `"20"` para `"22"`
+- `functions/package.json`: `firebase-functions` de `"^4.5.0"` para `"^5.1.0"`
+#### Resolvido
+- DT-016: Cloud Functions Node.js 20 → 22
+- DT-028: firebase-functions SDK 4.5 → 5.1
+#### Notas
+- SDK 5.x mantém compatibilidade com imports `firebase-functions/v1` (index.js) e `firebase-functions/v2/https` (assessment modules)
+- Sem mudança de signatures — todas as 18 CFs mantêm a mesma API
+- 755 testes passando
 
 ### [docs] - 29/03/2026
 **Sessão:** Branding, portal institucional, reestruturação de tiers

--- a/docs/dev/issues/issue-096-nodejs-22-cloud-functions.md
+++ b/docs/dev/issues/issue-096-nodejs-22-cloud-functions.md
@@ -1,0 +1,92 @@
+# Issue 096 — debt: Node.js 20 para 22 nas Cloud Functions (deadline 30/04/2026)
+> **Branch:** `debt/issue-096-nodejs-22-cloud-functions`
+> **Milestone:** v1.1.0 — Espelho Self-Service
+> **Aberto em:** 01/04/2026
+> **Status:** 🔵 Em andamento
+> **Versão entregue:** —
+
+---
+
+## 1. CONTEXTO
+
+Cloud Functions rodam Node.js 20, que será deprecated pelo Google em 30/04/2026 (decommission 30/10/2026). Após a data, novos deploys podem falhar. Além disso, o SDK `firebase-functions` está na versão `^4.5.0` e precisa ser atualizado para `>=5.1.0` (DT-028).
+
+**Referências:** DT-016, DT-028 (PROJECT.md seção 9)
+
+## 2. ACCEPTANCE CRITERIA
+
+- [ ] `engines.node` em `functions/package.json` alterado de `"20"` para `"22"`
+- [ ] `firebase-functions` SDK atualizado de `^4.5.0` para `>=5.1.0`
+- [ ] Breaking changes do SDK 5.x avaliados e adaptados (signatures `onCall`, import paths)
+- [ ] Todas as CFs testadas localmente: onTradeCreated, onTradeUpdated, onTradeDeleted, onMovementCreated, onMovementDeleted, createStudent, deleteStudent, resendStudentInvite, addFeedbackComment, closeTrade, recalculateCompliance, cleanupOldNotifications, classifyOpenResponse, generateProbingQuestions, analyzeProbingResponse, generateAssessmentReport, healthCheck, seedInitialData
+- [ ] Deploy em produção validado
+- [ ] DT-016 e DT-028 marcados como resolvidos no PROJECT.md
+
+## 3. ANÁLISE DE IMPACTO
+
+| Aspecto | Detalhe |
+|---------|---------|
+| Collections tocadas | Nenhuma alteração de schema — impacto é infra/runtime |
+| Cloud Functions afetadas | **Todas** (18 exports): mudança de runtime Node.js 20→22 + SDK 4.x→5.x |
+| Hooks/listeners afetados | Nenhum diretamente — mas CFs com trigger Firestore (onTradeCreated, onTradeUpdated, onTradeDeleted, onMovementCreated, onMovementDeleted) precisam validar compatibilidade |
+| Side-effects (PL, compliance, emotional) | Pipeline trades→CFs→PL/compliance intacto se signatures forem preservadas (INV-03) |
+| Blast radius | **Alto** — todas as CFs param de funcionar se o upgrade quebrar algo |
+| Rollback | Reverter `engines.node` para `"20"` e SDK para `^4.5.0` + redeploy |
+
+### Breaking changes conhecidos (firebase-functions 5.x)
+
+- `functions.https.onCall` signature muda — afeta: createStudent, deleteStudent, resendStudentInvite, addFeedbackComment, closeTrade, recalculateCompliance, seedInitialData
+- Import paths podem mudar — afeta: todos os 4 módulos em `./assessment/`
+- Referência: https://firebase.google.com/docs/functions/migrate-to-2nd-gen
+
+## 4. SESSÕES
+
+### Sessão — 01/04/2026
+
+**O que foi feito:**
+- Verificado estado real do codebase: `engines.node: "20"`, `firebase-functions: "^4.5.0"`
+- Descoberto codebase híbrido: `index.js` usa `/v1`, `assessment/*.js` usa `/v2/https`
+- Confirmado SDK 5.x mantém compatibilidade com ambos import paths
+- Atualizado `engines.node` de `"20"` para `"22"`
+- Atualizado `firebase-functions` de `"^4.5.0"` para `"^5.1.0"` (instalado 5.1.1)
+- Testado todos os import paths: `/v1`, `/v2/https`, `onCall`, `HttpsError`, `firestore.document`, `pubsub.schedule` — todos OK
+- 755 testes passando (36 test files)
+- `version.js` atualizado para v1.22.0
+- CHANGELOG atualizado no PROJECT.md
+- DT-016 e DT-028 marcados como resolvidos
+
+**Decisões tomadas:**
+
+| ID | Decisão | Justificativa |
+|----|---------|---------------|
+| — | Manter imports `/v1` no index.js (não migrar para v2 gen) | SDK 5.x suporta ambos; migração de signatures é escopo separado |
+
+**Arquivos tocados:**
+- `functions/package.json`
+- `functions/package-lock.json`
+- `src/version.js`
+- `docs/PROJECT.md`
+- `CLAUDE.md`
+- `docs/dev/issues/issue-096-nodejs-22-cloud-functions.md`
+
+**Testes:**
+- 755 testes passando, 36 test files, 0 falhas
+
+**Commits:**
+- *(pendente — aguardando confirmação)*
+
+**Pendências para próxima sessão:**
+- Deploy em produção (`firebase deploy --only functions`) — requer ambiente de produção
+- Validação pós-deploy de todas as 18 CFs em produção
+
+## 5. ENCERRAMENTO
+
+**Status:** Aguardando deploy em produção
+
+**Checklist final:**
+- [ ] Acceptance criteria atendidos
+- [ ] Testes passando
+- [ ] PROJECT.md atualizado (DEC, DT, CHANGELOG)
+- [ ] PR aberto e mergeado
+- [ ] Issue fechado no GitHub
+- [ ] Branch deletada

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "firebase-admin": "^12.0.0",
-        "firebase-functions": "^4.5.0"
+        "firebase-functions": "^5.1.0"
       },
       "engines": {
-        "node": "20"
+        "node": "22"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1191,9 +1191,9 @@
       "license": "MIT"
     },
     "node_modules/firebase-functions": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-4.9.0.tgz",
-      "integrity": "sha512-IqxOEsVAWGcRv9KRGzWQR5mOFuNsil3vsfkRPPiaV1U/ATC27/jbahh4z8I4rW8Xqa6cQE5xqnw0ueyMH7i7Ag==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-5.1.1.tgz",
+      "integrity": "sha512-KkyKZE98Leg/C73oRyuUYox04PQeeBThdygMfeX+7t1cmKWYKa/ZieYa89U8GHgED+0mF7m7wfNZOfbURYxIKg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -1209,7 +1209,7 @@
         "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": "^10.0.0 || ^11.0.0 || ^12.0.0"
+        "firebase-admin": "^11.10.0 || ^12.0.0"
       }
     },
     "node_modules/form-data": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -9,11 +9,11 @@
     "migrate": "node migrate-trade-status.js"
   },
   "engines": {
-    "node": "20"
+    "node": "22"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^4.5.0"
+    "firebase-functions": "^5.1.0"
   }
 }

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.22.0: debt: Node.js 20→22 + firebase-functions SDK 4.5→5.1 nas Cloud Functions (issue #096, DT-016, DT-028)
  * - 1.21.5: fix: probing rehydration — useProbing agora rehydrata perguntas do Firestore ao retornar à página; effectiveStatus resolve status preso em ai_assessed quando probing já foi gerado
  * - 1.21.4: fix: reportData persistence/rehydration, re-processar IA regenera report completo, probing questions panel, fix probingData.summary path, rewrite diretriz 4.4
  * - 1.21.3: feat: respostas abertas com análise IA no relatório do mentor (issue #097)
@@ -34,10 +35,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.21.5',
-  build: '20260330',
-  display: 'v1.21.5',
-  full: '1.21.5+20260330',
+  version: '1.22.0',
+  build: '20260401',
+  display: 'v1.22.0',
+  full: '1.22.0+20260401',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary
- Atualiza `engines.node` de `"20"` para `"22"` em `functions/package.json`
- Atualiza `firebase-functions` de `"^4.5.0"` para `"^5.1.0"` (instalado 5.1.1)
- Resolve DT-016 (Node.js 20 deprecated 30/04/2026) e DT-028 (SDK companion)
- SDK 5.x mantém compatibilidade com imports `/v1` (index.js) e `/v2/https` (assessment modules)
- 18/18 CFs carregam sem erro, 755 testes passando

## Test plan
- [x] `node -e require('./index.js')` — 18 CFs carregam sem erro de import/syntax
- [x] Todos os import paths validados: `/v1`, `/v2/https`, `onCall`, `HttpsError`, `firestore.document`, `pubsub.schedule`
- [x] 755 testes unitários passando (36 test files)
- [ ] Deploy em produção (`firebase deploy --only functions`)
- [ ] Validação pós-deploy das 18 CFs em produção

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)