### PR TITLE
feat(#52): Prop Firm Engine — Fases 1, 1.5, 2 (v1.24.0)

### DIFF
--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,8 +1,8 @@
 # PROJECT.md — Acompanhamento 2.0
 ## Documento Mestre do Projeto · Single Source of Truth
 
-> **Versão:** 0.9.0  
-> **Última atualização:** 05/04/2026 — CHUNK-17 Prop Firm Engine, lock #52  
+> **Versão:** 0.10.0  
+> **Última atualização:** 09/04/2026 — Prop Firm Engine deployado (#52 Fases 1/1.5/2), DEC-057/058/059, DT-034, v1.24.0  
 > **Criado:** 26/03/2026 — sessão de consolidação documental  
 > **Fontes originais:** ARCHITECTURE.md, AVOID-SESSION-FAILURES.md, VERSIONING.md, CHANGELOG.md, CHUNK-REGISTRY.md  
 > **Mantido por:** Marcio Portes (integrador único)
@@ -31,6 +31,7 @@ Este documento segue versionamento semântico:
 | 0.7.0 | 05/04/2026 | Controle de Assinaturas | #94 v1.23.0, DEC-055/DEC-056, CHUNK-16 liberado |
 | 0.8.0 | 05/04/2026 | Revisão documental | INV-15/16, DT-030/031, mapa CFs atualizado, convenções bash, #94 fechado |
 | 0.9.0 | 05/04/2026 | CHUNK-17 + lock #52 | CHUNK-17 Prop Firm Engine criado no registry, lock registrado para #52 |
+| 0.10.0 | 09/04/2026 | Prop Firm Engine deployado | #52 Fases 1/1.5/2 v1.24.0, DEC-057/058/059, DT-034, correção ATR v2 |
 
 **Regra de uso:**
 - Toda sessão que modificar este documento DEVE incrementar a versão e adicionar entrada na tabela acima
@@ -668,6 +669,9 @@ Chunks são conjuntos técnicos atômicos. Uma sessão faz check-out de chunks n
 | DEC-054 | Feedback semântico (#31) em 2 fases: Fase 1 rule-based (custo zero, dados existentes), Fase 2 Gemini Flash (incluso no Google Workspace, mesmo ecossistema GCP/Firebase). Claude API descartado por custo recorrente | #31 | 03/04/2026 |
 | DEC-055 | Subscriptions como subcollection de students (`students/{id}/subscriptions`), não collection raiz. Assinatura é entidade dependente — nunca existe sem aluno. Mentor queries via `collectionGroup('subscriptions')` | #94 | 04/04/2026 |
 | DEC-056 | Campo `type: trial/paid` + `trialEndsAt` na subscription + `accessTier` no student. Separa leads (trial) de convertidos (paid). Trial sem cobrança, CF expira automaticamente. `accessTier` derivado da subscription ativa, sincronizado pela CF `checkSubscriptions` | #94 | 04/04/2026 |
+| DEC-057 | **Plano de ataque prop firm — 5 perfis determinísticos instrument-aware** (CONS_A 10% DD, CONS_B 15% ★, CONS_C 20%, AGRES_A 25%, AGRES_B 30%). Lógica invertida: mais risco = menos trades (conservadores 2/dia, agressivos 1/dia). RR fixo 1:2. `roUSD = drawdownMax × roPct`, `stopPoints = roUSD / instrument.pointValue` (back-calculado). Viabilidade por 3 critérios: `stop_below_min_viable` (por instrument type), `stop_exceeds_ny_range` (>75%), `ro_exceeds_daily_loss`. Sugere micro variant se incompatível. **Substitui modelo binário conservador/agressivo** — normalizeAttackProfile() mantém compat com contas legadas | #52 | 07/04/2026 |
+| DEC-058 | **Restrição de sessão NY** — stops abaixo de `NY_MIN_VIABLE_STOP_PCT = 12.5%` do range NY não são viáveis na sessão NY (vela única consome), mas viáveis em Ásia/London. Flag `sessionRestricted` + `recommendedSessions: ['london', 'asia']`. Não inviabiliza a conta — apenas restringe quando operar. Threshold 12.5% genérico por tipo de instrumento; calibragem com ATR real (v2 09/04): NQ NY range = 549 × 0.60 = 329.4 pts → 12.5% = ~41 pts mínimo | #52 | 08/04/2026 |
+| DEC-059 | **Engine prop firm duplicado (Opção A)** — `src/utils/propFirmDrawdownEngine.js` (testado por 58 testes Vitest) e `functions/propFirmEngine.js` (CommonJS para Cloud Functions) são cópias manuais sincronizadas. Cloud Functions não podem importar de `../src/`. Header de aviso obrigatório em ambos. Alternativas descartadas: symlink (frágil em deploy), rollup/esbuild step (complexidade prematura). **DT-034 registra refactoring futuro via build step ou monorepo workspace** | #52 | 09/04/2026 |
 
 ---
 
@@ -717,6 +721,8 @@ Claude afirma algo sobre fluxo de dados, origem de campos ou estado de implement
 | DT-029 | ~~useProbing não rehydratava savedQuestions do Firestore — aluno em loop no aprofundamento~~ RESOLVIDO v1.21.5 | ALTA | — | #92 |
 | DT-030 | TradesJournal batch activate sem `setSuspendListener` — snapshots do onSnapshot processam trades intermediários durante batch, causando re-renders desnecessários. StudentDashboard tem o fix correto como referência | BAIXA | — | #93 |
 | DT-031 | `balanceBefore`/`balanceAfter` incorretos em movements criados em batch — cada `addTrade` lê o "último movement" mas em batch todos leem o mesmo. Saldo final correto via `FieldValue.increment` na CF. Afeta apenas visualização do extrato em movements intermediários (cosmético) | BAIXA | — | #93 |
+| DT-034 | Engine prop firm duplicado entre `src/utils/propFirmDrawdownEngine.js` (ESM, testado) e `functions/propFirmEngine.js` (CommonJS, executado). Sincronização manual com header de aviso. Mudanças de lógica exigem atualização nos 2 arquivos. Refactoring futuro: build step (rollup/esbuild) ou monorepo workspace permitindo import compartilhado. Engine é estável (58 testes, lógica determinística) — mudanças raras justificam pragmatismo de v1 | BAIXA | — | #52 |
+| DT-035 | ATR de NG (Natural Gas), HG (Copper) e 6A (Australian Dollar) na `instrumentsTable.js` não foram incluídos na recaptura TradingView v2 (09/04/2026). Mantêm valores v1 (alucinados). Não são usados em nenhum template Apex/MFF/Lucid/Tradeify atual — impacto baixo. Remedir trimestralmente junto com os outros | BAIXA | — | #52 |
 
 ---
 
@@ -724,6 +730,55 @@ Claude afirma algo sobre fluxo de dados, origem de campos ou estado de implement
 
 > Histórico de versões. Formato: [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 > Adicionar entradas no topo. Nunca editar entradas antigas.
+
+### [1.24.0] - 09/04/2026
+**Issue:** #52 (epic: Gestão de Contas em Mesas Proprietárias)
+**Milestone:** v1.1.0 — Espelho Self-Service
+**Fases:** 1 (Templates/Config/Plano rule-based) + 1.5 (Instrument-aware + 5 perfis + viabilidade) + 2 (Engine Drawdown + CFs)
+#### Adicionado
+- **Collection raiz `propFirmTemplates`** (INV-15 aprovado) — catálogo com 21 templates pré-configurados: Apex EOD 25K-300K, Apex Intraday, MFF Starter/Core/Scale, Lucid Pro/Flex, Tradeify Select 25K-150K
+- **`PropFirmConfigPage`** (Settings → aba Prop Firms) — mentor seed/edit/delete templates, agrupado por firma, botão "Limpar Todos"
+- **`src/constants/instrumentsTable.js`** — 23 instrumentos curados (equity_index, energy, metals, currency, agriculture, crypto) com ATR real TradingView v2, point value, micro variants, availability por firma, session profiles (AM Trades framework)
+- **`src/constants/propFirmDefaults.js`** — constantes `PROP_FIRM_PHASES`, `DRAWDOWN_TYPES`, `FEE_MODELS`, `DAILY_LOSS_ACTIONS`, `ATTACK_PLAN_PROFILES` (5 códigos), `ATTACK_PROFILES` (5 perfis com metadata), `MIN_VIABLE_STOP` por type, `MAX_STOP_NY_PCT=75`, `NY_MIN_VIABLE_STOP_PCT=12.5`, `normalizeAttackProfile()` legacy compat
+- **`src/utils/attackPlanCalculator.js`** — plano de ataque determinístico 5 perfis instrument-aware: `roUSD = drawdownMax × profile.roPct`, `stopPoints = roUSD / instrument.pointValue` back-calculado, RR fixo 1:2, `lossesToBust`, `evPerTrade`, viabilidade por 3 critérios + sugestão de micro, restrição sessão NY (`nySessionViable`, `recommendedSessions`) (DEC-057, DEC-058)
+- **`src/utils/propFirmDrawdownEngine.js`** — engine puro 4 tipos de drawdown (STATIC, TRAILING_INTRADAY, TRAILING_EOD, TRAILING_WITH_LOCK), `resolveLockAt()` com lockFormula `BALANCE + DD + 100`, `calculateDrawdownState()`, `initializePropFirmState()`, `calculateEvalDaysRemaining()`, 5 flags (`ACCOUNT_BUST`, `DD_NEAR`, `DAILY_LOSS_HIT`, `LOCK_ACTIVATED`, `EVAL_DEADLINE_NEAR`)
+- **`functions/propFirmEngine.js`** — cópia CommonJS do engine para Cloud Functions (DEC-059, DT-034)
+- **CF `onTradeCreated/onTradeUpdated/onTradeDeleted` estendidas** — branch prop firm com `runTransaction` (atomicidade peakBalance), helpers `recalculatePropFirmState`, `appendDrawdownHistory`, `notifyPropFirmFlag` throttled 1×/dia/flag via doc id determinístico
+- **Subcollection `accounts/{accountId}/drawdownHistory/{tradeId}`** — append-only audit log (INV-15 aprovado)
+- **Campo `propFirm` inline em `accounts`** — templateId, firmName, productName, phase, evalDeadline, selectedInstrument, suggestedPlan + runtime (peakBalance, currentDrawdownThreshold, lockLevel, isDayPaused, tradingDays, dailyPnL, lastTradeDate, currentBalance, distanceToDD, flags, lastUpdateTradeId)
+- **Seletor PROP 2 níveis** no `AccountsPage` (firma → produto) + 5 botões de perfil com tooltip + seletor de instrumento derivado de `getAllowedInstrumentsForFirm`
+- **Modal de conta redesenhado** — `max-w-lg` → `max-w-4xl`, layout 2/3 colunas, preview de execução em grid 3 cols
+- **Auto-abertura do `PlanManagementModal`** após criar conta PROP com defaults derivados do attackPlan (currency dinâmica, cycleGoalPct/cycleStopPct/periodGoalPct/periodStopPct derivados)
+#### Corrigido
+- **Bug crítico ATR alucinado (instrumentsTable v1)** — 13 valores corrigidos com ATR real TradingView v2 (ES 55→123, NQ 400→549, YM 420→856, RTY 30→70, CL 2.5→9.11, GC 40→180, SI 0.60→5.69, 6B/6J/ZC/ZW/ZS/MBT). Bug MES Apex 25K CONS_B 30pts: antes 90.9% do range NY (INVIÁVEL), agora 40.65% (VIÁVEL day trade) ✅
+- **Bug `availableCapital` dobrado no PlanManagementModal** — flag `__isDefaults: true` em propPlanDefaults evita que `currentPlanPl` dobre o saldo em conta PROP nova
+- **Currency BRL fixa no PlanManagementModal** — agora deriva `accountCurrency` da conta selecionada, símbolo dinâmico US$/€/R$
+- **Edit modal não rehydratava propFirm** — `openModal(account)` agora seta `propFirmData` a partir de `account.propFirm` quando existe
+#### Testes
+- **905 testes totais** (58 engine drawdown + 52 attackPlan calculator + 46 instrumentsTable + 749 pré-existentes) — zero regressão
+- Cobertura engine drawdown: 4 tipos × cenários, lock Apex, daily loss soft, distanceToDD edge cases, cenário integrado eval realista 5 dias
+- Cobertura attackPlan: 5 perfis × instrumentos, viabilidade, sugestão micro, restrição NY, validação operacional Apex 25K MNQ CONS_B
+- Cobertura instrumentsTable: 46 testes pós-correção ATR v2
+#### Infraestrutura
+- **CF bump v1.9.0 → v1.10.0** com CHANGELOG header
+- **`firestore.rules`** — regras para `propFirmTemplates` (mentor write) + subcollection `accounts/{id}/drawdownHistory` (read autenticado, write false apenas CF admin SDK)
+- **CHUNK-17 Prop Firm Engine** locked para #52 no registry (§6.3)
+#### Decisões
+- DEC-053 — Escopo revisado com regras Apex Mar/2026
+- **DEC-057** — 5 perfis determinísticos instrument-aware com RR fixo 1:2
+- **DEC-058** — Restrição sessão NY threshold 12.5%
+- **DEC-059** — Engine duplicado Opção A (DT-034 registra refactoring futuro)
+#### Dívida técnica nova
+- **DT-034** — Unificar engine prop firm via build step ou monorepo workspace
+- **DT-035** — Re-medir ATR de NG/HG/6A no TradingView (não incluídos no v2)
+#### Limitações v1 documentadas
+- `onTradeUpdated` aplica delta incremental, NÃO reconstrói histórico do peakBalance (trade editado antigo pode dessincronizar)
+- `onTradeDeleted` aplica reversão mas NÃO remove snapshot do drawdownHistory (append-only audit log — análises filtram por tradeId existente)
+- Pre-read `account.get()` em todos os trades (~50ms overhead para non-PROP — aceito v1, monitorar)
+#### Pendente (fases futuras)
+- **Fase 2.5** — CF `generatePropFirmApproachPlan` com Sonnet 4.6 (prompt v1.0 em `Temp/ai-approach-plan-prompt.md`)
+- **Fase 3** — Dashboard card prop + gauges + alertas visuais (depende CHUNK-04 unlock #93)
+- **Fase 4** — Payout tracking + qualifying days + simulador de saque
 
 ### [1.23.0] - 05/04/2026
 **Issue:** #94 (feat: Controle de Assinaturas da Mentoria)

--- a/docs/dev/issues/issue-052-prop-firms.md
+++ b/docs/dev/issues/issue-052-prop-firms.md
@@ -15,6 +15,8 @@ Muitos alunos operam em mesas proprietarias (prop firms). Cada mesa tem regras p
 
 **Revisao v3.0 (05/04/2026):** Discussao com sessao master (Opus 4.6) definiu modelo semantico completo, plano de ataque personalizado, 3 camadas de alerta, e decisoes de persistencia.
 
+**Revisao v4.0 (06/04/2026):** Fase 1 implementada e validada operacionalmente. Identificado e corrigido bug critico no algoritmo: `calculateAttackPlan` original tratava `drawdownMax` como input para % generico, gerando RO maior que `dailyLossLimit` (impossivel). Reescrito com hard constraints (RO baseado em `dailyLossLimit`, nunca em `drawdownMax`). Bug do `availableCapital` no `PlanManagementModal` (dobrava saldo via `currentPlanPl`) corrigido com flag `__isDefaults`. Validacao operacional revelou problema mais profundo: stop em USD nao tem significado sem contexto de instrumento (15pts no MNQ = imediatamente comido pelo ATR). Faseamento expandido com **Fase 1.5 (instrumentsTable + calculateAttackPlan instrument-aware)** e **Fase 2.5 (IA Sonnet 4.6 como narrador)**.
+
 ### Modelo semantico — 3 camadas
 
 **Camada 1 — Template (regras da mesa):**
@@ -81,14 +83,16 @@ O plano mostra de onde veio (`dataSource`) e alerta quando baseado em defaults: 
 | RO sugerido | Conservador (DD apertado, sem 2a chance) | Moderado (DD resetou) | Conforme perfil real |
 | Alertas | Pressao de prazo + margem de DD | Complacencia pos-aprovacao | Payout eligibility |
 
-### Faseamento (revisado)
+### Faseamento (revisado v4.0)
 
-| Fase | Escopo | Estimativa | Restricoes |
-|------|--------|-----------|-----------|
-| 1 | Templates `propFirmTemplates` + configuracao mentor + extensao `accounts` + plano de ataque rule-based | 1.5 sessoes | Sem conflito de chunks |
-| 2 | Engine de drawdown (4 tipos) + CFs com transacao + daily loss + eval deadline | 1.5 sessoes | CF usa `runTransaction` para drawdown |
-| 3 | Dashboard card prop + gauges + alertas mentor + tempo medio trades (universal) | 1 sessao | CHUNK-02 + CHUNK-04 (leitura) — #93 deve liberar locks antes |
-| 4 | Payout tracking + qualifying days + simulador | 0.5 sessao | — |
+| Fase | Escopo | Estimativa | Estado | Restricoes |
+|------|--------|-----------|--------|-----------|
+| 1 | Templates `propFirmTemplates` + configuracao mentor + extensao `accounts` + plano de ataque rule-based | 1.5 sessoes | ✅ Implementada (com correcoes) | Sem conflito de chunks |
+| **1.5** | **`instrumentsTable.js` curada (23 instrumentos: ATR, point value, micro variants, disponibilidade por mesa, session profiles) + `calculateAttackPlan` instrument-aware (sizing/stop em pontos reais) + campo `selectedInstrument` no `propFirm` + UI seleciona instrumento na criacao** | **1 sessao** | 🟡 Em andamento | Bloqueia Fase 2 — sem instrumento, plano e abstrato |
+| 2 | Engine de drawdown (4 tipos) + CFs com transacao + daily loss + eval deadline | 1.5 sessoes | ⏸️ Aguarda 1.5 | CF usa `runTransaction` para drawdown |
+| **2.5** | **CF `generatePropFirmApproachPlan` com Sonnet 4.6: narrativa estrategica + exemplos + tabela visual baseada em (perfil 4D + indicadores + instrumento + mesa + tipo conta + tipo ataque). Math determinada na camada 1.5; IA so narra. Validacao pos-processamento contra constraints. Persiste em `account.propFirm.aiApproachPlan`** | **2-3 sessoes** | 📋 Planejada | DEC nova: Sonnet 4.6 (nao Gemini Flash, DEC-054 nao se aplica) |
+| 3 | Dashboard card prop + gauges + alertas mentor + tempo medio trades (universal) | 1 sessao | ⏸️ Aguarda 2 | CHUNK-02 + CHUNK-04 (leitura) — #93 deve liberar locks antes |
+| 4 | Payout tracking + qualifying days + simulador | 0.5 sessao | ⏸️ | — |
 
 ### Decisoes arquiteturais (DEC-053 + discussao 05/04/2026)
 
@@ -105,6 +109,12 @@ O plano mostra de onde veio (`dataSource`) e alerta quando baseado em defaults: 
 | Drawdown usa `runTransaction` na CF | Trailing depende de read-then-write atomico do peakBalance. FieldValue.increment nao serve aqui |
 | Tempo medio de trades e metrica universal | Vai nos MetricsCards para todas as contas, nao so prop. No card prop mostra com contexto |
 | Eval deadline conta dias corridos | Apex conta corridos, nao dias de trading. UI deve ser explicita |
+| **`calculateAttackPlan` usa hard constraints absolutos (06/04)** | **roPerTrade NUNCA > dailyLossLimit. roPerTrade × maxTradesPerDay <= dailyLossLimit. metaDiaria × diasUteis >= profitTarget. Algoritmo original (% de drawdown) gerava planos impossiveis** |
+| **`instrumentsTable.js` como tabela curada hardcoded (06/04)** | **Path: `src/constants/instrumentsTable.js`. 23 instrumentos top com ATR + point value + micro variants. Helpers: `getInstrument`, `getSessionRange`, `isInstrumentAllowed`. Revisao trimestral pelo mentor. Nao em masterData (volume baixo, mudanca trimestral, schema rico). Fonte de verdade unica para volatilidade** |
+| **`restrictedInstruments` derivado dinamicamente (06/04)** | **Manter compatibilidade da UI atual (le `template.restrictedInstruments`), mas a fonte de verdade e `INSTRUMENTS_TABLE.availability[firm]`. Funcao helper expoe lista derivada para cada mesa** |
+| **Sonnet 4.6 para AI Approach Plan, NAO Gemini Flash (06/04)** | **DEC-054 (Gemini Flash para feedback semantico) nao se aplica. Justificativa: volume baixo (1 chamada/conta), stakes altas (dinheiro do trader), infra Claude ja existe (4 CFs), reasoning superior, custo aceitavel ate 500 alunos (~$24/mes). Nova DEC formal a registrar no PROJECT.md** |
+| **selectedInstrument inline em `account.propFirm` (06/04)** | **Atributo da instancia da conta. Faz parte do mesmo objeto `propFirm`. INV-15: aprovado verbalmente — campo do mesmo objeto ja aprovado, expansao natural** |
+| **Cap operacional max trades/dia (06/04)** | **8 conservador, 10 agressivo. Independente da formula matematica. Razao: dailyLoss/RO pode dar 21 trades, operacionalmente absurdo** |
 
 ## 2. ACCEPTANCE CRITERIA
 
@@ -240,9 +250,151 @@ Se encontrar conflito com shared file: documentar aqui e notificar Marcio.
 - Iniciar Fase 1 (templates + configuracao + plano de ataque)
 - Consultar body do issue GitHub (#52) para templates detalhados das mesas
 
+### Sessao — 05-06/04/2026 — Implementacao Fase 1 + Correcoes + Reescrita do calculator
+
+**Tipo:** codigo (worktree `~/projects/acomp-052`, branch `feature/issue-052-prop-firms`)
+**Baseado em:** PROJECT.md v0.9.0 (sessao iniciou nesse ponto; main avancou para v0.10.2 durante a sessao)
+
+**O que foi feito (Fase 1 — estrutura inicial):**
+- CHUNK-17 (Prop Firm Engine) registrado no PROJECT.md §6.3 com lock para #52
+- Worktree isolado criado: `git worktree add ~/projects/acomp-052 feature/issue-052-prop-firms` (INV-16)
+- `src/constants/propFirmDefaults.js` (NEW) — 23 templates: Apex EOD/Intraday 25K-300K (10), MFF Starter/Core/Scale 50K-150K (4), Lucid Pro/Flex 50K/100K (3), Tradeify Select 25K/50K/100K/150K (4) — 4 firms × multi-size
+- Constantes: PROP_FIRM_PHASES, DRAWDOWN_TYPES, FEE_MODELS, DAILY_LOSS_ACTIONS, ATTACK_PLAN_PROFILES, ATTACK_PLAN_DATA_SOURCES, EMPTY_TEMPLATE
+- `src/utils/attackPlanCalculator.js` (NEW) — primeira versao com cascata 4D → indicadores → defaults
+- `src/__tests__/utils/attackPlanCalculator.test.js` (NEW) — 34 testes iniciais
+- `src/hooks/usePropFirmTemplates.js` (NEW) — CRUD collection raiz com listener real-time, seedDefaults, deleteAllTemplates
+- `src/pages/PropFirmConfigPage.jsx` (NEW) — config mentor: seed, edit inline, delete, "Limpar Todos", agrupado por firma. DebugBadge (INV-04)
+- `src/hooks/useAccounts.js` — extensao addAccount/updateAccount com campo `propFirm` (templateId, firmName, productName, phase, peakBalance, currentDrawdownThreshold, suggestedPlan)
+- `src/components/AddAccountModal.jsx` — seletor firma → produto quando type=PROP, fallback para DEFAULT_TEMPLATES, auto-fill currency/balance/name, preview do plano de ataque
+- `src/pages/SettingsPage.jsx` — nova aba "Prop Firms"
+- `src/pages/AccountsPage.jsx` — DESCOBERTA: o modal de criacao de conta NAO usa AddAccountModal — tem form inline proprio. Adicionado seletor prop firm + propPlanDefaults + auto-abertura do PlanManagementModal para criar plano apos conta PROP
+- `firestore.rules` — rules para `propFirmTemplates` (mentor write, autenticado read) — DEPLOYED via `firebase deploy --only firestore:rules`
+
+**O que foi feito (5 correcoes de revisao identificadas pelo Marcio):**
+
+1. **Currency BRL fixa no PlanManagementModal** — modal usava `formatCurrency` sem currency, default BRL. Conta Apex em USD mostrava R$ no plano. Fix: derivar `accountCurrency` da conta selecionada (ou `editingPlan.currency` quando snapshot stale). 7 chamadas `formatCurrency(value)` → `formatCurrency(value, accountCurrency)`. Simbolo dinamico US$/€/R$.
+
+2. **Defaults do plano genericos** — `propPlanDefaults` so passava accountId, name, pl, riskPerOperation, rrTarget. Fix: derivar `cycleGoalPct = profitTarget/pl`, `cycleStopPct = drawdownMax/pl`, `periodGoalPct = dailyTarget/pl`, `periodStopPct = dailyLossLimit/pl` (ou cycleStop/5). Inclui `currency`, `name`, `type`, todos os 13 campos do form de plano.
+
+3. **Sizing fixo sem contexto de instrumento** — calculator retornava `sizing: 1 contrato` arbitrario. Sem saber se NQ ($20/pt) ou MNQ ($2/pt) ou ES ($50/pt), o sizing nao tem significado. Fix: `sizing: null` no calculator, UI mostra "a definir conforme instrumento" no preview.
+
+4. **Edit modal nao rehydratava propFirm** — ao editar conta PROP existente, dropdowns firma/produto voltavam vazios mesmo com `propFirm.templateId` salvo no Firestore. Fix: `openModal(account)` agora seta `propFirmData` a partir de `account.propFirm` quando existe.
+
+5. **Max trades/dia 21 (operacionalmente absurdo)** — formula `dailyLoss/stopPerTrade` dava numeros irreais. Fix: cap operacional **8 conservador / 10 agressivo**, independente da formula. Mesmo se a math diz 21, o cap reduz para 8.
+
+**O que foi feito (reescrita critica do calculateAttackPlan — bug $1.150):**
+
+Identificado bug: o algoritmo original calculava `roPerTrade = drawdownMax × percentual` (ex: $2.500 × 4.6% = $115 USD), e quando convertido para `riskPerOperation` em % do PL ($25.000), ficava 4.6% = $1.150 — 2.3x o daily loss limit ($500). Um unico trade ruim estouraria o dia inteiro.
+
+**Causa raiz:** algoritmo tratava `drawdownMax` como input para % generico. ERRADO. As regras da mesa sao **HARD CONSTRAINTS absolutas**, nao inputs.
+
+**Reescrito com hard constraints (`calculateAttackPlan` v2):**
+```
+stopTotal = drawdownMax (constraint mesa)
+stopDiario = dailyLossLimit (constraint mesa)
+metaTotal = profitTarget (constraint mesa)
+metaDiaria = profitTarget / diasUteis (Math.ceil para garantir)
+roPerTrade = dailyLossLimit × fatorPerfil (NUNCA × drawdownMax)
+maxTrades = floor(dailyLossLimit / roPerTrade) com cap 8/10
+rrMinimum = 1.5 conservador, 2.0 agressivo
+stopPerTrade = roPerTrade / rrMinimum
+```
+
+**Constraints invioláveis validadas:**
+- roPerTrade NUNCA > dailyLossLimit ✓
+- stopPerTrade NUNCA > dailyLossLimit ✓
+- roPerTrade × maxTradesPerDay NUNCA > dailyLossLimit ✓
+- metaDiaria × diasUteis >= profitTarget ✓
+
+**Validacao manual Apex EOD 25K (DD $1.000, daily $500, target $1.500, eval 30 dias):**
+
+| Metrica | Conservador (defaults) | Agressivo (4D forte) |
+|---|---|---|
+| RO/trade | $46 | $94 |
+| Stop/trade | $30 | $47 |
+| Max trades/dia | 8 (cap) | 5 |
+| RR minimo | 1.5:1 | 2.0:1 |
+| Meta diaria | $72 | $72 |
+| Dias uteis eval | 21 | 21 |
+| $46 × 8 = $368 ≤ $500 | ✓ | — |
+| $94 × 5 = $470 ≤ $500 | — | ✓ |
+| $72 × 21 = $1.512 ≥ $1.500 | ✓ | ✓ |
+| `constraintsViolated` | [] | [] |
+
+**Bug do `availableCapital` no PlanManagementModal:**
+Modal mostrava "Disponivel: US$ 50.000" para conta de US$ 25.000. Causa raiz: `currentPlanPl + freePl` dobrava o saldo quando `editingPlan = propPlanDefaults`. O `currentPlanPl` foi feito para edicao real (devolver pl ocupado por plano existente), mas foi disparado errado para defaults pre-preenchidos. Fix: flag `__isDefaults: true` em propPlanDefaults; o modal pula a devolucao quando ve a flag.
+
+**Validacao critica do Marcio (06/04):**
+Apesar dos numeros do calculator estarem matematicamente corretos, sao **operacionalmente inuteis**. Stop $30 = 15 pontos no MNQ (com NQ a 24.230). ATR diario do NQ ~400 pontos. Stop de 15 pts e comido pela primeira vela. **O algoritmo determina valores em USD sem saber o instrumento — abstracao sem significado.**
+
+**Conclusao:** Fase 1 entrega estrutura mas nao entrega valor real. Necessario:
+- **Fase 1.5**: tabela curada de instrumentos com ATR, point value, session profiles. Reescrever `calculateAttackPlan` para receber `instrument` como input e fazer math instrument-aware (back-calc: stop em pontos × valor do ponto = RO real).
+- **Fase 2.5**: Sonnet 4.6 como narrador (nao calculador). IA usa o math determinado da Fase 1.5 e gera narrativa estrategica + exemplos + tabela.
+
+**Discussao DEC-054 vs Sonnet 4.6 (06/04):**
+- DEC-054 (Gemini Flash para feedback semantico #31) NAO se aplica
+- Volume aqui e ~1 chamada/conta criada (raro) vs feedback que e 1 chamada/trade (alto volume)
+- Stakes diferentes: prop firm = dinheiro real do trader, requer reasoning superior
+- Custo Sonnet aceitavel ate 500 alunos (~$24/mes)
+- Infra Claude ja existe (4 CFs: classifyOpenResponse, generateProbingQuestions, analyzeProbingResponse, generateAssessmentReport) — secret ANTHROPIC_API_KEY ja configurado
+
+**Decisoes tomadas:**
+
+| ID | Decisao | Justificativa |
+|----|---------|---------------|
+| — | calculateAttackPlan v2 com hard constraints | Original gerava roPerTrade > dailyLossLimit, impossivel |
+| — | Cap operacional 8/10 trades/dia | Math poderia dar 21, absurdo operacional |
+| — | RR conservador 1.5, agressivo 2.0 | Conservador prioriza acerto (RR menor mais facil), agressivo prioriza eficiencia |
+| — | sizing: null | Depende do instrumento, calculado depois |
+| — | Tabela curada de instrumentos em src/constants/instrumentsTable.js | Volume baixo, mudanca trimestral, schema rico, separacao de dominio |
+| — | restrictedInstruments derivado da tabela | Source of truth unica, compatibilidade com UI atual |
+| — | Sonnet 4.6 (nao Gemini) para approach plan IA | Volume baixo, stakes altas, infra ja existe, reasoning superior |
+| — | selectedInstrument inline em propFirm | Atributo da instancia, INV-15 expansao natural |
+| — | __isDefaults flag para propPlanDefaults | Pular currentPlanPl no PlanManagementModal |
+
+**Arquivos tocados nesta sessao:**
+
+NOVOS:
+- `src/constants/propFirmDefaults.js`
+- `src/utils/attackPlanCalculator.js`
+- `src/__tests__/utils/attackPlanCalculator.test.js`
+- `src/hooks/usePropFirmTemplates.js`
+- `src/pages/PropFirmConfigPage.jsx`
+
+EDITADOS:
+- `src/hooks/useAccounts.js`
+- `src/components/AddAccountModal.jsx`
+- `src/pages/SettingsPage.jsx`
+- `src/pages/AccountsPage.jsx`
+- `src/components/PlanManagementModal.jsx`
+- `firestore.rules` (rules para propFirmTemplates) — **DEPLOYED**
+- `package-lock.json` (npm install no worktree)
+
+**Testes:**
+- 37 novos testes (`attackPlanCalculator.test.js`)
+- 844 testes totais passando — **zero regressao**
+- Build: limpo
+
+**Pendencias para esta mesma sessao (Fase 1.5):**
+- Criar `src/constants/instrumentsTable.js` baseado em `Temp/instruments-table-prop-firms.md`
+- Criar testes dos helpers (`getInstrument`, `getSessionRange`, `isInstrumentAllowed`)
+- Substituir `restrictedInstruments` hardcoded em `propFirmDefaults.js` por derivacao dinamica
+- Reescrever `calculateAttackPlan` instrument-aware (recebe `instrumentVolatility`)
+- Adicionar campo `selectedInstrument` em `propFirm` (INV-15 verbal aprovado — expansao do mesmo objeto)
+- Adicionar UI de selecao de instrumento na criacao de conta PROP
+- Atualizar `propPlanDefaults` para usar stop instrument-aware
+- Atualizar PROJECT.md com nova DEC ("instrumentsTable curada") e bump v0.11.0
+
+**Pendencias para sessoes futuras:**
+- Fase 2: Engine de drawdown (4 tipos) + CFs runTransaction
+- Fase 2.5: CF `generatePropFirmApproachPlan` com Sonnet 4.6 + UX
+- Fase 3: Dashboard card prop (depende de CHUNK-04 unlock)
+- Fase 4: Payout tracking
+- Conta APEX antiga sem propFirm: deletar via Firebase Console (sem service account no worktree)
+
 ## 5. ENCERRAMENTO
 
-**Status:** Aguardando inicio de codificacao
+**Status:** 🟡 Em andamento — Fase 1 implementada, Fase 1.5 iniciada
 
 **Checklist final:**
 - [ ] Acceptance criteria atendidos

--- a/docs/dev/issues/issue-052-prop-firms.md
+++ b/docs/dev/issues/issue-052-prop-firms.md
@@ -15,8 +15,6 @@ Muitos alunos operam em mesas proprietarias (prop firms). Cada mesa tem regras p
 
 **Revisao v3.0 (05/04/2026):** Discussao com sessao master (Opus 4.6) definiu modelo semantico completo, plano de ataque personalizado, 3 camadas de alerta, e decisoes de persistencia.
 
-**Revisao v4.0 (06/04/2026):** Fase 1 implementada e validada operacionalmente. Identificado e corrigido bug critico no algoritmo: `calculateAttackPlan` original tratava `drawdownMax` como input para % generico, gerando RO maior que `dailyLossLimit` (impossivel). Reescrito com hard constraints (RO baseado em `dailyLossLimit`, nunca em `drawdownMax`). Bug do `availableCapital` no `PlanManagementModal` (dobrava saldo via `currentPlanPl`) corrigido com flag `__isDefaults`. Validacao operacional revelou problema mais profundo: stop em USD nao tem significado sem contexto de instrumento (15pts no MNQ = imediatamente comido pelo ATR). Faseamento expandido com **Fase 1.5 (instrumentsTable + calculateAttackPlan instrument-aware)** e **Fase 2.5 (IA Sonnet 4.6 como narrador)**.
-
 ### Modelo semantico — 3 camadas
 
 **Camada 1 — Template (regras da mesa):**
@@ -83,16 +81,14 @@ O plano mostra de onde veio (`dataSource`) e alerta quando baseado em defaults: 
 | RO sugerido | Conservador (DD apertado, sem 2a chance) | Moderado (DD resetou) | Conforme perfil real |
 | Alertas | Pressao de prazo + margem de DD | Complacencia pos-aprovacao | Payout eligibility |
 
-### Faseamento (revisado v4.0)
+### Faseamento (revisado)
 
-| Fase | Escopo | Estimativa | Estado | Restricoes |
-|------|--------|-----------|--------|-----------|
-| 1 | Templates `propFirmTemplates` + configuracao mentor + extensao `accounts` + plano de ataque rule-based | 1.5 sessoes | ✅ Implementada (com correcoes) | Sem conflito de chunks |
-| **1.5** | **`instrumentsTable.js` curada (23 instrumentos: ATR, point value, micro variants, disponibilidade por mesa, session profiles) + `calculateAttackPlan` instrument-aware (sizing/stop em pontos reais) + campo `selectedInstrument` no `propFirm` + UI seleciona instrumento na criacao** | **1 sessao** | 🟡 Em andamento | Bloqueia Fase 2 — sem instrumento, plano e abstrato |
-| 2 | Engine de drawdown (4 tipos) + CFs com transacao + daily loss + eval deadline | 1.5 sessoes | ⏸️ Aguarda 1.5 | CF usa `runTransaction` para drawdown |
-| **2.5** | **CF `generatePropFirmApproachPlan` com Sonnet 4.6: narrativa estrategica + exemplos + tabela visual baseada em (perfil 4D + indicadores + instrumento + mesa + tipo conta + tipo ataque). Math determinada na camada 1.5; IA so narra. Validacao pos-processamento contra constraints. Persiste em `account.propFirm.aiApproachPlan`** | **2-3 sessoes** | 📋 Planejada | DEC nova: Sonnet 4.6 (nao Gemini Flash, DEC-054 nao se aplica) |
-| 3 | Dashboard card prop + gauges + alertas mentor + tempo medio trades (universal) | 1 sessao | ⏸️ Aguarda 2 | CHUNK-02 + CHUNK-04 (leitura) — #93 deve liberar locks antes |
-| 4 | Payout tracking + qualifying days + simulador | 0.5 sessao | ⏸️ | — |
+| Fase | Escopo | Estimativa | Restricoes |
+|------|--------|-----------|-----------|
+| 1 | Templates `propFirmTemplates` + configuracao mentor + extensao `accounts` + plano de ataque rule-based | 1.5 sessoes | Sem conflito de chunks |
+| 2 | Engine de drawdown (4 tipos) + CFs com transacao + daily loss + eval deadline | 1.5 sessoes | CF usa `runTransaction` para drawdown |
+| 3 | Dashboard card prop + gauges + alertas mentor + tempo medio trades (universal) | 1 sessao | CHUNK-02 + CHUNK-04 (leitura) — #93 deve liberar locks antes |
+| 4 | Payout tracking + qualifying days + simulador | 0.5 sessao | — |
 
 ### Decisoes arquiteturais (DEC-053 + discussao 05/04/2026)
 
@@ -109,12 +105,6 @@ O plano mostra de onde veio (`dataSource`) e alerta quando baseado em defaults: 
 | Drawdown usa `runTransaction` na CF | Trailing depende de read-then-write atomico do peakBalance. FieldValue.increment nao serve aqui |
 | Tempo medio de trades e metrica universal | Vai nos MetricsCards para todas as contas, nao so prop. No card prop mostra com contexto |
 | Eval deadline conta dias corridos | Apex conta corridos, nao dias de trading. UI deve ser explicita |
-| **`calculateAttackPlan` usa hard constraints absolutos (06/04)** | **roPerTrade NUNCA > dailyLossLimit. roPerTrade × maxTradesPerDay <= dailyLossLimit. metaDiaria × diasUteis >= profitTarget. Algoritmo original (% de drawdown) gerava planos impossiveis** |
-| **`instrumentsTable.js` como tabela curada hardcoded (06/04)** | **Path: `src/constants/instrumentsTable.js`. 23 instrumentos top com ATR + point value + micro variants. Helpers: `getInstrument`, `getSessionRange`, `isInstrumentAllowed`. Revisao trimestral pelo mentor. Nao em masterData (volume baixo, mudanca trimestral, schema rico). Fonte de verdade unica para volatilidade** |
-| **`restrictedInstruments` derivado dinamicamente (06/04)** | **Manter compatibilidade da UI atual (le `template.restrictedInstruments`), mas a fonte de verdade e `INSTRUMENTS_TABLE.availability[firm]`. Funcao helper expoe lista derivada para cada mesa** |
-| **Sonnet 4.6 para AI Approach Plan, NAO Gemini Flash (06/04)** | **DEC-054 (Gemini Flash para feedback semantico) nao se aplica. Justificativa: volume baixo (1 chamada/conta), stakes altas (dinheiro do trader), infra Claude ja existe (4 CFs), reasoning superior, custo aceitavel ate 500 alunos (~$24/mes). Nova DEC formal a registrar no PROJECT.md** |
-| **selectedInstrument inline em `account.propFirm` (06/04)** | **Atributo da instancia da conta. Faz parte do mesmo objeto `propFirm`. INV-15: aprovado verbalmente — campo do mesmo objeto ja aprovado, expansao natural** |
-| **Cap operacional max trades/dia (06/04)** | **8 conservador, 10 agressivo. Independente da formula matematica. Razao: dailyLoss/RO pode dar 21 trades, operacionalmente absurdo** |
 
 ## 2. ACCEPTANCE CRITERIA
 
@@ -250,151 +240,191 @@ Se encontrar conflito com shared file: documentar aqui e notificar Marcio.
 - Iniciar Fase 1 (templates + configuracao + plano de ataque)
 - Consultar body do issue GitHub (#52) para templates detalhados das mesas
 
-### Sessao — 05-06/04/2026 — Implementacao Fase 1 + Correcoes + Reescrita do calculator
+### Sessao — 09/04/2026 — Fase 2 passo 2.b + 2.d (CF + drawdownHistory)
 
-**Tipo:** codigo (worktree `~/projects/acomp-052`, branch `feature/issue-052-prop-firms`)
-**Baseado em:** PROJECT.md v0.9.0 (sessao iniciou nesse ponto; main avancou para v0.10.2 durante a sessao)
+**Tipo:** codigo (worktree `~/projects/acomp-052`)
+**Baseado em:** propFirmDrawdownEngine.js v1 (passo 2.a, 58 testes Vitest)
 
-**O que foi feito (Fase 1 — estrutura inicial):**
-- CHUNK-17 (Prop Firm Engine) registrado no PROJECT.md §6.3 com lock para #52
-- Worktree isolado criado: `git worktree add ~/projects/acomp-052 feature/issue-052-prop-firms` (INV-16)
-- `src/constants/propFirmDefaults.js` (NEW) — 23 templates: Apex EOD/Intraday 25K-300K (10), MFF Starter/Core/Scale 50K-150K (4), Lucid Pro/Flex 50K/100K (3), Tradeify Select 25K/50K/100K/150K (4) — 4 firms × multi-size
-- Constantes: PROP_FIRM_PHASES, DRAWDOWN_TYPES, FEE_MODELS, DAILY_LOSS_ACTIONS, ATTACK_PLAN_PROFILES, ATTACK_PLAN_DATA_SOURCES, EMPTY_TEMPLATE
-- `src/utils/attackPlanCalculator.js` (NEW) — primeira versao com cascata 4D → indicadores → defaults
-- `src/__tests__/utils/attackPlanCalculator.test.js` (NEW) — 34 testes iniciais
-- `src/hooks/usePropFirmTemplates.js` (NEW) — CRUD collection raiz com listener real-time, seedDefaults, deleteAllTemplates
-- `src/pages/PropFirmConfigPage.jsx` (NEW) — config mentor: seed, edit inline, delete, "Limpar Todos", agrupado por firma. DebugBadge (INV-04)
-- `src/hooks/useAccounts.js` — extensao addAccount/updateAccount com campo `propFirm` (templateId, firmName, productName, phase, peakBalance, currentDrawdownThreshold, suggestedPlan)
-- `src/components/AddAccountModal.jsx` — seletor firma → produto quando type=PROP, fallback para DEFAULT_TEMPLATES, auto-fill currency/balance/name, preview do plano de ataque
-- `src/pages/SettingsPage.jsx` — nova aba "Prop Firms"
-- `src/pages/AccountsPage.jsx` — DESCOBERTA: o modal de criacao de conta NAO usa AddAccountModal — tem form inline proprio. Adicionado seletor prop firm + propPlanDefaults + auto-abertura do PlanManagementModal para criar plano apos conta PROP
-- `firestore.rules` — rules para `propFirmTemplates` (mentor write, autenticado read) — DEPLOYED via `firebase deploy --only firestore:rules`
+**Escopo aprovado:** estender `functions/index.js` (`onTradeCreated`/`onTradeUpdated`/`onTradeDeleted`) com branch prop firm engine + `runTransaction` + write em `accounts/{id}/drawdownHistory`. Decisoes A/2/3/4/5 confirmadas pelo Marcio antes de codificar.
 
-**O que foi feito (5 correcoes de revisao identificadas pelo Marcio):**
+**O que foi feito:**
 
-1. **Currency BRL fixa no PlanManagementModal** — modal usava `formatCurrency` sem currency, default BRL. Conta Apex em USD mostrava R$ no plano. Fix: derivar `accountCurrency` da conta selecionada (ou `editingPlan.currency` quando snapshot stale). 7 chamadas `formatCurrency(value)` → `formatCurrency(value, accountCurrency)`. Simbolo dinamico US$/€/R$.
+1. **`functions/propFirmEngine.js`** (NEW) — copia CommonJS do `src/utils/propFirmDrawdownEngine.js`. Header de aviso "ESPELHO — manter sincronizado". Smoke test via `node -e` confirmou paridade com o engine ESM.
 
-2. **Defaults do plano genericos** — `propPlanDefaults` so passava accountId, name, pl, riskPerOperation, rrTarget. Fix: derivar `cycleGoalPct = profitTarget/pl`, `cycleStopPct = drawdownMax/pl`, `periodGoalPct = dailyTarget/pl`, `periodStopPct = dailyLossLimit/pl` (ou cycleStop/5). Inclui `currency`, `name`, `type`, todos os 13 campos do form de plano.
+2. **`functions/index.js`** — bump v1.9.0 → **v1.10.0**:
+   - CHANGELOG header atualizado
+   - VERSION constant: minor=10, patch=0, build=20260409
+   - `require('./propFirmEngine')` no topo (apos `db = admin.firestore()`)
+   - Helpers novos apos `updatePlanPl`:
+     - `recalculatePropFirmState(accountId, trade, tradeId)` — pre-check fora da tx (early return non-PROP), le template, runTransaction com re-read do propFirm + chamada engine + update dos campos runtime
+     - `appendDrawdownHistory(accountId, docId, trade, state)` — append-only snapshot
+     - `notifyPropFirmFlag(accountId, trade, state)` — throttle 1×/dia/flag via doc id deterministico `propfirm-{accountId}-{flag}-{date}`
+   - `onTradeCreated`: bloco 5 "PROP FIRM ENGINE" apos alerta emocional, isolado em try/catch
+   - `onTradeUpdated`: bloco "PROP FIRM RECALC" apos compliance recalc, antes do bloco emocional. Aplica `delta = newResult - oldResult` (LIMITACAO v1)
+   - `onTradeDeleted`: bloco "PROP FIRM RECALC" apos `updatePlanPl`. Aplica `-trade.result` (reversao). drawdownHistory permanece append-only (snapshot orfao intencional)
 
-3. **Sizing fixo sem contexto de instrumento** — calculator retornava `sizing: 1 contrato` arbitrario. Sem saber se NQ ($20/pt) ou MNQ ($2/pt) ou ES ($50/pt), o sizing nao tem significado. Fix: `sizing: null` no calculator, UI mostra "a definir conforme instrumento" no preview.
+3. **`firestore.rules`** — nova subcollection `accounts/{accountId}/drawdownHistory/{historyId}`: `read: isAuthenticated()`, `write: false` (apenas CF via admin SDK).
 
-4. **Edit modal nao rehydratava propFirm** — ao editar conta PROP existente, dropdowns firma/produto voltavam vazios mesmo com `propFirm.templateId` salvo no Firestore. Fix: `openModal(account)` agora seta `propFirmData` a partir de `account.propFirm` quando existe.
+**Schema novo em `account.propFirm` (expansao do objeto ja aprovado, INV-15):**
 
-5. **Max trades/dia 21 (operacionalmente absurdo)** — formula `dailyLoss/stopPerTrade` dava numeros irreais. Fix: cap operacional **8 conservador / 10 agressivo**, independente da formula. Mesmo se a math diz 21, o cap reduz para 8.
-
-**O que foi feito (reescrita critica do calculateAttackPlan — bug $1.150):**
-
-Identificado bug: o algoritmo original calculava `roPerTrade = drawdownMax × percentual` (ex: $2.500 × 4.6% = $115 USD), e quando convertido para `riskPerOperation` em % do PL ($25.000), ficava 4.6% = $1.150 — 2.3x o daily loss limit ($500). Um unico trade ruim estouraria o dia inteiro.
-
-**Causa raiz:** algoritmo tratava `drawdownMax` como input para % generico. ERRADO. As regras da mesa sao **HARD CONSTRAINTS absolutas**, nao inputs.
-
-**Reescrito com hard constraints (`calculateAttackPlan` v2):**
-```
-stopTotal = drawdownMax (constraint mesa)
-stopDiario = dailyLossLimit (constraint mesa)
-metaTotal = profitTarget (constraint mesa)
-metaDiaria = profitTarget / diasUteis (Math.ceil para garantir)
-roPerTrade = dailyLossLimit × fatorPerfil (NUNCA × drawdownMax)
-maxTrades = floor(dailyLossLimit / roPerTrade) com cap 8/10
-rrMinimum = 1.5 conservador, 2.0 agressivo
-stopPerTrade = roPerTrade / rrMinimum
-```
-
-**Constraints invioláveis validadas:**
-- roPerTrade NUNCA > dailyLossLimit ✓
-- stopPerTrade NUNCA > dailyLossLimit ✓
-- roPerTrade × maxTradesPerDay NUNCA > dailyLossLimit ✓
-- metaDiaria × diasUteis >= profitTarget ✓
-
-**Validacao manual Apex EOD 25K (DD $1.000, daily $500, target $1.500, eval 30 dias):**
-
-| Metrica | Conservador (defaults) | Agressivo (4D forte) |
+| Campo | Tipo | Descricao |
 |---|---|---|
-| RO/trade | $46 | $94 |
-| Stop/trade | $30 | $47 |
-| Max trades/dia | 8 (cap) | 5 |
-| RR minimo | 1.5:1 | 2.0:1 |
-| Meta diaria | $72 | $72 |
-| Dias uteis eval | 21 | 21 |
-| $46 × 8 = $368 ≤ $500 | ✓ | — |
-| $94 × 5 = $470 ≤ $500 | — | ✓ |
-| $72 × 21 = $1.512 ≥ $1.500 | ✓ | ✓ |
-| `constraintsViolated` | [] | [] |
+| `peakBalance` | number | maior saldo ja visto (ou snapshot EOD) |
+| `currentDrawdownThreshold` | number | nivel abaixo do qual a conta quebra |
+| `lockLevel` | number\|null | threshold congelado pos-lock (ou null) |
+| `isDayPaused` | boolean | daily loss limit atingido hoje |
+| `tradingDays` | number | dias com pelo menos 1 trade |
+| `dailyPnL` | number | P&L acumulado do dia (zera ao virar) |
+| `lastTradeDate` | string YYYY-MM-DD | usado pra detectar isNewDay |
+| `currentBalance` | number | saldo runtime mantido pelo engine |
+| `distanceToDD` | number 0..1 | margem proporcional ainda disponivel |
+| `flags` | string[] | snapshot atual de flags |
+| `lastUpdateTradeId` | string | ultimo tradeId que disparou recalc |
 
-**Bug do `availableCapital` no PlanManagementModal:**
-Modal mostrava "Disponivel: US$ 50.000" para conta de US$ 25.000. Causa raiz: `currentPlanPl + freePl` dobrava o saldo quando `editingPlan = propPlanDefaults`. O `currentPlanPl` foi feito para edicao real (devolver pl ocupado por plano existente), mas foi disparado errado para defaults pre-preenchidos. Fix: flag `__isDefaults: true` em propPlanDefaults; o modal pula a devolucao quando ve a flag.
+**Subcollection `accounts/{accountId}/drawdownHistory/{tradeId}`:**
 
-**Validacao critica do Marcio (06/04):**
-Apesar dos numeros do calculator estarem matematicamente corretos, sao **operacionalmente inuteis**. Stop $30 = 15 pontos no MNQ (com NQ a 24.230). ATR diario do NQ ~400 pontos. Stop de 15 pts e comido pela primeira vela. **O algoritmo determina valores em USD sem saber o instrumento — abstracao sem significado.**
+```js
+{
+  tradeId, date, balance, peakBalance, drawdownThreshold,
+  distanceToDD, dailyPnL, flags, lockLevel, createdAt
+}
+```
 
-**Conclusao:** Fase 1 entrega estrutura mas nao entrega valor real. Necessario:
-- **Fase 1.5**: tabela curada de instrumentos com ATR, point value, session profiles. Reescrever `calculateAttackPlan` para receber `instrument` como input e fazer math instrument-aware (back-calc: stop em pontos × valor do ponto = RO real).
-- **Fase 2.5**: Sonnet 4.6 como narrador (nao calculador). IA usa o math determinado da Fase 1.5 e gera narrativa estrategica + exemplos + tabela.
+Doc id = `tradeId` para idempotencia (re-execucao do trigger nao duplica). Para edits: doc id = `${tradeId}-edit-${Date.now()}`.
 
-**Discussao DEC-054 vs Sonnet 4.6 (06/04):**
-- DEC-054 (Gemini Flash para feedback semantico #31) NAO se aplica
-- Volume aqui e ~1 chamada/conta criada (raro) vs feedback que e 1 chamada/trade (alto volume)
-- Stakes diferentes: prop firm = dinheiro real do trader, requer reasoning superior
-- Custo Sonnet aceitavel ate 500 alunos (~$24/mes)
-- Infra Claude ja existe (4 CFs: classifyOpenResponse, generateProbingQuestions, analyzeProbingResponse, generateAssessmentReport) — secret ANTHROPIC_API_KEY ja configurado
+**Notificacoes `PROP_FIRM_FLAG`:**
+- `severity: CRITICAL` para `ACCOUNT_BUST`, `WARNING` para os demais
+- Idempotencia: doc id = `propfirm-{accountId}-{flag}-{date}` (1× por flag-tipo por dia)
+- Cobre: `ACCOUNT_BUST`, `DAILY_LOSS_HIT`, `DD_NEAR`, `LOCK_ACTIVATED`
+
+**Decisoes registradas (executadas conforme aprovacao do Marcio):**
+
+| ID | Decisao | Status |
+|----|---------|--------|
+| Engine sharing | Opcao A — duplicacao com header + DT-034 | ✅ Executado |
+| Schema novo | Campos runtime no propFirm (expansao INV-15) | ✅ Aprovado verbalmente |
+| Throttle | 1× por (flag-tipo, accountId, dia) | ✅ Executado |
+| onTradeDeleted | Snapshot append-only orfao | ✅ Executado |
+| Overhead account.get() | Aceito v1, monitorar | ✅ Aceito |
+
+**Limitacoes documentadas (v1):**
+- `onTradeUpdated` aplica DELTA incremental, NAO reconstrói historico do peakBalance
+- `onTradeDeleted` aplica reversao do delta, NAO remove snapshot do drawdownHistory
+- Trade editado muito antigo pode dessincronizar peakBalance — aceito (Marcio)
+- Pre-read `account.get()` em todos os trades — overhead ~50ms para non-PROP
+- DT-034 (NOVA): unificar engine prop firm via build step (rollup/esbuild) para eliminar a duplicacao
+
+**Validacao:**
+- `node --check functions/index.js` ✅
+- `node --check functions/propFirmEngine.js` ✅
+- Smoke test do engine CommonJS via `node -e` ✅ paridade com ESM
+- 963 testes Vitest passando (engine `src/utils/` inalterado) ✅
+- Build cliente limpo ✅
+
+**Arquivos tocados:**
+
+NOVOS:
+- `functions/propFirmEngine.js`
+
+EDITADOS:
+- `functions/index.js` (CHANGELOG, VERSION, helpers, onTradeCreated, onTradeUpdated, onTradeDeleted)
+- `firestore.rules` (subcollection drawdownHistory)
+- `docs/dev/issues/issue-052-prop-firms.md` (esta sessao)
+
+**Pendencias:**
+- Bump `src/version.js` (cliente) e `version` em `functions/package.json` se aplicavel
+- CHANGELOG do produto
+- DT-034 (NOVA) registrar em PROJECT.md
+- Deploy CFs: `firebase deploy --only functions:onTradeCreated,functions:onTradeUpdated,functions:onTradeDeleted` + `firebase deploy --only firestore:rules`
+- Validacao manual no browser apos deploy (criar trade em conta PROP, verificar campos runtime)
+- Fase 2.e (alerta mentor para flags) ja embutido neste passo via `notifyPropFirmFlag`
+- Fase 2.f (eval deadline countdown helper) — ja existe no engine puro como `calculateEvalDaysRemaining`/`isEvalDeadlineNear`. Pendente integracao com flag em algum lugar (provavelmente Fase 3 — UI)
+- Fase 3: card prop no StudentDashboard (depende de CHUNK-04 unlock)
+
+### Sessao — 09/04/2026 — Correcao critica de ATR (instrumentsTable v2)
+
+**Tipo:** correcao de bug critico (worktree `~/projects/acomp-052`)
+
+**Bug:** Fase 1.5 v1 da `instrumentsTable.js` tinha valores `avgDailyRange` ALUCINADOS — nao baseados em dados reais do TradingView. Impacto: viabilidade do plano de ataque calculada errada. Exemplo concreto: MES CONS_B Apex 25K com 30 pts → calculator dizia 90.9% do range NY (INVIAVEL), mas real e 40.6% (VIAVEL day trade).
+
+**Fonte de verdade:** `Temp/instruments-table-v2-atr-real.md` v2.0, captura TradingView ATR(14) diario em 09/04/2026.
+
+**O que foi feito:**
+
+1. **`src/constants/instrumentsTable.js`** — atualizado SOMENTE `avgDailyRange` (preserva availability, micros, types):
+
+| Símbolo | ATR v1 (alucinado) | ATR v2 (real) | Delta |
+|---|---|---|---|
+| ES | 55 | 123 | 2.24× |
+| NQ | 400 | 549 | 1.37× |
+| YM | 420 | 856 | 2.04× |
+| RTY | 30 | 70 | 2.33× |
+| CL | 2.5 | 9.11 | 3.64× |
+| GC | 40 | 180 | 4.50× |
+| SI | 0.60 | 5.69 | 9.48× |
+| 6B | 0.0110 | 0.0117 | 1.06× |
+| 6J | 0.00070 | 0.000046 | 0.066× (10× menor) |
+| ZC | 10 | 8.87 | 0.89× |
+| ZW | 15 | 17.75 | 1.18× |
+| ZS | 18 | 19.15 | 1.06× |
+| MBT | 4000 | 3201 | 0.80× |
+
+NG, HG, 6A: marcados como "ATR pendente de recaptura" — nao incluidos no v2, mantem valores v1.
+
+2. **`src/constants/propFirmDefaults.js`** — comentario do `NY_MIN_VIABLE_STOP_PCT` recalibrado: threshold 12.5% × NY range NQ (329.4) = ~41 pts (era 30 pts no calculo errado).
+
+3. **Testes recalculados — `attackPlanCalculator.test.js`:**
+   - "stop como % do range NY" — expected 240 → 329.4, stopNyPct 31.25 → 22.77
+   - "stop > 75% NY → INVIAVEL" — RTY 50K AGRES_B nao dispara mais (35.7%). Substituido por **M2K Apex 25K CONS_C**: 40 pts / 42 pts = 95.2% > 75% INVIAVEL ✓
+   - "AGRES_A NQ 50K — NY viavel" — 31.25/329.4 = 9.49% nao mais NY viavel. Substituido por **AGRES_B NQ 100K (DD $3000)**: 45 pts / 329.4 = 13.66% > 12.5% NY viavel ✓
+   - "threshold NY exato 12.5%" — recalculado: NQ DD $5490 CONS_B → RO $823.50 → 41.175 pts → 12.5% exato
+   - Comentarios de `NQ Apex 50K CONS_B/CONS_C` atualizados (5.69%/7.59% reais)
+   - **NOVO teste regressao**: `MES Apex 25K CONS_B com 30 pts é VIÁVEL na NY` (40.65% do range, nao 90.9%)
+
+4. **Testes recalculados — `instrumentsTable.test.js`:**
+   - `getSessionRange NQ NY` — 240 → 329.4
+   - `getSessionRange ES London` — 12.65 → 28.29
+   - `getRecommendedStop NQ` — 20pts/$400 → 27.45pts/$549 (atr passa a prevalecer)
+   - `getRecommendedStop MNQ` — $40 → $54.90
+   - `getRecommendedStop ES` — 4pts ($200, source min) → 6.15pts ($307.50, source atr)
+   - `getRecommendedStop YM` — 25pts ($125, source min) → 42.8pts ($214, source atr)
+   - Substituido teste "minStop prevalece" por **6E** (0.00045 × 5% < minStop 0.0008) — único caso onde minStop ainda ganha
+
+**Validacao chave:**
+- MES Apex 25K CONS_B: stop 30 pts, $150, 40.65% do range NY → ✅ VIAVEL day trade (era ❌ INVIAVEL)
+- MNQ Apex 25K CONS_B: stop 75 pts, 22.77% do range NY → ✅ VIAVEL NY (era 31.25% — mesma classificacao, valores diferentes)
+- NQ Apex 50K CONS_B: stop 18.75 pts, 5.69% do range NY → ⚠ session restricted (era 7.81% — mesma classificacao)
 
 **Decisoes tomadas:**
 
-| ID | Decisao | Justificativa |
-|----|---------|---------------|
-| — | calculateAttackPlan v2 com hard constraints | Original gerava roPerTrade > dailyLossLimit, impossivel |
-| — | Cap operacional 8/10 trades/dia | Math poderia dar 21, absurdo operacional |
-| — | RR conservador 1.5, agressivo 2.0 | Conservador prioriza acerto (RR menor mais facil), agressivo prioriza eficiencia |
-| — | sizing: null | Depende do instrumento, calculado depois |
-| — | Tabela curada de instrumentos em src/constants/instrumentsTable.js | Volume baixo, mudanca trimestral, schema rico, separacao de dominio |
-| — | restrictedInstruments derivado da tabela | Source of truth unica, compatibilidade com UI atual |
-| — | Sonnet 4.6 (nao Gemini) para approach plan IA | Volume baixo, stakes altas, infra ja existe, reasoning superior |
-| — | selectedInstrument inline em propFirm | Atributo da instancia, INV-15 expansao natural |
-| — | __isDefaults flag para propPlanDefaults | Pular currentPlanPl no PlanManagementModal |
+| Decisao | Justificativa |
+|---|---|
+| Atualizar SO `avgDailyRange`, nao tocar availability/micros/types | User explicitamente disse "Atualizar TODOS os avgDailyRange". Mudancas estruturais sao escopo separado |
+| Preservar GC `apex: false` (nota "suspenso Abr/2026") | v2 file mostra `apex: true` mas isso e sobre catalogo bruto. Nota de suspensao operacional permanece |
+| `getRecommendedStop` mantido como helper legado | Nao mais usado pelo calculator novo (5 perfis), mas testes ainda existem. Manter funcao + atualizar testes |
+| Threshold 12.5% generico mantido | Mesma logica da regra anterior do user, agora com numeros reais. Calibragem traduz para ~41 pts no NQ (era 30 com ATR errado) |
+| Adicionar teste de regressao MES Apex 25K | Caso pedagogico do user — garantir que o bug nao reaparece |
 
-**Arquivos tocados nesta sessao:**
-
-NOVOS:
-- `src/constants/propFirmDefaults.js`
-- `src/utils/attackPlanCalculator.js`
-- `src/__tests__/utils/attackPlanCalculator.test.js`
-- `src/hooks/usePropFirmTemplates.js`
-- `src/pages/PropFirmConfigPage.jsx`
+**Arquivos tocados:**
 
 EDITADOS:
-- `src/hooks/useAccounts.js`
-- `src/components/AddAccountModal.jsx`
-- `src/pages/SettingsPage.jsx`
-- `src/pages/AccountsPage.jsx`
-- `src/components/PlanManagementModal.jsx`
-- `firestore.rules` (rules para propFirmTemplates) — **DEPLOYED**
-- `package-lock.json` (npm install no worktree)
+- `src/constants/instrumentsTable.js` (16 valores avgDailyRange)
+- `src/constants/propFirmDefaults.js` (comentario calibragem)
+- `src/__tests__/utils/attackPlanCalculator.test.js` (4 testes corrigidos + 1 novo regressao)
+- `src/__tests__/utils/instrumentsTable.test.js` (6 testes recalculados)
 
 **Testes:**
-- 37 novos testes (`attackPlanCalculator.test.js`)
-- 844 testes totais passando — **zero regressao**
+- 905 testes totais passando (era 904 — +1 regressao MES)
 - Build: limpo
 
-**Pendencias para esta mesma sessao (Fase 1.5):**
-- Criar `src/constants/instrumentsTable.js` baseado em `Temp/instruments-table-prop-firms.md`
-- Criar testes dos helpers (`getInstrument`, `getSessionRange`, `isInstrumentAllowed`)
-- Substituir `restrictedInstruments` hardcoded em `propFirmDefaults.js` por derivacao dinamica
-- Reescrever `calculateAttackPlan` instrument-aware (recebe `instrumentVolatility`)
-- Adicionar campo `selectedInstrument` em `propFirm` (INV-15 verbal aprovado — expansao do mesmo objeto)
-- Adicionar UI de selecao de instrumento na criacao de conta PROP
-- Atualizar `propPlanDefaults` para usar stop instrument-aware
-- Atualizar PROJECT.md com nova DEC ("instrumentsTable curada") e bump v0.11.0
-
-**Pendencias para sessoes futuras:**
-- Fase 2: Engine de drawdown (4 tipos) + CFs runTransaction
-- Fase 2.5: CF `generatePropFirmApproachPlan` com Sonnet 4.6 + UX
-- Fase 3: Dashboard card prop (depende de CHUNK-04 unlock)
-- Fase 4: Payout tracking
-- Conta APEX antiga sem propFirm: deletar via Firebase Console (sem service account no worktree)
+**Pendencias:**
+- Re-medir ATR de NG, HG, 6A no TradingView (nao incluidos no v2)
+- Re-medir trimestralmente (recomendacao do user) ou quando VIX mudar significativamente
+- Bump version.js + CHANGELOG (aguardando direcao)
 
 ## 5. ENCERRAMENTO
 
-**Status:** 🟡 Em andamento — Fase 1 implementada, Fase 1.5 iniciada
+**Status:** Aguardando inicio de codificacao
 
 **Checklist final:**
 - [ ] Acceptance criteria atendidos

--- a/firestore.rules
+++ b/firestore.rules
@@ -88,10 +88,17 @@ service cloud.firestore {
       allow read: if isAuthenticated();
       allow create: if isAuthenticated();
       allow update, delete: if isAuthenticated() && (
-        isMentor() || 
+        isMentor() ||
         isOwner(resource.data.studentId) ||
         (resource.data.studentEmail != null && isOwnerByEmail(resource.data.studentEmail))
       );
+
+      // DRAWDOWN HISTORY (subcollection) — Prop Firm Engine #52 Fase 2
+      // Append-only audit log. Apenas CF (admin SDK) escreve. Aluno/mentor lêem.
+      match /drawdownHistory/{historyId} {
+        allow read: if isAuthenticated();
+        allow write: if false;
+      }
     }
 
     // MOVEMENTS — DEC-024: dados do aluno, aluno tem acesso total

--- a/firestore.rules
+++ b/firestore.rules
@@ -190,6 +190,14 @@ service cloud.firestore {
       allow delete: if false;
     }
 
+    // ========== Prop Firm Templates (CHUNK-17, issue #052) ==========
+    // Catálogo de templates de mesas proprietárias (collection raiz, INV-15 aprovado)
+    // Mentor configura, todos autenticados podem ler (aluno seleciona ao criar conta PROP)
+    match /propFirmTemplates/{templateId} {
+      allow read: if isAuthenticated();
+      allow write: if isMentor();
+    }
+
     // ========== Assessment — Student Onboarding (CHUNK-09) ==========
     // DEC-024: Aluno é autoridade sobre seus dados. auth != null.
     match /students/{studentId}/assessment/{docId} {

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,10 +1,19 @@
 /**
  * Firebase Cloud Functions - Tchio-Alpha
- * @version 1.9.0
- * 
+ * @version 1.10.0
+ *
  * SEMANTIC VERSIONING (SemVer 2.0.0)
  * MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
- * 
+ *
+ * CHANGELOG v1.10.0 (#52 Fase 2 — Prop Firm Drawdown Engine):
+ *   - Engine de drawdown integrado em onTradeCreated/onTradeUpdated/onTradeDeleted
+ *   - Novo helper recalculatePropFirmState com runTransaction (atomicidade peakBalance)
+ *   - Subcollection accounts/{id}/drawdownHistory append-only (1 doc por trade prop)
+ *   - Notificações PROP_FIRM_FLAG throttled 1× por flag-tipo por dia (idempotência via doc id)
+ *   - Idempotente: contas não-PROP têm early return e zero overhead funcional
+ *   - LIMITAÇÃO v1: trade editado/deletado usa delta incremental, NÃO reconstrói histórico
+ *   - Engine duplicado em functions/propFirmEngine.js (DT-034 — unificar via build step)
+ *
  * CHANGELOG v1.9.0 (alinhado com produto v1.19.2):
  *   - DEC-007: RR assumido integrado em calculateTradeCompliance para trades sem stop
  *     RR = result / (plan.pl × RO%). Usa plan.pl (capital base), não currentPl.
@@ -49,16 +58,21 @@ const admin = require('firebase-admin');
 admin.initializeApp();
 const db = admin.firestore();
 
+// === PROP FIRM ENGINE (Fase 2 #52) ===
+// Engine puro testado em src/__tests__/utils/propFirmDrawdownEngine.test.js (58 testes)
+// Espelhado em functions/propFirmEngine.js — DT-034: unificar via build step
+const propFirmEngine = require('./propFirmEngine');
+
 // ============================================
 // VERSÃO (SemVer 2.0.0)
 // ============================================
 
 const VERSION = {
   major: 1,
-  minor: 9,
+  minor: 10,
   patch: 0,
   prerelease: null,
-  build: '20260311',
+  build: '20260409',
   
   get full() {
     let v = `${this.major}.${this.minor}.${this.patch}`;
@@ -285,6 +299,142 @@ const updatePlanPl = async (planId, resultDiff) => {
       updatedAt: admin.firestore.FieldValue.serverTimestamp()
     });
   });
+};
+
+// ============================================
+// PROP FIRM HELPERS (#52 Fase 2)
+// ============================================
+
+/**
+ * Recalcula o estado runtime do prop firm da conta após um trade fechado.
+ * Idempotente para contas não-PROP (early return).
+ * Usa runTransaction para garantir atomicidade do peakBalance em escrita concorrente.
+ *
+ * Pré-condição: trade.result e trade.date precisam estar definidos.
+ * Pós-condição: account.propFirm.{peakBalance, threshold, lockLevel, isDayPaused,
+ *               tradingDays, dailyPnL, lastTradeDate, currentBalance, distanceToDD, flags}
+ *               atualizados; updatedAt bump.
+ *
+ * @param {string} accountId
+ * @param {Object} trade - documento do trade (precisa: result, date, accountId)
+ * @param {string} tradeId
+ * @returns {Promise<Object|null>} novo estado do engine ou null se não-PROP
+ */
+const recalculatePropFirmState = async (accountId, trade, tradeId) => {
+  if (!accountId || trade.result == null || !trade.date) return null;
+
+  const accountRef = db.collection('accounts').doc(accountId);
+
+  // Pre-read fora da transaction para evitar overhead em contas comuns
+  const preCheck = await accountRef.get();
+  if (!preCheck.exists) return null;
+  const accountData = preCheck.data();
+  if (accountData.type !== 'PROP' || !accountData.propFirm?.templateId) return null;
+
+  // Lê template (collection raiz)
+  const templateDoc = await db.collection('propFirmTemplates')
+    .doc(accountData.propFirm.templateId).get();
+  if (!templateDoc.exists) {
+    console.warn(`[propFirm] Template ${accountData.propFirm.templateId} não encontrado para conta ${accountId}`);
+    return null;
+  }
+  const template = templateDoc.data();
+  const accountSize = template.accountSize ?? accountData.initialBalance ?? 0;
+  if (accountSize <= 0) return null;
+
+  // Transaction: re-read propFirm dentro do tx (estado pode ter mudado entre pre-check e tx)
+  const newState = await db.runTransaction(async (t) => {
+    const fresh = await t.get(accountRef);
+    if (!fresh.exists) return null;
+    const propFirm = fresh.data().propFirm ?? {};
+    const balanceBefore = propFirm.currentBalance ?? accountSize;
+
+    const result = propFirmEngine.calculateDrawdownState({
+      propFirm,
+      template,
+      accountSize,
+      balanceBefore,
+      tradeNet: trade.result,
+      tradeDate: trade.date
+    });
+
+    t.update(accountRef, {
+      'propFirm.peakBalance': result.peakBalance,
+      'propFirm.currentDrawdownThreshold': result.currentDrawdownThreshold,
+      'propFirm.lockLevel': result.lockLevel,
+      'propFirm.isDayPaused': result.isDayPaused,
+      'propFirm.tradingDays': result.tradingDays,
+      'propFirm.dailyPnL': result.dailyPnL,
+      'propFirm.lastTradeDate': result.lastTradeDate,
+      'propFirm.currentBalance': result.newBalance,
+      'propFirm.distanceToDD': result.distanceToDD,
+      'propFirm.flags': result.flags,
+      'propFirm.lastUpdateTradeId': tradeId,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+
+    return result;
+  });
+
+  return newState;
+};
+
+/**
+ * Append snapshot em accounts/{accountId}/drawdownHistory após trade prop firm.
+ * Doc id = tradeId (idempotente — re-execução do trigger não duplica).
+ * Append-only audit log: trades deletados deixam snapshot orfão (intentional).
+ */
+const appendDrawdownHistory = async (accountId, docId, trade, state) => {
+  if (!state) return;
+  await db.collection('accounts').doc(accountId)
+    .collection('drawdownHistory').doc(docId)
+    .set({
+      tradeId: trade.id ?? docId,
+      date: trade.date,
+      balance: state.newBalance,
+      peakBalance: state.peakBalance,
+      drawdownThreshold: state.currentDrawdownThreshold,
+      distanceToDD: state.distanceToDD,
+      dailyPnL: state.dailyPnL,
+      flags: state.flags,
+      lockLevel: state.lockLevel,
+      createdAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+};
+
+/**
+ * Cria notificação para mentor sobre flag prop firm crítica.
+ * Throttled: cada (flag-tipo, accountId, dia) só notifica 1×.
+ * Idempotência via doc id determinístico.
+ */
+const notifyPropFirmFlag = async (accountId, trade, state) => {
+  if (!state || !state.flags || state.flags.length === 0) return;
+
+  const criticalFlags = state.flags.filter(f =>
+    f === 'ACCOUNT_BUST' || f === 'DAILY_LOSS_HIT' || f === 'DD_NEAR' || f === 'LOCK_ACTIVATED'
+  );
+  if (criticalFlags.length === 0) return;
+
+  for (const flag of criticalFlags) {
+    const notifId = `propfirm-${accountId}-${flag}-${trade.date}`;
+    const notifRef = db.collection('notifications').doc(notifId);
+    const exists = await notifRef.get();
+    if (exists.exists) continue;
+
+    await notifRef.set({
+      type: 'PROP_FIRM_FLAG',
+      flag,
+      severity: flag === 'ACCOUNT_BUST' ? 'CRITICAL' : 'WARNING',
+      targetRole: 'mentor',
+      studentId: trade.studentId,
+      studentEmail: trade.studentEmail,
+      accountId,
+      tradeId: trade.id ?? null,
+      message: `Prop firm: ${flag} (${trade.studentEmail?.split('@')[0]})`,
+      read: false,
+      createdAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+  }
 };
 
 /**
@@ -840,6 +990,20 @@ exports.onTradeCreated = functions.firestore
         }
       }
 
+      // === 5. PROP FIRM ENGINE (#52 Fase 2) ===
+      // Idempotente: early return em recalculatePropFirmState se conta não é PROP.
+      // Erro isolado em try/catch — não propaga para o pipeline existente.
+      try {
+        const propFirmState = await recalculatePropFirmState(trade.accountId, trade, tradeId);
+        if (propFirmState) {
+          await appendDrawdownHistory(trade.accountId, tradeId, { ...trade, id: tradeId }, propFirmState);
+          await notifyPropFirmFlag(trade.accountId, { ...trade, id: tradeId }, propFirmState);
+          console.log(`[onTradeCreated] PropFirm recalculado: balance=${propFirmState.newBalance}, threshold=${propFirmState.currentDrawdownThreshold}, flags=[${propFirmState.flags.join(',')}]`);
+        }
+      } catch (propErr) {
+        console.error('[onTradeCreated] Erro PropFirm engine:', propErr);
+      }
+
     } catch (e) { console.error('[onTradeCreated]', e); }
     
     return null;
@@ -919,6 +1083,34 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
       }
     }
 
+    // === PROP FIRM RECALC (#52 Fase 2) ===
+    // LIMITAÇÃO v1: aplica delta incremental (newResult - oldResult), NÃO reconstrói histórico.
+    // Trade editado muito antigo pode dessincronizar peakBalance. Aceito intencionalmente.
+    if ((resultChanged || planChanged) && after.accountId) {
+      try {
+        const incrementalNet = newResult - oldResult;
+        if (incrementalNet !== 0) {
+          const tradeForEngine = { ...after, result: incrementalNet };
+          const propFirmState = await recalculatePropFirmState(
+            after.accountId,
+            tradeForEngine,
+            context.params.tradeId
+          );
+          if (propFirmState) {
+            await appendDrawdownHistory(
+              after.accountId,
+              `${context.params.tradeId}-edit-${Date.now()}`,
+              { ...after, id: context.params.tradeId },
+              propFirmState
+            );
+            console.log(`[onTradeUpdated] PropFirm delta=${incrementalNet}, balance=${propFirmState.newBalance}, flags=[${propFirmState.flags.join(',')}]`);
+          }
+        }
+      } catch (propErr) {
+        console.error('[onTradeUpdated] Erro PropFirm engine:', propErr);
+      }
+    }
+
     // === B1 (v1.19.0): Re-check alerta emocional se emotionEntry mudou ===
     if (before.emotionEntry !== after.emotionEntry && after.emotionEntry) {
       try {
@@ -959,15 +1151,34 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
 
 exports.onTradeDeleted = functions.firestore.document('trades/{tradeId}').onDelete(async (snap, context) => {
   const trade = snap.data();
-  
+
   try {
     // Reverter PL do plano
     if (trade.planId && trade.result) {
       await updatePlanPl(trade.planId, -(trade.result));
       console.log(`[onTradeDeleted] PL plano ${trade.planId} revertido: ${-trade.result}`);
     }
+
+    // === PROP FIRM RECALC (#52 Fase 2) ===
+    // Aplica delta negativo (reverte o trade). drawdownHistory permanece append-only:
+    // o snapshot original NÃO é removido. Análises Phase 3 devem filtrar por tradeId existente.
+    if (trade.accountId && trade.result && trade.date) {
+      try {
+        const tradeForEngine = { ...trade, result: -trade.result };
+        const propFirmState = await recalculatePropFirmState(
+          trade.accountId,
+          tradeForEngine,
+          context.params.tradeId
+        );
+        if (propFirmState) {
+          console.log(`[onTradeDeleted] PropFirm reverso aplicado: balance=${propFirmState.newBalance}, flags=[${propFirmState.flags.join(',')}]`);
+        }
+      } catch (propErr) {
+        console.error('[onTradeDeleted] Erro PropFirm engine:', propErr);
+      }
+    }
   } catch (e) { console.error('[onTradeDeleted]', e); }
-  
+
   return null;
 });
 

--- a/functions/propFirmEngine.js
+++ b/functions/propFirmEngine.js
@@ -1,0 +1,209 @@
+// ============================================
+// PROP FIRM DRAWDOWN ENGINE — Cloud Functions copy
+// ============================================
+//
+// ⚠️ ESPELHO de src/utils/propFirmDrawdownEngine.js — MANTER SINCRONIZADO ⚠️
+//
+// Esta é uma cópia CommonJS do engine puro testado em src/utils/.
+// Cloud Functions não conseguem importar de ../src/ (separação de pacotes).
+//
+// Toda mudança na lógica DEVE ser propagada manualmente para os DOIS arquivos:
+//   1. src/utils/propFirmDrawdownEngine.js (testado por 58 testes Vitest)
+//   2. functions/propFirmEngine.js (este arquivo)
+//
+// Refactoring futuro: DT-034 — unificar via build step (rollup/esbuild) ou
+// monorepo workspace que permita import compartilhado.
+//
+// Ref: issue #52 Fase 2.b, decisão Opção A duplicação (sessão 09/04/2026)
+// ============================================
+
+// DRAWDOWN_TYPES inlined (evita import cross-package)
+const DRAWDOWN_TYPES = {
+  TRAILING_INTRADAY: 'TRAILING_INTRADAY',
+  TRAILING_EOD: 'TRAILING_EOD',
+  STATIC: 'STATIC',
+  TRAILING_WITH_LOCK: 'TRAILING_WITH_LOCK'
+};
+
+const DD_NEAR_THRESHOLD = 0.20;
+
+const DRAWDOWN_FLAGS = {
+  DAILY_LOSS_HIT: 'DAILY_LOSS_HIT',
+  ACCOUNT_BUST: 'ACCOUNT_BUST',
+  DD_NEAR: 'DD_NEAR',
+  LOCK_ACTIVATED: 'LOCK_ACTIVATED',
+  EVAL_DEADLINE_NEAR: 'EVAL_DEADLINE_NEAR'
+};
+
+function resolveLockAt(template, accountSize) {
+  const dd = template && template.drawdown;
+  if (!dd) return null;
+  if (typeof dd.lockAt === 'number') return dd.lockAt;
+  if (dd.lockFormula === 'BALANCE + DD + 100') {
+    return accountSize + (dd.maxAmount || 0) + 100;
+  }
+  return null;
+}
+
+function getPeakUpdateMode(type) {
+  if (type === DRAWDOWN_TYPES.STATIC) return 'never';
+  if (type === DRAWDOWN_TYPES.TRAILING_EOD) return 'eod';
+  return 'intraday';
+}
+
+function initializePropFirmState(template, accountSize) {
+  if (!template || !template.drawdown) {
+    throw new Error('template.drawdown é obrigatório');
+  }
+  const drawdownMax = template.drawdown.maxAmount || 0;
+  return {
+    peakBalance: accountSize,
+    currentDrawdownThreshold: accountSize - drawdownMax,
+    lockLevel: null,
+    isDayPaused: false,
+    tradingDays: 0,
+    dailyPnL: 0,
+    lastTradeDate: null
+  };
+}
+
+function calculateDrawdownState(args) {
+  const {
+    propFirm,
+    template,
+    accountSize,
+    balanceBefore,
+    tradeNet,
+    tradeDate
+  } = args;
+
+  if (!template || !template.drawdown) {
+    throw new Error('template.drawdown é obrigatório');
+  }
+  if (typeof accountSize !== 'number' || accountSize <= 0) {
+    throw new Error('accountSize deve ser número positivo');
+  }
+  if (typeof balanceBefore !== 'number') {
+    throw new Error('balanceBefore deve ser número');
+  }
+  if (typeof tradeNet !== 'number') {
+    throw new Error('tradeNet deve ser número');
+  }
+  if (!tradeDate || typeof tradeDate !== 'string') {
+    throw new Error('tradeDate (YYYY-MM-DD) é obrigatório');
+  }
+
+  const drawdownType = template.drawdown.type;
+  const drawdownMax = template.drawdown.maxAmount || 0;
+  const dailyLossLimit = template.dailyLossLimit || 0;
+  const peakMode = getPeakUpdateMode(drawdownType);
+
+  let peakBalance = (propFirm && propFirm.peakBalance != null) ? propFirm.peakBalance : accountSize;
+  let dailyPnL = (propFirm && propFirm.dailyPnL != null) ? propFirm.dailyPnL : 0;
+  let isDayPaused = (propFirm && propFirm.isDayPaused != null) ? propFirm.isDayPaused : false;
+  let tradingDays = (propFirm && propFirm.tradingDays != null) ? propFirm.tradingDays : 0;
+  let lockLevel = (propFirm && propFirm.lockLevel != null) ? propFirm.lockLevel : null;
+  const previousLockLevel = lockLevel;
+  const lastTradeDate = (propFirm && propFirm.lastTradeDate) ? propFirm.lastTradeDate : null;
+
+  const isNewDay = lastTradeDate !== tradeDate;
+
+  if (isNewDay) {
+    if (peakMode === 'eod' && lockLevel === null && lastTradeDate !== null) {
+      peakBalance = Math.max(peakBalance, balanceBefore);
+    }
+    dailyPnL = 0;
+    isDayPaused = false;
+    tradingDays += 1;
+  }
+
+  const newBalance = round(balanceBefore + tradeNet, 2);
+  dailyPnL = round(dailyPnL + tradeNet, 2);
+
+  if (peakMode === 'intraday' && lockLevel === null) {
+    peakBalance = Math.max(peakBalance, newBalance);
+  }
+
+  const lockAt = resolveLockAt(template, accountSize);
+  if (lockAt !== null && lockLevel === null && peakBalance >= lockAt) {
+    lockLevel = accountSize;
+  }
+
+  let currentDrawdownThreshold;
+  if (drawdownType === DRAWDOWN_TYPES.STATIC) {
+    currentDrawdownThreshold = accountSize - drawdownMax;
+  } else if (lockLevel !== null) {
+    currentDrawdownThreshold = lockLevel;
+  } else {
+    currentDrawdownThreshold = peakBalance - drawdownMax;
+  }
+
+  if (dailyLossLimit > 0 && dailyPnL <= -dailyLossLimit) {
+    isDayPaused = true;
+  }
+
+  const distanceToDD = drawdownMax > 0
+    ? round((newBalance - currentDrawdownThreshold) / drawdownMax, 4)
+    : 1;
+
+  const flags = [];
+  if (isDayPaused) flags.push(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+  if (newBalance <= currentDrawdownThreshold) flags.push(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  if (distanceToDD < DD_NEAR_THRESHOLD && distanceToDD > 0) flags.push(DRAWDOWN_FLAGS.DD_NEAR);
+  if (lockLevel !== null && previousLockLevel === null) flags.push(DRAWDOWN_FLAGS.LOCK_ACTIVATED);
+
+  return {
+    peakBalance: round(peakBalance, 2),
+    currentDrawdownThreshold: round(currentDrawdownThreshold, 2),
+    lockLevel: lockLevel !== null ? round(lockLevel, 2) : null,
+    isDayPaused,
+    tradingDays,
+    dailyPnL,
+    lastTradeDate: tradeDate,
+    newBalance,
+    distanceToDD,
+    flags,
+    isNewDay
+  };
+}
+
+function calculateEvalDaysRemaining(phaseStartDate, evalTimeLimit, now) {
+  if (!phaseStartDate || typeof evalTimeLimit !== 'number' || evalTimeLimit <= 0) {
+    return null;
+  }
+  const start = phaseStartDate instanceof Date
+    ? phaseStartDate
+    : new Date(phaseStartDate);
+  if (isNaN(start.getTime())) return null;
+
+  const reference = now || new Date();
+  const deadline = new Date(start);
+  deadline.setDate(deadline.getDate() + evalTimeLimit);
+
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const remaining = Math.ceil((deadline.getTime() - reference.getTime()) / msPerDay);
+  return Math.max(0, remaining);
+}
+
+function isEvalDeadlineNear(daysRemaining, threshold) {
+  const t = threshold || 7;
+  if (daysRemaining === null || daysRemaining === undefined) return false;
+  return daysRemaining > 0 && daysRemaining <= t;
+}
+
+function round(value, decimals) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}
+
+module.exports = {
+  DRAWDOWN_TYPES,
+  DRAWDOWN_FLAGS,
+  DD_NEAR_THRESHOLD,
+  resolveLockAt,
+  getPeakUpdateMode,
+  initializePropFirmState,
+  calculateDrawdownState,
+  calculateEvalDaysRemaining,
+  isEvalDeadlineNear
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,9 +2095,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2112,9 +2109,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2129,9 +2123,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2146,9 +2137,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2163,9 +2151,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2180,9 +2165,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2197,9 +2179,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2214,9 +2193,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2231,9 +2207,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2248,9 +2221,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2265,9 +2235,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2282,9 +2249,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2299,9 +2263,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/__tests__/utils/attackPlanCalculator.test.js
+++ b/src/__tests__/utils/attackPlanCalculator.test.js
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest';
+import { calculateAttackPlan, resolveDataSource } from '../../utils/attackPlanCalculator';
+
+// --- Template de referência: Apex EOD 50K ---
+const APEX_EOD_50K = {
+  firm: 'APEX',
+  accountSize: 50000,
+  drawdown: { type: 'TRAILING_EOD', maxAmount: 2500, lockAt: null },
+  dailyLossLimit: 1000,
+  profitTarget: 3000,
+  evalTimeLimit: 30,
+  evalMinTradingDays: 0,
+  contracts: { max: 10 }
+};
+
+// --- Template sem daily loss: Apex Intraday 50K ---
+const APEX_INTRADAY_50K = {
+  ...APEX_EOD_50K,
+  drawdown: { type: 'TRAILING_INTRADAY', maxAmount: 2500 },
+  dailyLossLimit: null
+};
+
+// --- Perfis 4D completos ---
+const PROFILE_4D_STRONG = {
+  emotionalScore: 80,
+  stage: 4,
+  coefficientOfVariation: 0.3
+};
+
+const PROFILE_4D_WEAK = {
+  emotionalScore: 30,
+  stage: 1,
+  coefficientOfVariation: 1.2
+};
+
+const PROFILE_4D_MID = {
+  emotionalScore: 50,
+  stage: 3,
+  coefficientOfVariation: 0.5
+};
+
+// --- Indicadores sem 4D ---
+const INDICATORS_GOOD = {
+  winRate: 0.6,
+  coefficientOfVariation: 0.4
+};
+
+const INDICATORS_POOR = {
+  winRate: 0.35,
+  coefficientOfVariation: 1.5
+};
+
+// ============================================
+// resolveDataSource
+// ============================================
+describe('resolveDataSource', () => {
+  it('usa 4D completo quando disponível', () => {
+    const result = resolveDataSource(PROFILE_4D_STRONG, INDICATORS_GOOD, 'conservative');
+    expect(result.dataSource).toBe('4d_full');
+    expect(result.adjustmentFactor).toBeGreaterThan(0);
+    expect(result.adjustmentFactor).toBeLessThanOrEqual(1);
+  });
+
+  it('calcula adjustmentFactor correto com 4D completo', () => {
+    // emotional: 80/100 = 0.8, maturity: 4/5 = 0.8, consistency: 1-0.3 = 0.7
+    // factor = 0.8*0.4 + 0.8*0.3 + 0.7*0.3 = 0.32 + 0.24 + 0.21 = 0.77
+    const result = resolveDataSource(PROFILE_4D_STRONG, null, 'conservative');
+    expect(result.adjustmentFactor).toBeCloseTo(0.77, 2);
+  });
+
+  it('usa indicadores quando 4D não disponível', () => {
+    const result = resolveDataSource(null, INDICATORS_GOOD, 'conservative');
+    expect(result.dataSource).toBe('indicators');
+  });
+
+  it('calcula adjustmentFactor com indicadores (emotional default 0.5)', () => {
+    // emotional: 0.5 (default), maturity proxy: WR 0.6, consistency: 1-0.4 = 0.6
+    // factor = 0.5*0.4 + 0.6*0.3 + 0.6*0.3 = 0.20 + 0.18 + 0.18 = 0.56
+    const result = resolveDataSource(null, INDICATORS_GOOD, 'conservative');
+    expect(result.adjustmentFactor).toBeCloseTo(0.56, 2);
+  });
+
+  it('usa defaults quando nada disponível', () => {
+    const result = resolveDataSource(null, null, 'conservative');
+    expect(result.dataSource).toBe('defaults');
+    expect(result.adjustmentFactor).toBe(0.3);
+  });
+
+  it('usa default agressivo quando perfil é aggressive', () => {
+    const result = resolveDataSource(null, null, 'aggressive');
+    expect(result.dataSource).toBe('defaults');
+    expect(result.adjustmentFactor).toBe(0.6);
+  });
+
+  it('prioriza 4D sobre indicadores quando ambos presentes', () => {
+    const result = resolveDataSource(PROFILE_4D_STRONG, INDICATORS_GOOD, 'conservative');
+    expect(result.dataSource).toBe('4d_full');
+  });
+
+  it('clamp adjustmentFactor a 0 quando CV muito alto', () => {
+    const extremeProfile = { emotionalScore: 0, stage: 1, coefficientOfVariation: 5.0 };
+    const result = resolveDataSource(extremeProfile, null, 'conservative');
+    expect(result.adjustmentFactor).toBeGreaterThanOrEqual(0);
+  });
+
+  it('clamp adjustmentFactor a 1 quando tudo máximo', () => {
+    const maxProfile = { emotionalScore: 100, stage: 5, coefficientOfVariation: 0 };
+    const result = resolveDataSource(maxProfile, null, 'conservative');
+    expect(result.adjustmentFactor).toBeLessThanOrEqual(1);
+    expect(result.adjustmentFactor).toBeCloseTo(1.0, 2);
+  });
+
+  it('ignora 4D incompleto (sem stage)', () => {
+    const incomplete = { emotionalScore: 80, coefficientOfVariation: 0.3 };
+    const result = resolveDataSource(incomplete, INDICATORS_GOOD, 'conservative');
+    expect(result.dataSource).toBe('indicators');
+  });
+
+  it('ignora indicadores incompletos (sem CV)', () => {
+    const incomplete = { winRate: 0.6 };
+    const result = resolveDataSource(null, incomplete, 'conservative');
+    expect(result.dataSource).toBe('defaults');
+  });
+});
+
+// ============================================
+// calculateAttackPlan — cenários básicos
+// ============================================
+describe('calculateAttackPlan', () => {
+  it('retorna todos os campos esperados', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
+    expect(plan).toHaveProperty('profile', 'conservative');
+    expect(plan).toHaveProperty('dataSource');
+    expect(plan).toHaveProperty('adjustmentFactor');
+    expect(plan).toHaveProperty('roFactor');
+    expect(plan).toHaveProperty('drawdownMax');
+    expect(plan).toHaveProperty('dailyLossLimit');
+    expect(plan).toHaveProperty('profitTarget');
+    expect(plan).toHaveProperty('roPerTrade');
+    expect(plan).toHaveProperty('stopPerTrade');
+    expect(plan).toHaveProperty('rrMinimum');
+    expect(plan).toHaveProperty('maxTradesPerDay');
+    expect(plan).toHaveProperty('dailyTarget');
+    expect(plan).toHaveProperty('evalBusinessDays');
+    expect(plan).toHaveProperty('daysToTarget');
+    expect(plan).toHaveProperty('bufferDays');
+    expect(plan).toHaveProperty('sizing');
+    expect(plan).toHaveProperty('constraintsViolated');
+    expect(plan).toHaveProperty('generatedAt');
+  });
+
+  it('NUNCA viola hard constraints da mesa', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
+    expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
+    expect(plan.stopPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
+    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(plan.dailyLossLimit);
+    expect(plan.dailyTarget * plan.evalBusinessDays).toBeGreaterThanOrEqual(plan.profitTarget);
+    expect(plan.constraintsViolated).toEqual([]);
+  });
+
+  it('Apex EOD 25K conservador defaults — valores operacionais corretos', () => {
+    const APEX_EOD_25K = {
+      ...APEX_EOD_50K,
+      accountSize: 25000,
+      drawdown: { type: 'TRAILING_EOD', maxAmount: 1000 },
+      dailyLossLimit: 500,
+      profitTarget: 1500,
+      contracts: { max: 4 }
+    };
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
+    // RO entre 8-12% de $500 com adjustment 0.3 → ~9.2% → ~$46
+    expect(plan.roPerTrade).toBeGreaterThanOrEqual(40);
+    expect(plan.roPerTrade).toBeLessThanOrEqual(60);
+    expect(plan.maxTradesPerDay).toBe(8); // cap conservador
+    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(500);
+    expect(plan.constraintsViolated).toEqual([]);
+  });
+
+  it('lança erro se templateRules ausente', () => {
+    expect(() => calculateAttackPlan(null, null, null, 'conservative', 'EVALUATION'))
+      .toThrow('templateRules é obrigatório');
+  });
+
+  it('usa conservative como default para profile inválido', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'invalid', 'EVALUATION');
+    expect(plan.profile).toBe('conservative');
+  });
+
+  it('usa EVALUATION como default para phase inválida', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'INVALID');
+    expect(plan.daysToTarget).toBeGreaterThan(0);
+  });
+});
+
+// ============================================
+// calculateAttackPlan — conservador vs agressivo
+// ============================================
+describe('calculateAttackPlan — perfis', () => {
+  it('agressivo tem RO por trade maior que conservador', () => {
+    const conservative = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION');
+    const aggressive = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'aggressive', 'EVALUATION');
+    expect(aggressive.roPerTrade).toBeGreaterThan(conservative.roPerTrade);
+  });
+
+  it('conservador tem RR mínimo 1.5, agressivo 2.0', () => {
+    const conservative = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
+    const aggressive = calculateAttackPlan(APEX_EOD_50K, null, null, 'aggressive', 'EVALUATION');
+    expect(conservative.rrMinimum).toBe(1.5);
+    expect(aggressive.rrMinimum).toBe(2.0);
+  });
+
+  it('sizing é null (depende do instrumento, calculado depois)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_STRONG, null, 'conservative', 'EVALUATION');
+    expect(plan.sizing).toBeNull();
+  });
+});
+
+// ============================================
+// calculateAttackPlan — stages 1-5 com 4D
+// ============================================
+describe('calculateAttackPlan — progressão por stage', () => {
+  const stages = [1, 2, 3, 4, 5];
+
+  it('adjustmentFactor cresce com stage (emotional e CV fixos)', () => {
+    const factors = stages.map(stage => {
+      const profile = { emotionalScore: 50, stage, coefficientOfVariation: 0.5 };
+      const plan = calculateAttackPlan(APEX_EOD_50K, profile, null, 'conservative', 'EVALUATION');
+      return plan.adjustmentFactor;
+    });
+
+    for (let i = 1; i < factors.length; i++) {
+      expect(factors[i]).toBeGreaterThan(factors[i - 1]);
+    }
+  });
+
+  it('roPerTrade cresce com stage', () => {
+    const ros = stages.map(stage => {
+      const profile = { emotionalScore: 50, stage, coefficientOfVariation: 0.5 };
+      return calculateAttackPlan(APEX_EOD_50K, profile, null, 'conservative', 'EVALUATION').roPerTrade;
+    });
+
+    for (let i = 1; i < ros.length; i++) {
+      expect(ros[i]).toBeGreaterThan(ros[i - 1]);
+    }
+  });
+});
+
+// ============================================
+// calculateAttackPlan — daily loss limit
+// ============================================
+describe('calculateAttackPlan — daily loss limit', () => {
+  it('maxTradesPerDay limitado pelo cap operacional (8 conservador, 10 agressivo)', () => {
+    const conservative = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
+    const aggressive = calculateAttackPlan(APEX_EOD_50K, null, null, 'aggressive', 'EVALUATION');
+    expect(conservative.maxTradesPerDay).toBeGreaterThanOrEqual(1);
+    expect(conservative.maxTradesPerDay).toBeLessThanOrEqual(8);
+    expect(aggressive.maxTradesPerDay).toBeLessThanOrEqual(10);
+  });
+
+  it('sem daily loss limit usa 40% do drawdown como referência', () => {
+    const plan = calculateAttackPlan(APEX_INTRADAY_50K, null, null, 'conservative', 'EVALUATION');
+    expect(plan.maxTradesPerDay).toBeGreaterThanOrEqual(1);
+  });
+
+  it('maxTradesPerDay nunca é zero', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION');
+    expect(plan.maxTradesPerDay).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ============================================
+// calculateAttackPlan — fases
+// ============================================
+describe('calculateAttackPlan — fases', () => {
+  it('dailyTarget é estável independente da fase (calculado por profitTarget/dias úteis)', () => {
+    // Hard constraint: dailyTarget × evalBusinessDays >= profitTarget
+    const eval_ = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION');
+    expect(eval_.dailyTarget * eval_.evalBusinessDays).toBeGreaterThanOrEqual(eval_.profitTarget);
+  });
+
+  it('bufferDays não é negativo', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION');
+    expect(plan.bufferDays).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ============================================
+// calculateAttackPlan — cascata de dados
+// ============================================
+describe('calculateAttackPlan — cascata de dados', () => {
+  it('com 4D completo, dataSource é 4d_full', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_STRONG, INDICATORS_GOOD, 'conservative', 'EVALUATION');
+    expect(plan.dataSource).toBe('4d_full');
+  });
+
+  it('sem 4D mas com indicadores, dataSource é indicators', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, INDICATORS_GOOD, 'conservative', 'EVALUATION');
+    expect(plan.dataSource).toBe('indicators');
+  });
+
+  it('sem nada, dataSource é defaults', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
+    expect(plan.dataSource).toBe('defaults');
+  });
+
+  it('aluno forte (4D) gera plano mais agressivo que aluno fraco', () => {
+    const strong = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_STRONG, null, 'conservative', 'EVALUATION');
+    const weak = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION');
+    expect(strong.roPerTrade).toBeGreaterThan(weak.roPerTrade);
+    expect(strong.adjustmentFactor).toBeGreaterThan(weak.adjustmentFactor);
+  });
+});
+
+// ============================================
+// calculateAttackPlan — edge cases
+// ============================================
+describe('calculateAttackPlan — edge cases', () => {
+  it('template com drawdown 0 e dailyLossLimit definido — usa dailyLossLimit como base', () => {
+    const template = { ...APEX_EOD_50K, drawdown: { type: 'STATIC', maxAmount: 0 } };
+    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
+    // Daily loss = 1000 do APEX_EOD_50K, RO = ~9.2% = ~$92
+    expect(plan.roPerTrade).toBeGreaterThan(0);
+    expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
+    expect(plan.constraintsViolated).toEqual([]);
+  });
+
+  it('template sem drawdown nem dailyLossLimit — fallback seguro', () => {
+    const template = {
+      ...APEX_EOD_50K,
+      drawdown: { type: 'STATIC', maxAmount: 0 },
+      dailyLossLimit: null
+    };
+    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
+    // dailyLossLimit fallback = drawdown × 0.25 = 0, mas roPerTrade tem mínimo de 1
+    expect(plan.roPerTrade).toBeGreaterThanOrEqual(1);
+  });
+
+  it('template com profitTarget 0 gera dailyTarget 0', () => {
+    const template = { ...APEX_EOD_50K, profitTarget: 0 };
+    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
+    expect(plan.dailyTarget).toBe(0);
+  });
+
+  it('template sem evalTimeLimit usa 30 como default', () => {
+    const template = { ...APEX_EOD_50K, evalTimeLimit: null };
+    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
+    expect(plan.daysToTarget).toBeGreaterThan(0);
+    expect(plan.daysToTarget).toBeLessThanOrEqual(30);
+  });
+
+  it('sizing é sempre null (independente do perfil)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION');
+    expect(plan.sizing).toBeNull();
+  });
+
+  it('todos os valores numéricos são finitos', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'aggressive', 'EVALUATION');
+    expect(Number.isFinite(plan.roPerTrade)).toBe(true);
+    expect(Number.isFinite(plan.stopPerTrade)).toBe(true);
+    expect(Number.isFinite(plan.dailyTarget)).toBe(true);
+    expect(Number.isFinite(plan.adjustmentFactor)).toBe(true);
+    expect(Number.isFinite(plan.maxTradesPerDay)).toBe(true);
+  });
+});

--- a/src/__tests__/utils/attackPlanCalculator.test.js
+++ b/src/__tests__/utils/attackPlanCalculator.test.js
@@ -1,7 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { calculateAttackPlan, resolveDataSource } from '../../utils/attackPlanCalculator';
+import {
+  calculateAttackPlan,
+  calculateMesaConstraints,
+  resolveDataSource
+} from '../../utils/attackPlanCalculator';
 
-// --- Template de referência: Apex EOD 50K ---
+// --- Templates de referência ---
+const APEX_EOD_25K = {
+  firm: 'APEX',
+  accountSize: 25000,
+  drawdown: { type: 'TRAILING_EOD', maxAmount: 1000, lockAt: null },
+  dailyLossLimit: 500,
+  profitTarget: 1500,
+  evalTimeLimit: 30,
+  contracts: { max: 4 }
+};
+
 const APEX_EOD_50K = {
   firm: 'APEX',
   accountSize: 50000,
@@ -9,75 +23,42 @@ const APEX_EOD_50K = {
   dailyLossLimit: 1000,
   profitTarget: 3000,
   evalTimeLimit: 30,
-  evalMinTradingDays: 0,
   contracts: { max: 10 }
 };
 
-// --- Template sem daily loss: Apex Intraday 50K ---
 const APEX_INTRADAY_50K = {
   ...APEX_EOD_50K,
   drawdown: { type: 'TRAILING_INTRADAY', maxAmount: 2500 },
   dailyLossLimit: null
 };
 
-// --- Perfis 4D completos ---
-const PROFILE_4D_STRONG = {
-  emotionalScore: 80,
-  stage: 4,
-  coefficientOfVariation: 0.3
-};
+// --- Perfis 4D ---
+const PROFILE_4D_STRONG = { emotionalScore: 80, stage: 4, coefficientOfVariation: 0.3 };
+const PROFILE_4D_WEAK = { emotionalScore: 30, stage: 1, coefficientOfVariation: 1.2 };
+const PROFILE_4D_MID = { emotionalScore: 50, stage: 3, coefficientOfVariation: 0.5 };
 
-const PROFILE_4D_WEAK = {
-  emotionalScore: 30,
-  stage: 1,
-  coefficientOfVariation: 1.2
-};
-
-const PROFILE_4D_MID = {
-  emotionalScore: 50,
-  stage: 3,
-  coefficientOfVariation: 0.5
-};
-
-// --- Indicadores sem 4D ---
-const INDICATORS_GOOD = {
-  winRate: 0.6,
-  coefficientOfVariation: 0.4
-};
-
-const INDICATORS_POOR = {
-  winRate: 0.35,
-  coefficientOfVariation: 1.5
-};
+const INDICATORS_GOOD = { winRate: 0.6, coefficientOfVariation: 0.4 };
+const INDICATORS_POOR = { winRate: 0.35, coefficientOfVariation: 1.5 };
 
 // ============================================
-// resolveDataSource
+// resolveDataSource (inalterado)
 // ============================================
 describe('resolveDataSource', () => {
   it('usa 4D completo quando disponível', () => {
     const result = resolveDataSource(PROFILE_4D_STRONG, INDICATORS_GOOD, 'conservative');
     expect(result.dataSource).toBe('4d_full');
-    expect(result.adjustmentFactor).toBeGreaterThan(0);
-    expect(result.adjustmentFactor).toBeLessThanOrEqual(1);
   });
 
   it('calcula adjustmentFactor correto com 4D completo', () => {
-    // emotional: 80/100 = 0.8, maturity: 4/5 = 0.8, consistency: 1-0.3 = 0.7
-    // factor = 0.8*0.4 + 0.8*0.3 + 0.7*0.3 = 0.32 + 0.24 + 0.21 = 0.77
+    // emotional 0.8, maturity 0.8, consistency 0.7
+    // factor = 0.8*0.4 + 0.8*0.3 + 0.7*0.3 = 0.77
     const result = resolveDataSource(PROFILE_4D_STRONG, null, 'conservative');
     expect(result.adjustmentFactor).toBeCloseTo(0.77, 2);
   });
 
-  it('usa indicadores quando 4D não disponível', () => {
+  it('usa indicadores quando 4D ausente', () => {
     const result = resolveDataSource(null, INDICATORS_GOOD, 'conservative');
     expect(result.dataSource).toBe('indicators');
-  });
-
-  it('calcula adjustmentFactor com indicadores (emotional default 0.5)', () => {
-    // emotional: 0.5 (default), maturity proxy: WR 0.6, consistency: 1-0.4 = 0.6
-    // factor = 0.5*0.4 + 0.6*0.3 + 0.6*0.3 = 0.20 + 0.18 + 0.18 = 0.56
-    const result = resolveDataSource(null, INDICATORS_GOOD, 'conservative');
-    expect(result.adjustmentFactor).toBeCloseTo(0.56, 2);
   });
 
   it('usa defaults quando nada disponível', () => {
@@ -86,279 +67,315 @@ describe('resolveDataSource', () => {
     expect(result.adjustmentFactor).toBe(0.3);
   });
 
-  it('usa default agressivo quando perfil é aggressive', () => {
+  it('default agressivo é 0.6', () => {
     const result = resolveDataSource(null, null, 'aggressive');
-    expect(result.dataSource).toBe('defaults');
     expect(result.adjustmentFactor).toBe(0.6);
   });
 
-  it('prioriza 4D sobre indicadores quando ambos presentes', () => {
-    const result = resolveDataSource(PROFILE_4D_STRONG, INDICATORS_GOOD, 'conservative');
-    expect(result.dataSource).toBe('4d_full');
-  });
+  it('clamp 0..1', () => {
+    const extreme = { emotionalScore: 0, stage: 1, coefficientOfVariation: 5.0 };
+    expect(resolveDataSource(extreme, null, 'conservative').adjustmentFactor).toBeGreaterThanOrEqual(0);
 
-  it('clamp adjustmentFactor a 0 quando CV muito alto', () => {
-    const extremeProfile = { emotionalScore: 0, stage: 1, coefficientOfVariation: 5.0 };
-    const result = resolveDataSource(extremeProfile, null, 'conservative');
-    expect(result.adjustmentFactor).toBeGreaterThanOrEqual(0);
-  });
-
-  it('clamp adjustmentFactor a 1 quando tudo máximo', () => {
-    const maxProfile = { emotionalScore: 100, stage: 5, coefficientOfVariation: 0 };
-    const result = resolveDataSource(maxProfile, null, 'conservative');
-    expect(result.adjustmentFactor).toBeLessThanOrEqual(1);
-    expect(result.adjustmentFactor).toBeCloseTo(1.0, 2);
-  });
-
-  it('ignora 4D incompleto (sem stage)', () => {
-    const incomplete = { emotionalScore: 80, coefficientOfVariation: 0.3 };
-    const result = resolveDataSource(incomplete, INDICATORS_GOOD, 'conservative');
-    expect(result.dataSource).toBe('indicators');
-  });
-
-  it('ignora indicadores incompletos (sem CV)', () => {
-    const incomplete = { winRate: 0.6 };
-    const result = resolveDataSource(null, incomplete, 'conservative');
-    expect(result.dataSource).toBe('defaults');
+    const max = { emotionalScore: 100, stage: 5, coefficientOfVariation: 0 };
+    expect(resolveDataSource(max, null, 'conservative').adjustmentFactor).toBeLessThanOrEqual(1);
   });
 });
 
 // ============================================
-// calculateAttackPlan — cenários básicos
+// calculateMesaConstraints
 // ============================================
-describe('calculateAttackPlan', () => {
-  it('retorna todos os campos esperados', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
-    expect(plan).toHaveProperty('profile', 'conservative');
-    expect(plan).toHaveProperty('dataSource');
-    expect(plan).toHaveProperty('adjustmentFactor');
-    expect(plan).toHaveProperty('roFactor');
-    expect(plan).toHaveProperty('drawdownMax');
-    expect(plan).toHaveProperty('dailyLossLimit');
-    expect(plan).toHaveProperty('profitTarget');
-    expect(plan).toHaveProperty('roPerTrade');
-    expect(plan).toHaveProperty('stopPerTrade');
-    expect(plan).toHaveProperty('rrMinimum');
-    expect(plan).toHaveProperty('maxTradesPerDay');
-    expect(plan).toHaveProperty('dailyTarget');
-    expect(plan).toHaveProperty('evalBusinessDays');
-    expect(plan).toHaveProperty('daysToTarget');
-    expect(plan).toHaveProperty('bufferDays');
-    expect(plan).toHaveProperty('sizing');
-    expect(plan).toHaveProperty('constraintsViolated');
-    expect(plan).toHaveProperty('generatedAt');
+describe('calculateMesaConstraints', () => {
+  it('retorna constraints absolutas da mesa', () => {
+    const c = calculateMesaConstraints(APEX_EOD_25K);
+    expect(c.drawdownMax).toBe(1000);
+    expect(c.dailyLossLimit).toBe(500);
+    expect(c.profitTarget).toBe(1500);
+    expect(c.evalTimeLimit).toBe(30);
+    expect(c.evalBusinessDays).toBe(21); // 30 × 5/7 = 21.4 → floor 21
+    expect(c.dailyTarget).toBe(72); // ceil(1500/21) = 72
   });
 
-  it('NUNCA viola hard constraints da mesa', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
-    expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
-    expect(plan.stopPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
-    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(plan.dailyLossLimit);
-    expect(plan.dailyTarget * plan.evalBusinessDays).toBeGreaterThanOrEqual(plan.profitTarget);
-    expect(plan.constraintsViolated).toEqual([]);
+  it('dailyTarget × evalBusinessDays >= profitTarget', () => {
+    const c = calculateMesaConstraints(APEX_EOD_25K);
+    expect(c.dailyTarget * c.evalBusinessDays).toBeGreaterThanOrEqual(c.profitTarget);
   });
 
-  it('Apex EOD 25K conservador defaults — valores operacionais corretos', () => {
-    const APEX_EOD_25K = {
-      ...APEX_EOD_50K,
-      accountSize: 25000,
-      drawdown: { type: 'TRAILING_EOD', maxAmount: 1000 },
-      dailyLossLimit: 500,
-      profitTarget: 1500,
-      contracts: { max: 4 }
-    };
+  it('usa proxy 25% do drawdown quando dailyLossLimit ausente', () => {
+    const c = calculateMesaConstraints(APEX_INTRADAY_50K);
+    expect(c.dailyLossLimit).toBe(625); // 2500 × 0.25
+  });
+
+  it('lança erro sem template', () => {
+    expect(() => calculateMesaConstraints(null)).toThrow();
+  });
+});
+
+// ============================================
+// calculateAttackPlan — modo abstract (sem instrumento)
+// ============================================
+describe('calculateAttackPlan — modo abstract', () => {
+  it('sem instrumento retorna mode=abstract com constraints da mesa', () => {
     const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
-    // RO entre 8-12% de $500 com adjustment 0.3 → ~9.2% → ~$46
-    expect(plan.roPerTrade).toBeGreaterThanOrEqual(40);
-    expect(plan.roPerTrade).toBeLessThanOrEqual(60);
-    expect(plan.maxTradesPerDay).toBe(8); // cap conservador
-    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(500);
-    expect(plan.constraintsViolated).toEqual([]);
+    expect(plan.mode).toBe('abstract');
+    expect(plan.drawdownMax).toBe(1000);
+    expect(plan.dailyLossLimit).toBe(500);
+    expect(plan.profitTarget).toBe(1500);
+    expect(plan.dailyTarget).toBe(72);
+    expect(plan.evalBusinessDays).toBe(21);
   });
 
-  it('lança erro se templateRules ausente', () => {
-    expect(() => calculateAttackPlan(null, null, null, 'conservative', 'EVALUATION'))
-      .toThrow('templateRules é obrigatório');
-  });
-
-  it('usa conservative como default para profile inválido', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'invalid', 'EVALUATION');
-    expect(plan.profile).toBe('conservative');
-  });
-
-  it('usa EVALUATION como default para phase inválida', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'INVALID');
-    expect(plan.daysToTarget).toBeGreaterThan(0);
-  });
-});
-
-// ============================================
-// calculateAttackPlan — conservador vs agressivo
-// ============================================
-describe('calculateAttackPlan — perfis', () => {
-  it('agressivo tem RO por trade maior que conservador', () => {
-    const conservative = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION');
-    const aggressive = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'aggressive', 'EVALUATION');
-    expect(aggressive.roPerTrade).toBeGreaterThan(conservative.roPerTrade);
-  });
-
-  it('conservador tem RR mínimo 1.5, agressivo 2.0', () => {
-    const conservative = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
-    const aggressive = calculateAttackPlan(APEX_EOD_50K, null, null, 'aggressive', 'EVALUATION');
-    expect(conservative.rrMinimum).toBe(1.5);
-    expect(aggressive.rrMinimum).toBe(2.0);
-  });
-
-  it('sizing é null (depende do instrumento, calculado depois)', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_STRONG, null, 'conservative', 'EVALUATION');
+  it('modo abstract não tem campos de execução', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
+    expect(plan.instrument).toBeNull();
+    expect(plan.stopPoints).toBeNull();
+    expect(plan.stopPerTrade).toBeNull();
+    expect(plan.roPerTrade).toBeNull();
+    expect(plan.maxTradesPerDay).toBeNull();
     expect(plan.sizing).toBeNull();
   });
-});
 
-// ============================================
-// calculateAttackPlan — stages 1-5 com 4D
-// ============================================
-describe('calculateAttackPlan — progressão por stage', () => {
-  const stages = [1, 2, 3, 4, 5];
-
-  it('adjustmentFactor cresce com stage (emotional e CV fixos)', () => {
-    const factors = stages.map(stage => {
-      const profile = { emotionalScore: 50, stage, coefficientOfVariation: 0.5 };
-      const plan = calculateAttackPlan(APEX_EOD_50K, profile, null, 'conservative', 'EVALUATION');
-      return plan.adjustmentFactor;
-    });
-
-    for (let i = 1; i < factors.length; i++) {
-      expect(factors[i]).toBeGreaterThan(factors[i - 1]);
-    }
+  it('modo abstract tem mensagem informativa', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
+    expect(plan.message).toContain('instrumento');
   });
 
-  it('roPerTrade cresce com stage', () => {
-    const ros = stages.map(stage => {
-      const profile = { emotionalScore: 50, stage, coefficientOfVariation: 0.5 };
-      return calculateAttackPlan(APEX_EOD_50K, profile, null, 'conservative', 'EVALUATION').roPerTrade;
-    });
-
-    for (let i = 1; i < ros.length; i++) {
-      expect(ros[i]).toBeGreaterThan(ros[i - 1]);
-    }
-  });
-});
-
-// ============================================
-// calculateAttackPlan — daily loss limit
-// ============================================
-describe('calculateAttackPlan — daily loss limit', () => {
-  it('maxTradesPerDay limitado pelo cap operacional (8 conservador, 10 agressivo)', () => {
-    const conservative = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
-    const aggressive = calculateAttackPlan(APEX_EOD_50K, null, null, 'aggressive', 'EVALUATION');
-    expect(conservative.maxTradesPerDay).toBeGreaterThanOrEqual(1);
-    expect(conservative.maxTradesPerDay).toBeLessThanOrEqual(8);
-    expect(aggressive.maxTradesPerDay).toBeLessThanOrEqual(10);
-  });
-
-  it('sem daily loss limit usa 40% do drawdown como referência', () => {
-    const plan = calculateAttackPlan(APEX_INTRADAY_50K, null, null, 'conservative', 'EVALUATION');
-    expect(plan.maxTradesPerDay).toBeGreaterThanOrEqual(1);
-  });
-
-  it('maxTradesPerDay nunca é zero', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION');
-    expect(plan.maxTradesPerDay).toBeGreaterThanOrEqual(1);
-  });
-});
-
-// ============================================
-// calculateAttackPlan — fases
-// ============================================
-describe('calculateAttackPlan — fases', () => {
-  it('dailyTarget é estável independente da fase (calculado por profitTarget/dias úteis)', () => {
-    // Hard constraint: dailyTarget × evalBusinessDays >= profitTarget
-    const eval_ = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION');
-    expect(eval_.dailyTarget * eval_.evalBusinessDays).toBeGreaterThanOrEqual(eval_.profitTarget);
-  });
-
-  it('bufferDays não é negativo', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION');
-    expect(plan.bufferDays).toBeGreaterThanOrEqual(0);
-  });
-});
-
-// ============================================
-// calculateAttackPlan — cascata de dados
-// ============================================
-describe('calculateAttackPlan — cascata de dados', () => {
-  it('com 4D completo, dataSource é 4d_full', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_STRONG, INDICATORS_GOOD, 'conservative', 'EVALUATION');
+  it('modo abstract preserva profile, dataSource, rrMinimum', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_STRONG, null, 'aggressive', 'EVALUATION');
+    expect(plan.profile).toBe('aggressive');
     expect(plan.dataSource).toBe('4d_full');
+    expect(plan.rrMinimum).toBe(2.0);
   });
 
-  it('sem 4D mas com indicadores, dataSource é indicators', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, INDICATORS_GOOD, 'conservative', 'EVALUATION');
-    expect(plan.dataSource).toBe('indicators');
-  });
-
-  it('sem nada, dataSource é defaults', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION');
-    expect(plan.dataSource).toBe('defaults');
-  });
-
-  it('aluno forte (4D) gera plano mais agressivo que aluno fraco', () => {
-    const strong = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_STRONG, null, 'conservative', 'EVALUATION');
-    const weak = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION');
-    expect(strong.roPerTrade).toBeGreaterThan(weak.roPerTrade);
-    expect(strong.adjustmentFactor).toBeGreaterThan(weak.adjustmentFactor);
+  it('modo abstract não viola constraints', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
+    expect(plan.constraintsViolated).toEqual([]);
   });
 });
 
 // ============================================
-// calculateAttackPlan — edge cases
+// calculateAttackPlan — modo execution com instrumento
 // ============================================
-describe('calculateAttackPlan — edge cases', () => {
-  it('template com drawdown 0 e dailyLossLimit definido — usa dailyLossLimit como base', () => {
-    const template = { ...APEX_EOD_50K, drawdown: { type: 'STATIC', maxAmount: 0 } };
-    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
-    // Daily loss = 1000 do APEX_EOD_50K, RO = ~9.2% = ~$92
-    expect(plan.roPerTrade).toBeGreaterThan(0);
+describe('calculateAttackPlan — modo execution', () => {
+  it('com MNQ retorna mode=execution com sizing 1', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    expect(plan.mode).toBe('execution');
+    expect(plan.sizing).toBe(1);
+    expect(plan.instrument.symbol).toBe('MNQ');
+    expect(plan.instrument.isMicro).toBe(true);
+    expect(plan.instrument.pointValue).toBe(2);
+  });
+
+  it('MNQ stop natural: 20 pts × $2 = $40', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    expect(plan.stopPoints).toBe(20);
+    expect(plan.stopPerTrade).toBe(40);
+  });
+
+  it('MNQ Apex 25K conservador — valores operacionalmente sensatos', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    // stop $40, RO ~$44-48 (overhead +10% × ajuste por adjustment)
+    expect(plan.roPerTrade).toBeGreaterThanOrEqual(44);
+    expect(plan.roPerTrade).toBeLessThanOrEqual(60);
+    // RO < daily loss
+    expect(plan.roPerTrade).toBeLessThan(500);
+    // max trades cabe no daily loss
+    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(500);
+    // cap operacional
+    expect(plan.maxTradesPerDay).toBeLessThanOrEqual(8);
+    expect(plan.constraintsViolated).toEqual([]);
+    expect(plan.incompatible).toBe(false);
+  });
+
+  it('NQ (full) na Apex 25K — INCOMPATÍVEL (1 trade $400 ~ daily loss $500)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'NQ');
+    // stop NQ = 20 pts × $20 = $400, RO com overhead ~$440-480 = quase todo daily loss
+    // mas ainda < $500, então NÃO incompatível tecnicamente, max trades = 1
+    // Vamos validar:
+    expect(plan.mode).toBe('execution');
+    if (plan.incompatible) {
+      // Se incompatível, deve sugerir MNQ
+      expect(plan.microSuggestion).toBe('MNQ');
+    } else {
+      // Se não incompatível, max trades é muito baixo (1)
+      expect(plan.maxTradesPerDay).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('ES Apex 50K conservador — viável, RO razoável', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION', 'ES');
+    // ES stop 4 pts × $50 = $200, RO ~$220-240
+    expect(plan.stopPerTrade).toBe(200);
     expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
     expect(plan.constraintsViolated).toEqual([]);
   });
 
-  it('template sem drawdown nem dailyLossLimit — fallback seguro', () => {
-    const template = {
-      ...APEX_EOD_50K,
-      drawdown: { type: 'STATIC', maxAmount: 0 },
-      dailyLossLimit: null
-    };
-    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
-    // dailyLossLimit fallback = drawdown × 0.25 = 0, mas roPerTrade tem mínimo de 1
-    expect(plan.roPerTrade).toBeGreaterThanOrEqual(1);
+  it('GC na Apex — não permitido (suspenso)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION', 'GC');
+    expect(plan.mode).toBe('execution');
+    // Deve ter constraint violation por instrumento não permitido
+    const hasNotAllowed = plan.constraintsViolated.some(v => v.includes('não permitido') || v.includes('apex'));
+    expect(hasNotAllowed).toBe(true);
   });
 
-  it('template com profitTarget 0 gera dailyTarget 0', () => {
-    const template = { ...APEX_EOD_50K, profitTarget: 0 };
-    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
-    expect(plan.dailyTarget).toBe(0);
+  it('instrumento desconhecido retorna mode=error', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'XYZ');
+    expect(plan.mode).toBe('error');
+    expect(plan.error).toContain('XYZ');
+    expect(plan.constraintsViolated).toContain('instrument_not_found');
+  });
+});
+
+// ============================================
+// calculateAttackPlan — perfis com instrumento
+// ============================================
+describe('calculateAttackPlan — perfis (execution)', () => {
+  it('agressivo tem RO maior que conservador (overhead maior)', () => {
+    const cons = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION', 'MNQ');
+    const agg = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_MID, null, 'aggressive', 'EVALUATION', 'MNQ');
+    expect(agg.roPerTrade).toBeGreaterThanOrEqual(cons.roPerTrade);
   });
 
-  it('template sem evalTimeLimit usa 30 como default', () => {
-    const template = { ...APEX_EOD_50K, evalTimeLimit: null };
-    const plan = calculateAttackPlan(template, null, null, 'conservative', 'EVALUATION');
-    expect(plan.daysToTarget).toBeGreaterThan(0);
-    expect(plan.daysToTarget).toBeLessThanOrEqual(30);
+  it('conservador rrMinimum 1.5, agressivo 2.0', () => {
+    const cons = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    const agg = calculateAttackPlan(APEX_EOD_25K, null, null, 'aggressive', 'EVALUATION', 'MNQ');
+    expect(cons.rrMinimum).toBe(1.5);
+    expect(agg.rrMinimum).toBe(2.0);
   });
 
-  it('sizing é sempre null (independente do perfil)', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION');
-    expect(plan.sizing).toBeNull();
+  it('targetPerTrade = stopPerTrade × rrMinimum', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    expect(plan.targetPerTrade).toBeCloseTo(plan.stopPerTrade * plan.rrMinimum, 2);
   });
 
-  it('todos os valores numéricos são finitos', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, PROFILE_4D_MID, null, 'aggressive', 'EVALUATION');
-    expect(Number.isFinite(plan.roPerTrade)).toBe(true);
-    expect(Number.isFinite(plan.stopPerTrade)).toBe(true);
-    expect(Number.isFinite(plan.dailyTarget)).toBe(true);
-    expect(Number.isFinite(plan.adjustmentFactor)).toBe(true);
-    expect(Number.isFinite(plan.maxTradesPerDay)).toBe(true);
+  it('aluno fraco recebe RO com mais overhead', () => {
+    const strong = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_STRONG, null, 'conservative', 'EVALUATION', 'MNQ');
+    const weak = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION', 'MNQ');
+    // Stop é o mesmo (depende do instrumento), mas RO do weak tem overhead maior
+    expect(weak.roPerTrade).toBeGreaterThanOrEqual(strong.roPerTrade);
+  });
+});
+
+// ============================================
+// calculateAttackPlan — hard constraints
+// ============================================
+describe('calculateAttackPlan — hard constraints invioláveis', () => {
+  const fixtures = [
+    { name: 'Apex 25K conservador MNQ', t: APEX_EOD_25K, profile: 'conservative', sym: 'MNQ' },
+    { name: 'Apex 25K agressivo MNQ', t: APEX_EOD_25K, profile: 'aggressive', sym: 'MNQ' },
+    { name: 'Apex 50K conservador MNQ', t: APEX_EOD_50K, profile: 'conservative', sym: 'MNQ' },
+    { name: 'Apex 50K conservador ES', t: APEX_EOD_50K, profile: 'conservative', sym: 'ES' },
+    { name: 'Apex 50K agressivo MES', t: APEX_EOD_50K, profile: 'aggressive', sym: 'MES' }
+  ];
+
+  for (const fx of fixtures) {
+    it(`${fx.name} — todas as 4 constraints respeitadas`, () => {
+      const plan = calculateAttackPlan(fx.t, null, null, fx.profile, 'EVALUATION', fx.sym);
+      if (plan.incompatible) return; // skip se incompatível (já é safety)
+
+      // C1: roPerTrade <= dailyLossLimit
+      expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
+      // C2: stopPerTrade <= dailyLossLimit
+      expect(plan.stopPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
+      // C3: roPerTrade × maxTradesPerDay <= dailyLossLimit
+      expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(plan.dailyLossLimit);
+      // C4: dailyTarget × evalBusinessDays >= profitTarget
+      expect(plan.dailyTarget * plan.evalBusinessDays).toBeGreaterThanOrEqual(plan.profitTarget);
+      // Sem violations registradas
+      expect(plan.constraintsViolated).toEqual([]);
+    });
+  }
+});
+
+// ============================================
+// calculateAttackPlan — cap operacional
+// ============================================
+describe('calculateAttackPlan — cap max trades', () => {
+  it('conservador cap 8', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    if (!plan.incompatible) {
+      expect(plan.maxTradesPerDay).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it('agressivo cap 10', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'aggressive', 'EVALUATION', 'MNQ');
+    if (!plan.incompatible) {
+      expect(plan.maxTradesPerDay).toBeLessThanOrEqual(10);
+    }
+  });
+});
+
+// ============================================
+// calculateAttackPlan — incompatibilidade e sugestão de micro
+// ============================================
+describe('calculateAttackPlan — incompatibilidade', () => {
+  it('quando incompatível, maxTrades=0 e sizing=0', () => {
+    // Forçar instrumento muito caro para mesa pequena
+    // CL stop 0.20 pts × $1000 = $200, RO ~$220 — viável em 25K? daily $500 = sim
+    // Vamos forçar com algo caro: MBT (Bitcoin) tem stop 200 × $0.10 = $20 — viável
+    // GC stop 3 × $100 = $300, RO ~$330 — em 25K daily $500: viável mas só 1 trade
+    // SI stop 0.05 × $5000 = $250, RO ~$275 — viável também
+    // Vamos usar template menor: dailyLoss $100 hipotético
+    const tinyTemplate = { ...APEX_EOD_25K, dailyLossLimit: 100 };
+    const plan = calculateAttackPlan(tinyTemplate, null, null, 'conservative', 'EVALUATION', 'NQ');
+    expect(plan.incompatible).toBe(true);
+    expect(plan.maxTradesPerDay).toBe(0);
+    expect(plan.sizing).toBe(0);
+    // Sugere MNQ
+    expect(plan.microSuggestion).toBe('MNQ');
+  });
+
+  it('micro variant não tem sugestão de outro micro', () => {
+    const tinyTemplate = { ...APEX_EOD_25K, dailyLossLimit: 1 };
+    const plan = calculateAttackPlan(tinyTemplate, null, null, 'conservative', 'EVALUATION', 'MNQ');
+    if (plan.incompatible) {
+      // MNQ já é micro, não deve sugerir nada
+      expect(plan.microSuggestion).toBeNull();
+    }
+  });
+});
+
+// ============================================
+// calculateAttackPlan — sanidade Apex EOD 25K MNQ conservador
+// ============================================
+describe('VALIDAÇÃO OPERACIONAL — Apex EOD 25K MNQ conservador', () => {
+  it('valores fazem sentido operacional', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+
+    // Estrutura básica
+    expect(plan.mode).toBe('execution');
+    expect(plan.instrument.symbol).toBe('MNQ');
+    expect(plan.instrument.isMicro).toBe(true);
+
+    // Constraints da mesa
+    expect(plan.dailyLossLimit).toBe(500);
+    expect(plan.profitTarget).toBe(1500);
+
+    // Stop natural NQ/MNQ = 20 pts (max(ATR 400 × 5%, minStop 20))
+    expect(plan.stopPoints).toBe(20);
+    expect(plan.stopPerTrade).toBe(40); // 20 × $2
+
+    // RO com overhead — entre $44 e $60 (depende do adjustment)
+    expect(plan.roPerTrade).toBeGreaterThanOrEqual(44);
+    expect(plan.roPerTrade).toBeLessThanOrEqual(60);
+
+    // RR conservador = 1.5
+    expect(plan.rrMinimum).toBe(1.5);
+    expect(plan.targetPerTrade).toBe(60); // 40 × 1.5
+
+    // Max trades: cap 8 ou floor(500/RO)
+    // RO ~$48 → floor(500/48) = 10 → cap 8
+    expect(plan.maxTradesPerDay).toBe(8);
+
+    // Constraint cabe: 48 × 8 = 384 ≤ 500 ✓
+    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(500);
+
+    // Meta diária $72, dias úteis 21
+    expect(plan.dailyTarget).toBe(72);
+    expect(plan.evalBusinessDays).toBe(21);
+
+    // Constraints violadas: zero
+    expect(plan.constraintsViolated).toEqual([]);
+    expect(plan.incompatible).toBe(false);
   });
 });

--- a/src/__tests__/utils/attackPlanCalculator.test.js
+++ b/src/__tests__/utils/attackPlanCalculator.test.js
@@ -4,6 +4,7 @@ import {
   calculateMesaConstraints,
   resolveDataSource
 } from '../../utils/attackPlanCalculator';
+import { normalizeAttackProfile } from '../../constants/propFirmDefaults';
 
 // --- Templates de referência ---
 const APEX_EOD_25K = {
@@ -38,10 +39,34 @@ const PROFILE_4D_WEAK = { emotionalScore: 30, stage: 1, coefficientOfVariation: 
 const PROFILE_4D_MID = { emotionalScore: 50, stage: 3, coefficientOfVariation: 0.5 };
 
 const INDICATORS_GOOD = { winRate: 0.6, coefficientOfVariation: 0.4 };
-const INDICATORS_POOR = { winRate: 0.35, coefficientOfVariation: 1.5 };
+const INDICATORS_POOR = { winRate: 0.30, coefficientOfVariation: 1.5 };
 
 // ============================================
-// resolveDataSource (inalterado)
+// normalizeAttackProfile — legacy compat
+// ============================================
+describe('normalizeAttackProfile', () => {
+  it('aceita os 5 novos códigos', () => {
+    expect(normalizeAttackProfile('CONS_A')).toBe('CONS_A');
+    expect(normalizeAttackProfile('CONS_B')).toBe('CONS_B');
+    expect(normalizeAttackProfile('CONS_C')).toBe('CONS_C');
+    expect(normalizeAttackProfile('AGRES_A')).toBe('AGRES_A');
+    expect(normalizeAttackProfile('AGRES_B')).toBe('AGRES_B');
+  });
+
+  it('mapeia legados conservative → CONS_B, aggressive → AGRES_A', () => {
+    expect(normalizeAttackProfile('conservative')).toBe('CONS_B');
+    expect(normalizeAttackProfile('aggressive')).toBe('AGRES_A');
+  });
+
+  it('default CONS_B quando ausente ou desconhecido', () => {
+    expect(normalizeAttackProfile(null)).toBe('CONS_B');
+    expect(normalizeAttackProfile(undefined)).toBe('CONS_B');
+    expect(normalizeAttackProfile('xyz')).toBe('CONS_B');
+  });
+});
+
+// ============================================
+// resolveDataSource
 // ============================================
 describe('resolveDataSource', () => {
   it('usa 4D completo quando disponível', () => {
@@ -49,27 +74,23 @@ describe('resolveDataSource', () => {
     expect(result.dataSource).toBe('4d_full');
   });
 
-  it('calcula adjustmentFactor correto com 4D completo', () => {
-    // emotional 0.8, maturity 0.8, consistency 0.7
-    // factor = 0.8*0.4 + 0.8*0.3 + 0.7*0.3 = 0.77
-    const result = resolveDataSource(PROFILE_4D_STRONG, null, 'conservative');
-    expect(result.adjustmentFactor).toBeCloseTo(0.77, 2);
-  });
-
   it('usa indicadores quando 4D ausente', () => {
     const result = resolveDataSource(null, INDICATORS_GOOD, 'conservative');
     expect(result.dataSource).toBe('indicators');
+    expect(result.assumedWR).toBe(0.6);
   });
 
   it('usa defaults quando nada disponível', () => {
     const result = resolveDataSource(null, null, 'conservative');
     expect(result.dataSource).toBe('defaults');
     expect(result.adjustmentFactor).toBe(0.3);
+    expect(result.assumedWR).toBe(0.5);
   });
 
-  it('default agressivo é 0.6', () => {
+  it('default agressivo é 0.6 e WR 0.5', () => {
     const result = resolveDataSource(null, null, 'aggressive');
     expect(result.adjustmentFactor).toBe(0.6);
+    expect(result.assumedWR).toBe(0.5);
   });
 
   it('clamp 0..1', () => {
@@ -90,19 +111,13 @@ describe('calculateMesaConstraints', () => {
     expect(c.drawdownMax).toBe(1000);
     expect(c.dailyLossLimit).toBe(500);
     expect(c.profitTarget).toBe(1500);
-    expect(c.evalTimeLimit).toBe(30);
-    expect(c.evalBusinessDays).toBe(21); // 30 × 5/7 = 21.4 → floor 21
+    expect(c.evalBusinessDays).toBe(21);
     expect(c.dailyTarget).toBe(72); // ceil(1500/21) = 72
-  });
-
-  it('dailyTarget × evalBusinessDays >= profitTarget', () => {
-    const c = calculateMesaConstraints(APEX_EOD_25K);
-    expect(c.dailyTarget * c.evalBusinessDays).toBeGreaterThanOrEqual(c.profitTarget);
   });
 
   it('usa proxy 25% do drawdown quando dailyLossLimit ausente', () => {
     const c = calculateMesaConstraints(APEX_INTRADAY_50K);
-    expect(c.dailyLossLimit).toBe(625); // 2500 × 0.25
+    expect(c.dailyLossLimit).toBe(625);
   });
 
   it('lança erro sem template', () => {
@@ -111,239 +126,380 @@ describe('calculateMesaConstraints', () => {
 });
 
 // ============================================
-// calculateAttackPlan — modo abstract (sem instrumento)
+// calculateAttackPlan — modo abstract
 // ============================================
 describe('calculateAttackPlan — modo abstract', () => {
-  it('sem instrumento retorna mode=abstract com constraints da mesa', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
+  it('CONS_B Apex 25K — RO = 15% do DD = $150', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION');
     expect(plan.mode).toBe('abstract');
-    expect(plan.drawdownMax).toBe(1000);
-    expect(plan.dailyLossLimit).toBe(500);
-    expect(plan.profitTarget).toBe(1500);
-    expect(plan.dailyTarget).toBe(72);
-    expect(plan.evalBusinessDays).toBe(21);
+    expect(plan.profile).toBe('CONS_B');
+    expect(plan.profileFamily).toBe('conservative');
+    expect(plan.profileRecommended).toBe(true);
+    expect(plan.roPerTrade).toBe(150);
+    expect(plan.roPct).toBe(0.15);
+    expect(plan.rrMinimum).toBe(2);
+    expect(plan.maxTradesPerDay).toBe(2);
+    expect(plan.winUSD).toBe(300); // 150 × 2
+    expect(plan.lossesToBust).toBe(6); // floor(1000/150)
   });
 
-  it('modo abstract não tem campos de execução', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
+  it('CONS_A — RO 10% = $100, lossesToBust 10', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_A', 'EVALUATION');
+    expect(plan.roPerTrade).toBe(100);
+    expect(plan.lossesToBust).toBe(10);
+    expect(plan.maxTradesPerDay).toBe(2);
+  });
+
+  it('AGRES_B — RO 30% = $300, 1 trade/dia, lossesToBust 3', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION');
+    expect(plan.roPerTrade).toBe(300);
+    expect(plan.maxTradesPerDay).toBe(1);
+    expect(plan.lossesToBust).toBe(3);
+    expect(plan.profileFamily).toBe('aggressive');
+  });
+
+  it('EV @ WR 50% — CONS_B = $75 ((0.5 × 300) - (0.5 × 150))', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION');
+    expect(plan.assumedWR).toBe(0.5);
+    expect(plan.evPerTrade).toBe(75);
+    expect(plan.wrBelowBreakeven).toBe(false);
+  });
+
+  it('EV @ WR 50% — AGRES_B = $150', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION');
+    expect(plan.evPerTrade).toBe(150);
+  });
+
+  it('WR abaixo do breakeven (33.3%) marca wrBelowBreakeven=true', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, INDICATORS_POOR, 'CONS_B', 'EVALUATION');
+    expect(plan.assumedWR).toBe(0.30);
+    expect(plan.wrBelowBreakeven).toBe(true);
+    expect(plan.evPerTrade).toBeLessThan(0);
+  });
+
+  it('modo abstract não tem campos de execução em pontos', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION');
     expect(plan.instrument).toBeNull();
     expect(plan.stopPoints).toBeNull();
     expect(plan.stopPerTrade).toBeNull();
-    expect(plan.roPerTrade).toBeNull();
-    expect(plan.maxTradesPerDay).toBeNull();
+    expect(plan.targetPoints).toBeNull();
     expect(plan.sizing).toBeNull();
   });
 
-  it('modo abstract tem mensagem informativa', () => {
+  it('perfil legado conservative → CONS_B', () => {
     const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
-    expect(plan.message).toContain('instrumento');
+    expect(plan.profile).toBe('CONS_B');
   });
 
-  it('modo abstract preserva profile, dataSource, rrMinimum', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_STRONG, null, 'aggressive', 'EVALUATION');
-    expect(plan.profile).toBe('aggressive');
-    expect(plan.dataSource).toBe('4d_full');
-    expect(plan.rrMinimum).toBe(2.0);
-  });
-
-  it('modo abstract não viola constraints', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION');
-    expect(plan.constraintsViolated).toEqual([]);
+  it('perfil legado aggressive → AGRES_A', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'aggressive', 'EVALUATION');
+    expect(plan.profile).toBe('AGRES_A');
   });
 });
 
 // ============================================
-// calculateAttackPlan — modo execution com instrumento
+// calculateAttackPlan — modo execution
 // ============================================
 describe('calculateAttackPlan — modo execution', () => {
-  it('com MNQ retorna mode=execution com sizing 1', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
+  it('CONS_B + MNQ Apex 25K — stop 75 pts back-calculado de $150 / $2', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'MNQ');
     expect(plan.mode).toBe('execution');
+    expect(plan.roPerTrade).toBe(150);
+    expect(plan.stopPoints).toBe(75); // 150 / 2
+    expect(plan.targetPoints).toBe(150); // 75 × 2
+    expect(plan.stopPerTrade).toBe(150);
+    expect(plan.targetPerTrade).toBe(300);
+    expect(plan.maxTradesPerDay).toBe(2);
     expect(plan.sizing).toBe(1);
-    expect(plan.instrument.symbol).toBe('MNQ');
-    expect(plan.instrument.isMicro).toBe(true);
-    expect(plan.instrument.pointValue).toBe(2);
-  });
-
-  it('MNQ stop natural: 20 pts × $2 = $40', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
-    expect(plan.stopPoints).toBe(20);
-    expect(plan.stopPerTrade).toBe(40);
-  });
-
-  it('MNQ Apex 25K conservador — valores operacionalmente sensatos', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
-    // stop $40, RO ~$44-48 (overhead +10% × ajuste por adjustment)
-    expect(plan.roPerTrade).toBeGreaterThanOrEqual(44);
-    expect(plan.roPerTrade).toBeLessThanOrEqual(60);
-    // RO < daily loss
-    expect(plan.roPerTrade).toBeLessThan(500);
-    // max trades cabe no daily loss
-    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(500);
-    // cap operacional
-    expect(plan.maxTradesPerDay).toBeLessThanOrEqual(8);
+    expect(plan.incompatible).toBe(false);
     expect(plan.constraintsViolated).toEqual([]);
+  });
+
+  it('CONS_A + MNQ — 50 pts (back-calc de $100/$2)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_A', 'EVALUATION', 'MNQ');
+    expect(plan.roPerTrade).toBe(100);
+    expect(plan.stopPoints).toBe(50);
+    expect(plan.targetPoints).toBe(100);
     expect(plan.incompatible).toBe(false);
   });
 
-  it('NQ (full) na Apex 25K — INCOMPATÍVEL (1 trade $400 ~ daily loss $500)', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'NQ');
-    // stop NQ = 20 pts × $20 = $400, RO com overhead ~$440-480 = quase todo daily loss
-    // mas ainda < $500, então NÃO incompatível tecnicamente, max trades = 1
-    // Vamos validar:
-    expect(plan.mode).toBe('execution');
-    if (plan.incompatible) {
-      // Se incompatível, deve sugerir MNQ
-      expect(plan.microSuggestion).toBe('MNQ');
-    } else {
-      // Se não incompatível, max trades é muito baixo (1)
-      expect(plan.maxTradesPerDay).toBeLessThanOrEqual(1);
-    }
+  it('AGRES_B + MNQ — 150 pts, 1 trade/dia, viável', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION', 'MNQ');
+    expect(plan.roPerTrade).toBe(300);
+    expect(plan.stopPoints).toBe(150);
+    expect(plan.maxTradesPerDay).toBe(1);
+    expect(plan.incompatible).toBe(false);
   });
 
-  it('ES Apex 50K conservador — viável, RO razoável', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION', 'ES');
-    // ES stop 4 pts × $50 = $200, RO ~$220-240
-    expect(plan.stopPerTrade).toBe(200);
-    expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
-    expect(plan.constraintsViolated).toEqual([]);
+  it('NQ na Apex 25K com CONS_B — INVIÁVEL (stop 7.5pts < 15 minViable)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'NQ');
+    expect(plan.incompatible).toBe(true);
+    expect(plan.microSuggestion).toBe('MNQ');
+    expect(plan.constraintsViolated).toContain('stop_below_min_viable');
+    expect(plan.maxTradesPerDay).toBe(0);
+    expect(plan.sizing).toBe(0);
   });
 
-  it('GC na Apex — não permitido (suspenso)', () => {
-    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'conservative', 'EVALUATION', 'GC');
+  it('ES na Apex 50K com CONS_B — INVIÁVEL (stop 7.5pts < 15)', () => {
+    // 50K: drawdown 2500, RO CONS_B = 375. ES point value 50. Stop = 7.5 pts < 15
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'CONS_B', 'EVALUATION', 'ES');
+    expect(plan.incompatible).toBe(true);
+    expect(plan.microSuggestion).toBe('MES');
+  });
+
+  it('NQ na Apex 50K com CONS_B — VIÁVEL (stop 18.75pts ≥ 15)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'CONS_B', 'EVALUATION', 'NQ');
+    expect(plan.roPerTrade).toBe(375); // 2500 × 0.15
+    expect(plan.stopPoints).toBe(18.75);
+    expect(plan.incompatible).toBe(false);
+  });
+
+  it('GC na Apex — não permitido (suspenso) registra constraint', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'CONS_B', 'EVALUATION', 'GC');
     expect(plan.mode).toBe('execution');
-    // Deve ter constraint violation por instrumento não permitido
-    const hasNotAllowed = plan.constraintsViolated.some(v => v.includes('não permitido') || v.includes('apex'));
+    const hasNotAllowed = plan.constraintsViolated.some(v => v.includes('não permitido'));
     expect(hasNotAllowed).toBe(true);
   });
 
   it('instrumento desconhecido retorna mode=error', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'XYZ');
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'XYZ');
     expect(plan.mode).toBe('error');
     expect(plan.error).toContain('XYZ');
     expect(plan.constraintsViolated).toContain('instrument_not_found');
   });
+
+  it('stop como % do range NY é calculado', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'MNQ');
+    // NQ avgDailyRange = 549 (real ATR v2), NY range = 549 × 0.6 = 329.4
+    // stop 75 / 329.4 × 100 = 22.77%
+    expect(plan.nyRangePoints).toBeCloseTo(329.4, 1);
+    expect(plan.stopNyPct).toBeCloseTo(22.77, 1);
+  });
+
+  it('reduz maxTradesPerDay se RO × profile.maxTradesPerDay > dailyLossLimit', () => {
+    // Cenário forçado: dailyLossLimit pequeno
+    const tinyDaily = { ...APEX_EOD_25K, dailyLossLimit: 200 };
+    const plan = calculateAttackPlan(tinyDaily, null, null, 'CONS_B', 'EVALUATION', 'MNQ');
+    // RO = $150. profile.maxTradesPerDay = 2. 150 × 2 = 300 > 200 → reduz para floor(200/150) = 1
+    expect(plan.maxTradesPerDay).toBe(1);
+  });
+
+  it('RO > dailyLossLimit → INVIÁVEL', () => {
+    // CONS_C 20% × $1000 = $200; force daily loss 100
+    const tinyDaily = { ...APEX_EOD_25K, dailyLossLimit: 100 };
+    const plan = calculateAttackPlan(tinyDaily, null, null, 'CONS_C', 'EVALUATION', 'MNQ');
+    expect(plan.incompatible).toBe(true);
+    expect(plan.constraintsViolated).toContain('ro_exceeds_daily_loss');
+  });
+
+  it('stop NY > 75% → INVIÁVEL (vela única consome stop)', () => {
+    // M2K (RTY micro): avgDailyRange 70, NY range 42. Apex 25K CONS_C → RO $200.
+    // M2K pointValue $5 → stop pts = 40. 40/42 = 95.2% > 75% INVIÁVEL.
+    // Stop 40pts ≥ 15 (minViable equity_index) ✓ não dispara V1
+    // RO $200 ≤ daily $500 ✓ não dispara V3
+    // Apenas V2 (stop > 75% NY) dispara.
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_C', 'EVALUATION', 'M2K');
+    expect(plan.stopPoints).toBe(40);
+    expect(plan.stopNyPct).toBeGreaterThan(75);
+    expect(plan.incompatible).toBe(true);
+    expect(plan.constraintsViolated).toContain('stop_exceeds_ny_range');
+  });
 });
 
 // ============================================
-// calculateAttackPlan — perfis com instrumento
+// calculateAttackPlan — perfis comparativos
 // ============================================
-describe('calculateAttackPlan — perfis (execution)', () => {
-  it('agressivo tem RO maior que conservador (overhead maior)', () => {
-    const cons = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_MID, null, 'conservative', 'EVALUATION', 'MNQ');
-    const agg = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_MID, null, 'aggressive', 'EVALUATION', 'MNQ');
-    expect(agg.roPerTrade).toBeGreaterThanOrEqual(cons.roPerTrade);
+describe('calculateAttackPlan — comparação entre perfis', () => {
+  it('roPct cresce do CONS_A → AGRES_B', () => {
+    const a = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_A', 'EVALUATION');
+    const b = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION');
+    const c = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_C', 'EVALUATION');
+    const d = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_A', 'EVALUATION');
+    const e = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION');
+    expect(a.roPerTrade).toBeLessThan(b.roPerTrade);
+    expect(b.roPerTrade).toBeLessThan(c.roPerTrade);
+    expect(c.roPerTrade).toBeLessThan(d.roPerTrade);
+    expect(d.roPerTrade).toBeLessThan(e.roPerTrade);
   });
 
-  it('conservador rrMinimum 1.5, agressivo 2.0', () => {
-    const cons = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
-    const agg = calculateAttackPlan(APEX_EOD_25K, null, null, 'aggressive', 'EVALUATION', 'MNQ');
-    expect(cons.rrMinimum).toBe(1.5);
-    expect(agg.rrMinimum).toBe(2.0);
+  it('agressivos têm 1 trade/dia, conservadores têm 2', () => {
+    const cons_a = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_A', 'EVALUATION');
+    const cons_b = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION');
+    const cons_c = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_C', 'EVALUATION');
+    const agr_a = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_A', 'EVALUATION');
+    const agr_b = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION');
+    expect(cons_a.maxTradesPerDay).toBe(2);
+    expect(cons_b.maxTradesPerDay).toBe(2);
+    expect(cons_c.maxTradesPerDay).toBe(2);
+    expect(agr_a.maxTradesPerDay).toBe(1);
+    expect(agr_b.maxTradesPerDay).toBe(1);
   });
 
-  it('targetPerTrade = stopPerTrade × rrMinimum', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
-    expect(plan.targetPerTrade).toBeCloseTo(plan.stopPerTrade * plan.rrMinimum, 2);
+  it('lossesToBust DECRESCE quando RO cresce', () => {
+    const a = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_A', 'EVALUATION');
+    const e = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION');
+    expect(a.lossesToBust).toBeGreaterThan(e.lossesToBust);
   });
 
-  it('aluno fraco recebe RO com mais overhead', () => {
-    const strong = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_STRONG, null, 'conservative', 'EVALUATION', 'MNQ');
-    const weak = calculateAttackPlan(APEX_EOD_25K, PROFILE_4D_WEAK, null, 'conservative', 'EVALUATION', 'MNQ');
-    // Stop é o mesmo (depende do instrumento), mas RO do weak tem overhead maior
-    expect(weak.roPerTrade).toBeGreaterThanOrEqual(strong.roPerTrade);
+  it('EV cresce com RO (dado WR fixo)', () => {
+    const a = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_A', 'EVALUATION');
+    const e = calculateAttackPlan(APEX_EOD_25K, null, null, 'AGRES_B', 'EVALUATION');
+    expect(e.evPerTrade).toBeGreaterThan(a.evPerTrade);
+  });
+
+  it('RR sempre 1:2 em todos os perfis', () => {
+    for (const code of ['CONS_A', 'CONS_B', 'CONS_C', 'AGRES_A', 'AGRES_B']) {
+      const plan = calculateAttackPlan(APEX_EOD_25K, null, null, code, 'EVALUATION');
+      expect(plan.rrMinimum).toBe(2);
+    }
   });
 });
 
 // ============================================
-// calculateAttackPlan — hard constraints
+// calculateAttackPlan — hard constraints invioláveis (sweep)
 // ============================================
-describe('calculateAttackPlan — hard constraints invioláveis', () => {
+describe('calculateAttackPlan — hard constraints (modo execution viável)', () => {
   const fixtures = [
-    { name: 'Apex 25K conservador MNQ', t: APEX_EOD_25K, profile: 'conservative', sym: 'MNQ' },
-    { name: 'Apex 25K agressivo MNQ', t: APEX_EOD_25K, profile: 'aggressive', sym: 'MNQ' },
-    { name: 'Apex 50K conservador MNQ', t: APEX_EOD_50K, profile: 'conservative', sym: 'MNQ' },
-    { name: 'Apex 50K conservador ES', t: APEX_EOD_50K, profile: 'conservative', sym: 'ES' },
-    { name: 'Apex 50K agressivo MES', t: APEX_EOD_50K, profile: 'aggressive', sym: 'MES' }
+    { name: 'Apex 25K CONS_A MNQ', t: APEX_EOD_25K, profile: 'CONS_A', sym: 'MNQ' },
+    { name: 'Apex 25K CONS_B MNQ', t: APEX_EOD_25K, profile: 'CONS_B', sym: 'MNQ' },
+    { name: 'Apex 25K CONS_C MNQ', t: APEX_EOD_25K, profile: 'CONS_C', sym: 'MNQ' },
+    { name: 'Apex 25K AGRES_A MNQ', t: APEX_EOD_25K, profile: 'AGRES_A', sym: 'MNQ' },
+    { name: 'Apex 25K AGRES_B MNQ', t: APEX_EOD_25K, profile: 'AGRES_B', sym: 'MNQ' },
+    { name: 'Apex 50K CONS_B NQ', t: APEX_EOD_50K, profile: 'CONS_B', sym: 'NQ' }
   ];
 
   for (const fx of fixtures) {
-    it(`${fx.name} — todas as 4 constraints respeitadas`, () => {
+    it(`${fx.name} — viável e respeita constraints`, () => {
       const plan = calculateAttackPlan(fx.t, null, null, fx.profile, 'EVALUATION', fx.sym);
-      if (plan.incompatible) return; // skip se incompatível (já é safety)
+      if (plan.incompatible) return;
 
-      // C1: roPerTrade <= dailyLossLimit
+      // C1: RO ≤ daily loss
       expect(plan.roPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
-      // C2: stopPerTrade <= dailyLossLimit
-      expect(plan.stopPerTrade).toBeLessThanOrEqual(plan.dailyLossLimit);
-      // C3: roPerTrade × maxTradesPerDay <= dailyLossLimit
+      // C2: RO × maxTrades ≤ daily loss
       expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(plan.dailyLossLimit);
-      // C4: dailyTarget × evalBusinessDays >= profitTarget
+      // C3: stop em pontos ≥ minViable
+      expect(plan.stopPoints).toBeGreaterThanOrEqual(plan.instrument.minViableStop);
+      // C4: stop ≤ 75% do range NY
+      expect(plan.stopNyPct).toBeLessThanOrEqual(75);
+      // C5: dailyTarget × dias ≥ profitTarget
       expect(plan.dailyTarget * plan.evalBusinessDays).toBeGreaterThanOrEqual(plan.profitTarget);
-      // Sem violations registradas
-      expect(plan.constraintsViolated).toEqual([]);
+      // C6: RR fixo 1:2
+      expect(plan.rrMinimum).toBe(2);
     });
   }
 });
 
 // ============================================
-// calculateAttackPlan — cap operacional
+// calculateAttackPlan — restrição de sessão NY (stop pequeno)
 // ============================================
-describe('calculateAttackPlan — cap max trades', () => {
-  it('conservador cap 8', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
-    if (!plan.incompatible) {
-      expect(plan.maxTradesPerDay).toBeLessThanOrEqual(8);
-    }
+describe('calculateAttackPlan — restrição de sessão NY', () => {
+  it('NQ Apex 50K CONS_B (stop 18.75pts ≈5.7% NY com ATR real) — operar fora de NY', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'CONS_B', 'EVALUATION', 'NQ');
+    expect(plan.incompatible).toBe(false); // viável (stop ≥ 15 minViable)
+    expect(plan.stopPoints).toBe(18.75);
+    expect(plan.stopNyPct).toBeLessThan(12.5);
+    expect(plan.nySessionViable).toBe(false);
+    expect(plan.sessionRestricted).toBe(true);
+    expect(plan.recommendedSessions).toEqual(['london', 'asia']);
   });
 
-  it('agressivo cap 10', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'aggressive', 'EVALUATION', 'MNQ');
-    if (!plan.incompatible) {
-      expect(plan.maxTradesPerDay).toBeLessThanOrEqual(10);
-    }
+  it('NQ Apex 50K CONS_C (stop 25pts ≈7.6% NY) — operar fora de NY', () => {
+    const plan = calculateAttackPlan(APEX_EOD_50K, null, null, 'CONS_C', 'EVALUATION', 'NQ');
+    expect(plan.stopPoints).toBe(25);
+    expect(plan.stopNyPct).toBeLessThan(12.5);
+    expect(plan.nySessionViable).toBe(false);
+    expect(plan.recommendedSessions).toContain('london');
+    expect(plan.recommendedSessions).not.toContain('ny');
   });
-});
 
-// ============================================
-// calculateAttackPlan — incompatibilidade e sugestão de micro
-// ============================================
-describe('calculateAttackPlan — incompatibilidade', () => {
-  it('quando incompatível, maxTrades=0 e sizing=0', () => {
-    // Forçar instrumento muito caro para mesa pequena
-    // CL stop 0.20 pts × $1000 = $200, RO ~$220 — viável em 25K? daily $500 = sim
-    // Vamos forçar com algo caro: MBT (Bitcoin) tem stop 200 × $0.10 = $20 — viável
-    // GC stop 3 × $100 = $300, RO ~$330 — em 25K daily $500: viável mas só 1 trade
-    // SI stop 0.05 × $5000 = $250, RO ~$275 — viável também
-    // Vamos usar template menor: dailyLoss $100 hipotético
-    const tinyTemplate = { ...APEX_EOD_25K, dailyLossLimit: 100 };
-    const plan = calculateAttackPlan(tinyTemplate, null, null, 'conservative', 'EVALUATION', 'NQ');
+  it('NQ Apex 100K AGRES_B (stop 45pts ≈13.7% NY) — NY viável', () => {
+    // Com ATR real NQ=549, NY range=329.4. Threshold 12.5% = 41.175 pts.
+    // Apex 100K (DD $3000) AGRES_B → RO $900, /20 = 45 pts. 45/329.4 = 13.66% > 12.5 ✓
+    const APEX_100K = {
+      firm: 'APEX',
+      drawdown: { type: 'TRAILING_EOD', maxAmount: 3000 },
+      dailyLossLimit: 1500,
+      profitTarget: 6000,
+      evalTimeLimit: 30
+    };
+    const plan = calculateAttackPlan(APEX_100K, null, null, 'AGRES_B', 'EVALUATION', 'NQ');
+    expect(plan.stopPoints).toBe(45);
+    expect(plan.stopNyPct).toBeGreaterThanOrEqual(12.5);
+    expect(plan.nySessionViable).toBe(true);
+    expect(plan.sessionRestricted).toBe(false);
+    expect(plan.recommendedSessions).toContain('ny');
+  });
+
+  it('MNQ Apex 25K CONS_B (75pts ≈22.8% NY com ATR real) — NY viável', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'MNQ');
+    expect(plan.nySessionViable).toBe(true);
+    expect(plan.sessionRestricted).toBe(false);
+    expect(plan.recommendedSessions[0]).toBe('ny');
+  });
+
+  it('threshold NY exato 12.5% — limite operacional para NQ é ~41pts (ATR real)', () => {
+    // NQ NY range = 549 × 0.6 = 329.4. 12.5% = 41.175 pts. RO = 41.175 × 20 = $823.5.
+    // CONS_B (15%) → drawdown necessário = 5490
+    const tplNQ41 = {
+      firm: 'APEX',
+      drawdown: { type: 'TRAILING_EOD', maxAmount: 5490 },
+      dailyLossLimit: 1500,
+      profitTarget: 6000,
+      evalTimeLimit: 30
+    };
+    const plan = calculateAttackPlan(tplNQ41, null, null, 'CONS_B', 'EVALUATION', 'NQ');
+    expect(plan.stopPoints).toBe(41.175);
+    expect(plan.stopNyPct).toBe(12.5);
+    expect(plan.nySessionViable).toBe(true); // exatamente no limite
+  });
+
+  it('plano abstract não tem restrição de sessão', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION');
+    expect(plan.mode).toBe('abstract');
+    expect(plan.nySessionViable).toBeUndefined(); // só existe em mode=execution
+  });
+
+  it('incompatível não recomenda sessões', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'NQ');
     expect(plan.incompatible).toBe(true);
-    expect(plan.maxTradesPerDay).toBe(0);
-    expect(plan.sizing).toBe(0);
-    // Sugere MNQ
-    expect(plan.microSuggestion).toBe('MNQ');
-  });
-
-  it('micro variant não tem sugestão de outro micro', () => {
-    const tinyTemplate = { ...APEX_EOD_25K, dailyLossLimit: 1 };
-    const plan = calculateAttackPlan(tinyTemplate, null, null, 'conservative', 'EVALUATION', 'MNQ');
-    if (plan.incompatible) {
-      // MNQ já é micro, não deve sugerir nada
-      expect(plan.microSuggestion).toBeNull();
-    }
+    expect(plan.recommendedSessions).toEqual([]);
+    expect(plan.nySessionViable).toBe(false);
   });
 });
 
 // ============================================
-// calculateAttackPlan — sanidade Apex EOD 25K MNQ conservador
+// REGRESSÃO ATR v2 — MES CONS_B Apex 25K agora é VIÁVEL em NY
 // ============================================
-describe('VALIDAÇÃO OPERACIONAL — Apex EOD 25K MNQ conservador', () => {
-  it('valores fazem sentido operacional', () => {
-    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'conservative', 'EVALUATION', 'MNQ');
-
-    // Estrutura básica
+// Bug v1: ATR ES alucinado em 55 → MES com 30 pts dava 90.9% NY (INVIÁVEL).
+// Real ATR ES = 123 → NY range MES = 73.8 → 30 pts = 40.6% (VIÁVEL day trade).
+describe('REGRESSÃO ATR v2 — MES Apex 25K CONS_B', () => {
+  it('MES com 30 pts é VIÁVEL na NY (40.6% do range, não 90.9%)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'MES');
     expect(plan.mode).toBe('execution');
+    expect(plan.instrument.symbol).toBe('MES');
+    expect(plan.roPerTrade).toBe(150); // 15% × $1000
+    expect(plan.stopPoints).toBe(30);  // $150 / $5 pt
+    expect(plan.stopPerTrade).toBe(150);
+    expect(plan.targetPoints).toBe(60); // 30 × 2 (RR fixo 1:2)
+    expect(plan.nyRangePoints).toBeCloseTo(73.8, 1); // 123 × 0.6
+    expect(plan.stopNyPct).toBeCloseTo(40.65, 1);
+    expect(plan.incompatible).toBe(false);
+    expect(plan.nySessionViable).toBe(true);
+    expect(plan.sessionRestricted).toBe(false);
+    expect(plan.recommendedSessions[0]).toBe('ny');
+  });
+});
+
+// ============================================
+// VALIDAÇÃO OPERACIONAL — Apex EOD 25K MNQ CONS_B (recomendado)
+// ============================================
+describe('VALIDAÇÃO OPERACIONAL — Apex EOD 25K MNQ CONS_B', () => {
+  it('valores casam com tabela determinística (75 pts, 2 trades/dia, EV $75)', () => {
+    const plan = calculateAttackPlan(APEX_EOD_25K, null, null, 'CONS_B', 'EVALUATION', 'MNQ');
+
+    expect(plan.mode).toBe('execution');
+    expect(plan.profile).toBe('CONS_B');
+    expect(plan.profileRecommended).toBe(true);
     expect(plan.instrument.symbol).toBe('MNQ');
     expect(plan.instrument.isMicro).toBe(true);
 
@@ -351,30 +507,32 @@ describe('VALIDAÇÃO OPERACIONAL — Apex EOD 25K MNQ conservador', () => {
     expect(plan.dailyLossLimit).toBe(500);
     expect(plan.profitTarget).toBe(1500);
 
-    // Stop natural NQ/MNQ = 20 pts (max(ATR 400 × 5%, minStop 20))
-    expect(plan.stopPoints).toBe(20);
-    expect(plan.stopPerTrade).toBe(40); // 20 × $2
+    // RO determinístico — 15% de $1000 = $150
+    expect(plan.roPerTrade).toBe(150);
+    expect(plan.roPct).toBe(0.15);
 
-    // RO com overhead — entre $44 e $60 (depende do adjustment)
-    expect(plan.roPerTrade).toBeGreaterThanOrEqual(44);
-    expect(plan.roPerTrade).toBeLessThanOrEqual(60);
+    // Stop back-calculado de $150 / $2/pt
+    expect(plan.stopPoints).toBe(75);
+    expect(plan.stopPerTrade).toBe(150);
+    expect(plan.targetPoints).toBe(150);
+    expect(plan.targetPerTrade).toBe(300);
 
-    // RR conservador = 1.5
-    expect(plan.rrMinimum).toBe(1.5);
-    expect(plan.targetPerTrade).toBe(60); // 40 × 1.5
+    // 2 trades/dia conservador → 150 × 2 = $300 ≤ $500 ✓
+    expect(plan.maxTradesPerDay).toBe(2);
+    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(plan.dailyLossLimit);
 
-    // Max trades: cap 8 ou floor(500/RO)
-    // RO ~$48 → floor(500/48) = 10 → cap 8
-    expect(plan.maxTradesPerDay).toBe(8);
+    // Losses até bust
+    expect(plan.lossesToBust).toBe(6);
 
-    // Constraint cabe: 48 × 8 = 384 ≤ 500 ✓
-    expect(plan.roPerTrade * plan.maxTradesPerDay).toBeLessThanOrEqual(500);
+    // EV @ WR 50% = $75
+    expect(plan.evPerTrade).toBe(75);
+    expect(plan.wrBelowBreakeven).toBe(false);
 
-    // Meta diária $72, dias úteis 21
+    // Meta diária $72 × 21 dias = $1512 ≥ $1500 ✓
     expect(plan.dailyTarget).toBe(72);
     expect(plan.evalBusinessDays).toBe(21);
 
-    // Constraints violadas: zero
+    // Sem violations
     expect(plan.constraintsViolated).toEqual([]);
     expect(plan.incompatible).toBe(false);
   });

--- a/src/__tests__/utils/instrumentsTable.test.js
+++ b/src/__tests__/utils/instrumentsTable.test.js
@@ -1,0 +1,368 @@
+import { describe, it, expect } from 'vitest';
+import {
+  INSTRUMENTS_TABLE,
+  SESSION_PROFILES,
+  DAILY_PROFILES,
+  STOP_PERCENT_OF_ATR,
+  getInstrument,
+  getSessionRange,
+  isInstrumentAllowed,
+  getRestrictedInstrumentsForFirm,
+  getAllowedInstrumentsForFirm,
+  suggestMicroAlternative,
+  getRecommendedStop
+} from '../../constants/instrumentsTable';
+
+// ============================================
+// INSTRUMENTS_TABLE — sanidade dos dados
+// ============================================
+describe('INSTRUMENTS_TABLE — sanidade', () => {
+  it('contém pelo menos os instrumentos top esperados', () => {
+    const symbols = INSTRUMENTS_TABLE.map(i => i.symbol);
+    expect(symbols).toContain('ES');
+    expect(symbols).toContain('NQ');
+    expect(symbols).toContain('YM');
+    expect(symbols).toContain('RTY');
+    expect(symbols).toContain('CL');
+    expect(symbols).toContain('GC');
+  });
+
+  it('todo instrumento tem campos obrigatórios', () => {
+    for (const inst of INSTRUMENTS_TABLE) {
+      expect(inst).toHaveProperty('symbol');
+      expect(inst).toHaveProperty('name');
+      expect(inst).toHaveProperty('exchange');
+      expect(inst).toHaveProperty('type');
+      expect(inst).toHaveProperty('pointValue');
+      expect(inst).toHaveProperty('avgDailyRange');
+      expect(inst).toHaveProperty('minStopPoints');
+      expect(inst).toHaveProperty('availability');
+      expect(typeof inst.pointValue).toBe('number');
+      expect(typeof inst.avgDailyRange).toBe('number');
+      expect(typeof inst.minStopPoints).toBe('number');
+      expect(inst.minStopPoints).toBeGreaterThan(0);
+    }
+  });
+
+  it('availability tem todas as 4 mesas', () => {
+    for (const inst of INSTRUMENTS_TABLE) {
+      expect(inst.availability).toHaveProperty('apex');
+      expect(inst.availability).toHaveProperty('mff');
+      expect(inst.availability).toHaveProperty('lucid');
+      expect(inst.availability).toHaveProperty('tradeify');
+    }
+  });
+
+  it('Apex restringe metals (GC, SI, HG)', () => {
+    const gc = INSTRUMENTS_TABLE.find(i => i.symbol === 'GC');
+    const si = INSTRUMENTS_TABLE.find(i => i.symbol === 'SI');
+    const hg = INSTRUMENTS_TABLE.find(i => i.symbol === 'HG');
+    expect(gc.availability.apex).toBe(false);
+    expect(si.availability.apex).toBe(false);
+    expect(hg.availability.apex).toBe(false);
+  });
+
+  it('Equity index micros estão definidos no full', () => {
+    expect(INSTRUMENTS_TABLE.find(i => i.symbol === 'ES').micro).toBe('MES');
+    expect(INSTRUMENTS_TABLE.find(i => i.symbol === 'NQ').micro).toBe('MNQ');
+    expect(INSTRUMENTS_TABLE.find(i => i.symbol === 'YM').micro).toBe('MYM');
+    expect(INSTRUMENTS_TABLE.find(i => i.symbol === 'RTY').micro).toBe('M2K');
+  });
+});
+
+// ============================================
+// SESSION_PROFILES
+// ============================================
+describe('SESSION_PROFILES', () => {
+  it('soma das % das sessões = 100%', () => {
+    const total = SESSION_PROFILES.asia.rangePct + SESSION_PROFILES.london.rangePct + SESSION_PROFILES.ny.rangePct;
+    expect(total).toBeCloseTo(1.0, 2);
+  });
+
+  it('NY tem maior range (60%)', () => {
+    expect(SESSION_PROFILES.ny.rangePct).toBe(0.60);
+    expect(SESSION_PROFILES.ny.rangePct).toBeGreaterThan(SESSION_PROFILES.london.rangePct);
+    expect(SESSION_PROFILES.ny.rangePct).toBeGreaterThan(SESSION_PROFILES.asia.rangePct);
+  });
+
+  it('NY tem maior direcionalidade', () => {
+    expect(SESSION_PROFILES.ny.directionalPct).toBeGreaterThan(SESSION_PROFILES.asia.directionalPct);
+  });
+});
+
+// ============================================
+// DAILY_PROFILES
+// ============================================
+describe('DAILY_PROFILES', () => {
+  it('contém os 4 profiles esperados', () => {
+    expect(DAILY_PROFILES.ASIA_REVERSAL).toBeDefined();
+    expect(DAILY_PROFILES.LONDON_REVERSAL).toBeDefined();
+    expect(DAILY_PROFILES.NY_REVERSAL).toBeDefined();
+    expect(DAILY_PROFILES.INVALIDATION).toBeDefined();
+  });
+
+  it('INVALIDATION é o único que nem conservador nem agressivo opera', () => {
+    expect(DAILY_PROFILES.INVALIDATION.conservative).toBe(false);
+    expect(DAILY_PROFILES.INVALIDATION.aggressive).toBe(false);
+  });
+
+  it('NY_REVERSAL é apenas para agressivo', () => {
+    expect(DAILY_PROFILES.NY_REVERSAL.conservative).toBe(false);
+    expect(DAILY_PROFILES.NY_REVERSAL.aggressive).toBe(true);
+  });
+});
+
+// ============================================
+// getInstrument
+// ============================================
+describe('getInstrument', () => {
+  it('busca direta por full size symbol', () => {
+    const nq = getInstrument('NQ');
+    expect(nq).not.toBeNull();
+    expect(nq.symbol).toBe('NQ');
+    expect(nq.pointValue).toBe(20.00);
+    expect(nq.isMicro).toBe(false);
+    expect(nq.parentSymbol).toBeNull();
+  });
+
+  it('busca como micro (MNQ → encontra NQ pai)', () => {
+    const mnq = getInstrument('MNQ');
+    expect(mnq).not.toBeNull();
+    expect(mnq.symbol).toBe('MNQ');
+    expect(mnq.pointValue).toBe(2.00);
+    expect(mnq.isMicro).toBe(true);
+    expect(mnq.parentSymbol).toBe('NQ');
+    expect(mnq.name).toContain('Micro');
+  });
+
+  it('case insensitive', () => {
+    expect(getInstrument('nq')?.symbol).toBe('NQ');
+    expect(getInstrument('mnq')?.symbol).toBe('MNQ');
+  });
+
+  it('retorna null para símbolo não mapeado', () => {
+    expect(getInstrument('XYZ')).toBeNull();
+    expect(getInstrument('')).toBeNull();
+    expect(getInstrument(null)).toBeNull();
+  });
+
+  it('micro herda ATR e minStopPoints do pai', () => {
+    const nq = getInstrument('NQ');
+    const mnq = getInstrument('MNQ');
+    expect(mnq.avgDailyRange).toBe(nq.avgDailyRange);
+    expect(mnq.minStopPoints).toBe(nq.minStopPoints);
+  });
+
+  it('full e micro têm pointValue diferentes', () => {
+    const nq = getInstrument('NQ');
+    const mnq = getInstrument('MNQ');
+    expect(nq.pointValue).toBe(20.00);
+    expect(mnq.pointValue).toBe(2.00);
+    expect(nq.pointValue).toBe(mnq.pointValue * 10);
+  });
+});
+
+// ============================================
+// getSessionRange
+// ============================================
+describe('getSessionRange', () => {
+  it('NQ NY = ATR(400) × 0.60 = 240 pts', () => {
+    const range = getSessionRange('NQ', 'ny');
+    expect(range.rangePoints).toBe(240);
+    expect(range.rangeUSD).toBe(240 * 20); // $4800
+    expect(range.sessionName).toBe('New York');
+  });
+
+  it('ES London = ATR(55) × 0.23 ≈ 12.65 pts', () => {
+    const range = getSessionRange('ES', 'london');
+    expect(range.rangePoints).toBeCloseTo(12.65, 2);
+    expect(range.rangeUSD).toBeCloseTo(632.5, 1);
+  });
+
+  it('MNQ herda mesmo ATR de NQ', () => {
+    const nqNY = getSessionRange('NQ', 'ny');
+    const mnqNY = getSessionRange('MNQ', 'ny');
+    expect(mnqNY.rangePoints).toBe(nqNY.rangePoints);
+    // Mas USD diferente
+    expect(mnqNY.rangeUSD).toBe(nqNY.rangePoints * 2); // pointValue 2 vs 20
+  });
+
+  it('retorna null para sessão inválida', () => {
+    expect(getSessionRange('NQ', 'invalid')).toBeNull();
+  });
+
+  it('retorna null para instrumento inválido', () => {
+    expect(getSessionRange('XYZ', 'ny')).toBeNull();
+  });
+
+  it('inclui directionalPct e hours', () => {
+    const range = getSessionRange('NQ', 'ny');
+    expect(range.directionalPct).toBe(0.86);
+    expect(range.hours).toContain('EST');
+  });
+});
+
+// ============================================
+// isInstrumentAllowed
+// ============================================
+describe('isInstrumentAllowed', () => {
+  it('NQ é permitido em todas as mesas', () => {
+    expect(isInstrumentAllowed('NQ', 'apex')).toBe(true);
+    expect(isInstrumentAllowed('NQ', 'mff')).toBe(true);
+    expect(isInstrumentAllowed('NQ', 'lucid')).toBe(true);
+    expect(isInstrumentAllowed('NQ', 'tradeify')).toBe(true);
+  });
+
+  it('GC NÃO é permitido na Apex (suspenso)', () => {
+    expect(isInstrumentAllowed('GC', 'apex')).toBe(false);
+    expect(isInstrumentAllowed('GC', 'mff')).toBe(true);
+  });
+
+  it('MGC NÃO é permitido na Apex (mesma restrição do parent GC)', () => {
+    expect(isInstrumentAllowed('MGC', 'apex')).toBe(false);
+  });
+
+  it('Case insensitive em firm', () => {
+    expect(isInstrumentAllowed('NQ', 'APEX')).toBe(true);
+    expect(isInstrumentAllowed('NQ', 'Apex')).toBe(true);
+  });
+
+  it('retorna false para instrumento não mapeado', () => {
+    expect(isInstrumentAllowed('XYZ', 'apex')).toBe(false);
+  });
+});
+
+// ============================================
+// getRestrictedInstrumentsForFirm
+// ============================================
+describe('getRestrictedInstrumentsForFirm', () => {
+  it('Apex restringe GC, SI, HG e seus micros', () => {
+    const apexRestricted = getRestrictedInstrumentsForFirm('apex');
+    expect(apexRestricted).toContain('GC');
+    expect(apexRestricted).toContain('MGC');
+    expect(apexRestricted).toContain('SI');
+    expect(apexRestricted).toContain('HG');
+  });
+
+  it('MFF tem poucas restrições (HG)', () => {
+    const mffRestricted = getRestrictedInstrumentsForFirm('mff');
+    expect(mffRestricted).toContain('HG');
+    expect(mffRestricted).not.toContain('GC');
+    expect(mffRestricted).not.toContain('NQ');
+  });
+
+  it('case insensitive', () => {
+    expect(getRestrictedInstrumentsForFirm('APEX')).toEqual(getRestrictedInstrumentsForFirm('apex'));
+  });
+
+  it('retorna array vazio para mesa inexistente', () => {
+    // mesas inexistentes não têm availability definida → instrumentos têm undefined
+    // → undefined !== false → não restringidos
+    expect(getRestrictedInstrumentsForFirm('xyz')).toEqual([]);
+  });
+});
+
+// ============================================
+// getAllowedInstrumentsForFirm
+// ============================================
+describe('getAllowedInstrumentsForFirm', () => {
+  it('Apex tem instrumentos permitidos incluindo full e micros', () => {
+    const allowed = getAllowedInstrumentsForFirm('apex');
+    const symbols = allowed.map(i => i.symbol);
+    expect(symbols).toContain('NQ');
+    expect(symbols).toContain('MNQ');
+    expect(symbols).toContain('ES');
+    expect(symbols).toContain('MES');
+  });
+
+  it('Apex NÃO inclui GC nem MGC (suspensos)', () => {
+    const symbols = getAllowedInstrumentsForFirm('apex').map(i => i.symbol);
+    expect(symbols).not.toContain('GC');
+    expect(symbols).not.toContain('MGC');
+  });
+
+  it('cada item tem isMicro flag e pointValue correto', () => {
+    const allowed = getAllowedInstrumentsForFirm('apex');
+    const nq = allowed.find(i => i.symbol === 'NQ');
+    const mnq = allowed.find(i => i.symbol === 'MNQ');
+    expect(nq.isMicro).toBe(false);
+    expect(nq.pointValue).toBe(20);
+    expect(mnq.isMicro).toBe(true);
+    expect(mnq.pointValue).toBe(2);
+    expect(mnq.parentSymbol).toBe('NQ');
+  });
+});
+
+// ============================================
+// suggestMicroAlternative
+// ============================================
+describe('suggestMicroAlternative', () => {
+  it('NQ → MNQ', () => {
+    const micro = suggestMicroAlternative('NQ');
+    expect(micro).not.toBeNull();
+    expect(micro.symbol).toBe('MNQ');
+    expect(micro.isMicro).toBe(true);
+  });
+
+  it('ES → MES', () => {
+    expect(suggestMicroAlternative('ES').symbol).toBe('MES');
+  });
+
+  it('retorna null se já é micro', () => {
+    expect(suggestMicroAlternative('MNQ')).toBeNull();
+  });
+
+  it('retorna null se não tem micro variant', () => {
+    expect(suggestMicroAlternative('NG')).toBeNull(); // NG não tem micro
+    expect(suggestMicroAlternative('SI')).toBeNull(); // SI não tem micro
+  });
+
+  it('retorna null para símbolo inválido', () => {
+    expect(suggestMicroAlternative('XYZ')).toBeNull();
+  });
+});
+
+// ============================================
+// getRecommendedStop
+// ============================================
+describe('getRecommendedStop', () => {
+  it('NQ: ATR 400 × 5% = 20pts (igual ao minStop)', () => {
+    const nq = getInstrument('NQ');
+    const stop = getRecommendedStop(nq);
+    expect(stop.stopPoints).toBe(20);
+    expect(stop.stopUSD).toBe(400); // 20 × $20
+  });
+
+  it('MNQ: mesmo stopPoints, mas USD diferente', () => {
+    const mnq = getInstrument('MNQ');
+    const stop = getRecommendedStop(mnq);
+    expect(stop.stopPoints).toBe(20);
+    expect(stop.stopUSD).toBe(40); // 20 × $2
+  });
+
+  it('ES: ATR 55 × 5% = 2.75 → minStop 4 prevalece', () => {
+    const es = getInstrument('ES');
+    const stop = getRecommendedStop(es);
+    expect(stop.stopPoints).toBe(4);
+    expect(stop.stopUSD).toBe(200); // 4 × $50
+    expect(stop.source).toBe('min'); // minStop prevaleceu
+  });
+
+  it('YM: ATR 420 × 5% = 21 → maior que minStop 25? Não, 21 < 25, então minStop 25', () => {
+    const ym = getInstrument('YM');
+    const stop = getRecommendedStop(ym);
+    expect(stop.stopPoints).toBe(25); // minStop prevalece
+    expect(stop.stopUSD).toBe(125); // 25 × $5
+    expect(stop.source).toBe('min');
+  });
+
+  it('source = "atr" quando ATR × 5% > minStop', () => {
+    // NQ: ATR 400, ATR×5% = 20, minStop = 20 → empate, atr ganha (>=)
+    const nq = getInstrument('NQ');
+    expect(getRecommendedStop(nq).source).toBe('atr');
+  });
+
+  it('retorna null para instrument null', () => {
+    expect(getRecommendedStop(null)).toBeNull();
+  });
+});

--- a/src/__tests__/utils/instrumentsTable.test.js
+++ b/src/__tests__/utils/instrumentsTable.test.js
@@ -166,17 +166,17 @@ describe('getInstrument', () => {
 // getSessionRange
 // ============================================
 describe('getSessionRange', () => {
-  it('NQ NY = ATR(400) × 0.60 = 240 pts', () => {
+  it('NQ NY = ATR(549) × 0.60 = 329.4 pts (ATR real v2)', () => {
     const range = getSessionRange('NQ', 'ny');
-    expect(range.rangePoints).toBe(240);
-    expect(range.rangeUSD).toBe(240 * 20); // $4800
+    expect(range.rangePoints).toBeCloseTo(329.4, 1);
+    expect(range.rangeUSD).toBeCloseTo(329.4 * 20, 0); // $6588
     expect(range.sessionName).toBe('New York');
   });
 
-  it('ES London = ATR(55) × 0.23 ≈ 12.65 pts', () => {
+  it('ES London = ATR(123) × 0.23 ≈ 28.29 pts (ATR real v2)', () => {
     const range = getSessionRange('ES', 'london');
-    expect(range.rangePoints).toBeCloseTo(12.65, 2);
-    expect(range.rangeUSD).toBeCloseTo(632.5, 1);
+    expect(range.rangePoints).toBeCloseTo(28.29, 2);
+    expect(range.rangeUSD).toBeCloseTo(1414.5, 1);
   });
 
   it('MNQ herda mesmo ATR de NQ', () => {
@@ -325,41 +325,47 @@ describe('suggestMicroAlternative', () => {
 // ============================================
 // getRecommendedStop
 // ============================================
+// NOTA: getRecommendedStop é helper legado — não mais usado pelo calculator novo
+// (5 perfis usa MIN_VIABLE_STOP do propFirmDefaults). Mantido para retrocompatibilidade
+// e estes testes garantem que ainda funciona com ATR real v2 (09/04/2026).
 describe('getRecommendedStop', () => {
-  it('NQ: ATR 400 × 5% = 20pts (igual ao minStop)', () => {
+  it('NQ: ATR 549 × 5% = 27.45pts (atr prevalece sobre minStop 20)', () => {
     const nq = getInstrument('NQ');
     const stop = getRecommendedStop(nq);
-    expect(stop.stopPoints).toBe(20);
-    expect(stop.stopUSD).toBe(400); // 20 × $20
+    expect(stop.stopPoints).toBeCloseTo(27.45, 2);
+    expect(stop.stopUSD).toBeCloseTo(549, 0); // 27.45 × $20
+    expect(stop.source).toBe('atr');
   });
 
   it('MNQ: mesmo stopPoints, mas USD diferente', () => {
     const mnq = getInstrument('MNQ');
     const stop = getRecommendedStop(mnq);
-    expect(stop.stopPoints).toBe(20);
-    expect(stop.stopUSD).toBe(40); // 20 × $2
+    expect(stop.stopPoints).toBeCloseTo(27.45, 2);
+    expect(stop.stopUSD).toBeCloseTo(54.9, 1); // 27.45 × $2
   });
 
-  it('ES: ATR 55 × 5% = 2.75 → minStop 4 prevalece', () => {
+  it('ES: ATR 123 × 5% = 6.15pts (atr prevalece sobre minStop 4)', () => {
     const es = getInstrument('ES');
     const stop = getRecommendedStop(es);
-    expect(stop.stopPoints).toBe(4);
-    expect(stop.stopUSD).toBe(200); // 4 × $50
-    expect(stop.source).toBe('min'); // minStop prevaleceu
+    expect(stop.stopPoints).toBeCloseTo(6.15, 2);
+    expect(stop.stopUSD).toBeCloseTo(307.5, 1); // 6.15 × $50
+    expect(stop.source).toBe('atr');
   });
 
-  it('YM: ATR 420 × 5% = 21 → maior que minStop 25? Não, 21 < 25, então minStop 25', () => {
+  it('YM: ATR 856 × 5% = 42.8pts (atr prevalece sobre minStop 25)', () => {
     const ym = getInstrument('YM');
     const stop = getRecommendedStop(ym);
-    expect(stop.stopPoints).toBe(25); // minStop prevalece
-    expect(stop.stopUSD).toBe(125); // 25 × $5
-    expect(stop.source).toBe('min');
+    expect(stop.stopPoints).toBeCloseTo(42.8, 2);
+    expect(stop.stopUSD).toBeCloseTo(214, 0); // 42.8 × $5
+    expect(stop.source).toBe('atr');
   });
 
-  it('source = "atr" quando ATR × 5% > minStop', () => {
-    // NQ: ATR 400, ATR×5% = 20, minStop = 20 → empate, atr ganha (>=)
-    const nq = getInstrument('NQ');
-    expect(getRecommendedStop(nq).source).toBe('atr');
+  it('6E: ATR 0.0090 × 5% = 0.00045 → minStop 0.0008 prevalece', () => {
+    // Cenário onde minStop AINDA ganha (instrumento de range pequeno)
+    const eur = getInstrument('6E');
+    const stop = getRecommendedStop(eur);
+    expect(stop.stopPoints).toBeCloseTo(0.0008, 5);
+    expect(stop.source).toBe('min');
   });
 
   it('retorna null para instrument null', () => {

--- a/src/__tests__/utils/propFirmDrawdownEngine.test.js
+++ b/src/__tests__/utils/propFirmDrawdownEngine.test.js
@@ -1,0 +1,831 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateDrawdownState,
+  initializePropFirmState,
+  resolveLockAt,
+  getPeakUpdateMode,
+  calculateEvalDaysRemaining,
+  isEvalDeadlineNear,
+  DRAWDOWN_FLAGS,
+  DD_NEAR_THRESHOLD
+} from '../../utils/propFirmDrawdownEngine';
+import { DRAWDOWN_TYPES } from '../../constants/propFirmDefaults';
+
+// ============================================
+// Templates de referência
+// ============================================
+const APEX_EOD_25K = {
+  drawdown: { type: DRAWDOWN_TYPES.TRAILING_EOD, maxAmount: 1000, lockAt: null, lockFormula: 'BALANCE + DD + 100' },
+  dailyLossLimit: 500,
+  profitTarget: 1500,
+  evalTimeLimit: 30,
+  accountSize: 25000
+};
+
+const APEX_INTRADAY_25K = {
+  drawdown: { type: DRAWDOWN_TYPES.TRAILING_INTRADAY, maxAmount: 1500, lockAt: null, lockFormula: null },
+  dailyLossLimit: 500,
+  profitTarget: 1500,
+  evalTimeLimit: 30,
+  accountSize: 25000
+};
+
+const STATIC_50K = {
+  drawdown: { type: DRAWDOWN_TYPES.STATIC, maxAmount: 2500, lockAt: null, lockFormula: null },
+  dailyLossLimit: 1000,
+  profitTarget: 3000,
+  evalTimeLimit: 30,
+  accountSize: 50000
+};
+
+const TRAILING_EOD_NO_LOCK = {
+  drawdown: { type: DRAWDOWN_TYPES.TRAILING_EOD, maxAmount: 2000, lockAt: null, lockFormula: null },
+  dailyLossLimit: 800,
+  profitTarget: 3000,
+  evalTimeLimit: 30,
+  accountSize: 50000
+};
+
+const NO_DAILY_LOSS_TEMPLATE = {
+  drawdown: { type: DRAWDOWN_TYPES.TRAILING_INTRADAY, maxAmount: 2500, lockAt: null, lockFormula: null },
+  dailyLossLimit: null,
+  profitTarget: 3000,
+  evalTimeLimit: 30,
+  accountSize: 50000
+};
+
+// ============================================
+// Helpers do estado inicial
+// ============================================
+function freshState(template) {
+  return initializePropFirmState(template, template.accountSize);
+}
+
+// ============================================
+// resolveLockAt
+// ============================================
+describe('resolveLockAt', () => {
+  it('lockAt numérico explícito tem prioridade', () => {
+    const tpl = { drawdown: { lockAt: 30000, maxAmount: 1000 } };
+    expect(resolveLockAt(tpl, 25000)).toBe(30000);
+  });
+
+  it("fórmula 'BALANCE + DD + 100' retorna accountSize + DD + 100", () => {
+    expect(resolveLockAt(APEX_EOD_25K, 25000)).toBe(26100);
+  });
+
+  it('sem lockAt nem lockFormula → null', () => {
+    expect(resolveLockAt(STATIC_50K, 50000)).toBeNull();
+  });
+
+  it('template inválido → null', () => {
+    expect(resolveLockAt(null, 25000)).toBeNull();
+    expect(resolveLockAt({}, 25000)).toBeNull();
+  });
+});
+
+// ============================================
+// getPeakUpdateMode
+// ============================================
+describe('getPeakUpdateMode', () => {
+  it('STATIC → never', () => {
+    expect(getPeakUpdateMode(DRAWDOWN_TYPES.STATIC)).toBe('never');
+  });
+  it('TRAILING_EOD → eod', () => {
+    expect(getPeakUpdateMode(DRAWDOWN_TYPES.TRAILING_EOD)).toBe('eod');
+  });
+  it('TRAILING_INTRADAY → intraday', () => {
+    expect(getPeakUpdateMode(DRAWDOWN_TYPES.TRAILING_INTRADAY)).toBe('intraday');
+  });
+  it('TRAILING_WITH_LOCK → intraday (legacy)', () => {
+    expect(getPeakUpdateMode(DRAWDOWN_TYPES.TRAILING_WITH_LOCK)).toBe('intraday');
+  });
+  it('valor desconhecido → intraday (default seguro)', () => {
+    expect(getPeakUpdateMode('FOO')).toBe('intraday');
+  });
+});
+
+// ============================================
+// initializePropFirmState
+// ============================================
+describe('initializePropFirmState', () => {
+  it('Apex EOD 25K → peak 25K, threshold 24K', () => {
+    const s = initializePropFirmState(APEX_EOD_25K, 25000);
+    expect(s.peakBalance).toBe(25000);
+    expect(s.currentDrawdownThreshold).toBe(24000);
+    expect(s.lockLevel).toBeNull();
+    expect(s.isDayPaused).toBe(false);
+    expect(s.tradingDays).toBe(0);
+    expect(s.dailyPnL).toBe(0);
+    expect(s.lastTradeDate).toBeNull();
+  });
+
+  it('Static 50K DD 2500 → threshold 47.5K', () => {
+    const s = initializePropFirmState(STATIC_50K, 50000);
+    expect(s.peakBalance).toBe(50000);
+    expect(s.currentDrawdownThreshold).toBe(47500);
+  });
+
+  it('lança erro sem template.drawdown', () => {
+    expect(() => initializePropFirmState(null, 25000)).toThrow();
+    expect(() => initializePropFirmState({}, 25000)).toThrow();
+  });
+});
+
+// ============================================
+// calculateDrawdownState — STATIC
+// ============================================
+describe('calculateDrawdownState — STATIC', () => {
+  const tpl = STATIC_50K;
+  const accountSize = 50000;
+
+  it('init + win 200 → threshold permanece 47.5K', () => {
+    const result = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 50000,
+      tradeNet: 200,
+      tradeDate: '2026-04-09'
+    });
+    expect(result.newBalance).toBe(50200);
+    expect(result.peakBalance).toBe(50000); // STATIC nunca move
+    expect(result.currentDrawdownThreshold).toBe(47500); // fixo
+    expect(result.flags).toEqual([]);
+    expect(result.tradingDays).toBe(1); // primeiro trade do dia
+  });
+
+  it('loss leve → threshold permanece, sem flag', () => {
+    const result = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 50000,
+      tradeNet: -100,
+      tradeDate: '2026-04-09'
+    });
+    expect(result.newBalance).toBe(49900);
+    expect(result.currentDrawdownThreshold).toBe(47500);
+    expect(result.flags).not.toContain(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  });
+
+  it('loss até bust → flag ACCOUNT_BUST', () => {
+    const result = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 50000,
+      tradeNet: -2600, // novo balance 47.4K < 47.5K
+      tradeDate: '2026-04-09'
+    });
+    expect(result.newBalance).toBe(47400);
+    expect(result.flags).toContain(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  });
+
+  it('múltiplos trades em sequência: peak nunca move', () => {
+    let state = freshState(tpl);
+    const trades = [+200, +500, -100, +300, -50];
+    let balance = accountSize;
+    for (const net of trades) {
+      const r = calculateDrawdownState({
+        propFirm: state,
+        template: tpl,
+        accountSize,
+        balanceBefore: balance,
+        tradeNet: net,
+        tradeDate: '2026-04-09'
+      });
+      state = { ...state, ...r };
+      balance = r.newBalance;
+    }
+    expect(state.peakBalance).toBe(50000);
+    expect(state.currentDrawdownThreshold).toBe(47500);
+  });
+});
+
+// ============================================
+// calculateDrawdownState — TRAILING_INTRADAY
+// ============================================
+describe('calculateDrawdownState — TRAILING_INTRADAY', () => {
+  const tpl = APEX_INTRADAY_25K;
+  const accountSize = 25000;
+
+  it('init: peak 25K, threshold 23.5K', () => {
+    const s = freshState(tpl);
+    expect(s.peakBalance).toBe(25000);
+    expect(s.currentDrawdownThreshold).toBe(23500);
+  });
+
+  it('win 200: peak sobe para 25.2K, threshold 23.7K', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: 200,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.peakBalance).toBe(25200);
+    expect(r.currentDrawdownThreshold).toBe(23700);
+  });
+
+  it('loss após win NÃO baixa o peak (trailing one-way)', () => {
+    let state = freshState(tpl);
+    // win 300
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 25000, tradeNet: 300, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    expect(state.peakBalance).toBe(25300);
+
+    // loss 100
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: r.newBalance, tradeNet: -100, tradeDate: '2026-04-09'
+    });
+    expect(r.peakBalance).toBe(25300); // não desce
+    expect(r.currentDrawdownThreshold).toBe(23800); // 25300 - 1500
+    expect(r.newBalance).toBe(25200);
+  });
+
+  it('sequência de wins: peak vai subindo a cada um', () => {
+    let state = freshState(tpl);
+    let balance = accountSize;
+    const wins = [100, 200, 150, 300];
+    for (const w of wins) {
+      const r = calculateDrawdownState({
+        propFirm: state, template: tpl, accountSize,
+        balanceBefore: balance, tradeNet: w, tradeDate: '2026-04-09'
+      });
+      state = { ...state, ...r };
+      balance = r.newBalance;
+    }
+    expect(state.peakBalance).toBe(25750); // 25K + 750
+    expect(state.currentDrawdownThreshold).toBe(24250); // 25750 - 1500
+  });
+
+  it('flag DD_NEAR quando margem < 20%', () => {
+    // peak 25K, threshold 23.5K. distância = (newBalance - 23500) / 1500
+    // queremos distância 0.10 (= 10%) → newBalance = 23500 + 150 = 23650
+    // tradeNet = 23650 - 25000 = -1350
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -1350,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.newBalance).toBe(23650);
+    expect(r.distanceToDD).toBeCloseTo(0.10, 2);
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.DD_NEAR);
+  });
+
+  it('loss até bust → ACCOUNT_BUST', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -1500, // newBalance = 23500 = threshold (≤)
+      tradeDate: '2026-04-09'
+    });
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  });
+});
+
+// ============================================
+// calculateDrawdownState — TRAILING_EOD
+// ============================================
+describe('calculateDrawdownState — TRAILING_EOD', () => {
+  const tpl = TRAILING_EOD_NO_LOCK;
+  const accountSize = 50000;
+
+  it('vários trades no MESMO dia: peak NÃO atualiza intraday', () => {
+    let state = freshState(tpl);
+    let balance = accountSize;
+
+    // 3 wins no mesmo dia
+    for (const w of [200, 300, 400]) {
+      const r = calculateDrawdownState({
+        propFirm: state, template: tpl, accountSize,
+        balanceBefore: balance, tradeNet: w, tradeDate: '2026-04-09'
+      });
+      state = { ...state, ...r };
+      balance = r.newBalance;
+    }
+
+    // peak permanece accountSize (snapshot só acontece na virada do dia)
+    expect(state.peakBalance).toBe(50000);
+    expect(state.currentDrawdownThreshold).toBe(48000); // 50K - 2K
+    expect(balance).toBe(50900);
+  });
+
+  it('virada do dia: peak snapshot do saldo de fechamento do dia anterior', () => {
+    let state = freshState(tpl);
+    let balance = accountSize;
+
+    // Dia 1: termina em +900
+    for (const w of [200, 300, 400]) {
+      const r = calculateDrawdownState({
+        propFirm: state, template: tpl, accountSize,
+        balanceBefore: balance, tradeNet: w, tradeDate: '2026-04-09'
+      });
+      state = { ...state, ...r };
+      balance = r.newBalance;
+    }
+    expect(state.peakBalance).toBe(50000); // ainda não atualizou
+
+    // Dia 2: primeiro trade — peak deve atualizar para o saldo de fechamento do dia anterior
+    const r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: balance, // 50900
+      tradeNet: 100,
+      tradeDate: '2026-04-10'
+    });
+    expect(r.peakBalance).toBe(50900); // snapshot do saldo do dia anterior
+    expect(r.currentDrawdownThreshold).toBe(48900); // 50900 - 2000
+    expect(r.tradingDays).toBe(2);
+    expect(r.isNewDay).toBe(true);
+  });
+
+  it('virada do dia com saldo MENOR não baixa o peak', () => {
+    let state = freshState(tpl);
+    // dia 1: vai pra 51K depois cai pra 50.5K
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 50000, tradeNet: 1000, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 51000, tradeNet: -500, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    // dia 2: peak snapshot do fechamento (50.5K) — mas peak começou em 50K, então max(50K, 50.5K) = 50.5K
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 50500, tradeNet: 100, tradeDate: '2026-04-10'
+    });
+    expect(r.peakBalance).toBe(50500);
+  });
+
+  it('múltiplos dias em sequência: peak escala monotonicamente', () => {
+    let state = freshState(tpl);
+    let balance = accountSize;
+    const dailyResults = [+800, +400, -200, +600];
+    const dates = ['2026-04-09', '2026-04-10', '2026-04-11', '2026-04-12'];
+
+    dailyResults.forEach((dailyNet, i) => {
+      const r = calculateDrawdownState({
+        propFirm: state, template: tpl, accountSize,
+        balanceBefore: balance, tradeNet: dailyNet, tradeDate: dates[i]
+      });
+      state = { ...state, ...r };
+      balance = r.newBalance;
+    });
+
+    // Dia 1 fechou em 50800, dia 2 em 51200, dia 3 em 51000, dia 4 em 51600
+    // Peak no início do dia 4 deveria ser max sobre fechamentos vistos: 51200
+    // No dia 4 (último processado), peak já atualizou para 51000 (fechamento do dia 3)
+    // Mas peakMax monotonicamente: 50000 → 50800 (d2) → 51200 (d3) → 51200 (d4)
+    expect(state.peakBalance).toBe(51200);
+    expect(state.tradingDays).toBe(4);
+  });
+});
+
+// ============================================
+// calculateDrawdownState — Lock (Apex EOD com lockFormula)
+// ============================================
+describe('calculateDrawdownState — Lock (Apex EOD 25K)', () => {
+  const tpl = APEX_EOD_25K;
+  const accountSize = 25000;
+
+  it('lockAt = accountSize + DD + 100 = 26100', () => {
+    expect(resolveLockAt(tpl, accountSize)).toBe(26100);
+  });
+
+  it('peak abaixo do lockAt → lockLevel ainda null', () => {
+    let state = freshState(tpl);
+    // dia 1: ganha 500 → 25500
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 25000, tradeNet: 500, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    // dia 2: snapshot peak para 25500
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 25500, tradeNet: 100, tradeDate: '2026-04-10'
+    });
+    expect(r.peakBalance).toBe(25500);
+    expect(r.lockLevel).toBeNull();
+    expect(r.flags).not.toContain(DRAWDOWN_FLAGS.LOCK_ACTIVATED);
+  });
+
+  it('peak atinge lockAt 26100 → lock ativado, threshold congela em accountSize', () => {
+    let state = freshState(tpl);
+    // dia 1: fechou em 26200 (> lockAt 26100)
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 25000, tradeNet: 1200, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    // No fim do dia 1 ainda não disparou (peak = 25000 ainda — só atualiza no dia seguinte)
+    expect(state.peakBalance).toBe(25000);
+
+    // dia 2: snapshot peak = 26200, dispara lock (>= 26100)
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 26200, tradeNet: 100, tradeDate: '2026-04-10'
+    });
+    expect(r.peakBalance).toBe(26200);
+    expect(r.lockLevel).toBe(25000); // congela em accountSize
+    expect(r.currentDrawdownThreshold).toBe(25000);
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.LOCK_ACTIVATED);
+  });
+
+  it('após lock: novos peaks não movem mais o threshold', () => {
+    let state = freshState(tpl);
+    // ativa o lock
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 25000, tradeNet: 1500, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 26500, tradeNet: 100, tradeDate: '2026-04-10'
+    });
+    state = { ...state, ...r };
+    expect(state.lockLevel).toBe(25000);
+    expect(state.currentDrawdownThreshold).toBe(25000);
+
+    // Mais wins não devem mover o threshold
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 26600, tradeNet: 500, tradeDate: '2026-04-10'
+    });
+    expect(r.lockLevel).toBe(25000);
+    expect(r.currentDrawdownThreshold).toBe(25000);
+    expect(r.flags).not.toContain(DRAWDOWN_FLAGS.LOCK_ACTIVATED); // já estava ativo
+  });
+});
+
+// ============================================
+// calculateDrawdownState — Daily Loss (soft)
+// ============================================
+describe('calculateDrawdownState — Daily Loss', () => {
+  const tpl = APEX_EOD_25K; // dailyLossLimit = 500
+  const accountSize = 25000;
+
+  it('dailyPnL > -limit: isDayPaused false', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -300,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.dailyPnL).toBe(-300);
+    expect(r.isDayPaused).toBe(false);
+    expect(r.flags).not.toContain(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+  });
+
+  it('dailyPnL = -limit exato: isDayPaused true', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -500,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.dailyPnL).toBe(-500);
+    expect(r.isDayPaused).toBe(true);
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+  });
+
+  it('soma cumulativa atinge limite: isDayPaused true', () => {
+    let state = freshState(tpl);
+    // -200 -200 -150 = -550 ≤ -500
+    let balance = 25000;
+    let r;
+    for (const net of [-200, -200, -150]) {
+      r = calculateDrawdownState({
+        propFirm: state, template: tpl, accountSize,
+        balanceBefore: balance, tradeNet: net, tradeDate: '2026-04-09'
+      });
+      state = { ...state, ...r };
+      balance = r.newBalance;
+    }
+    expect(state.dailyPnL).toBe(-550);
+    expect(state.isDayPaused).toBe(true);
+  });
+
+  it('reset no dia seguinte: isDayPaused false e dailyPnL zera', () => {
+    let state = freshState(tpl);
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 25000, tradeNet: -500, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    expect(state.isDayPaused).toBe(true);
+
+    // Próximo dia
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: 24500, tradeNet: 100, tradeDate: '2026-04-10'
+    });
+    expect(r.isDayPaused).toBe(false);
+    expect(r.dailyPnL).toBe(100); // só este trade
+    expect(r.tradingDays).toBe(2);
+  });
+
+  it('template sem dailyLossLimit: nunca pausa o dia', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(NO_DAILY_LOSS_TEMPLATE),
+      template: NO_DAILY_LOSS_TEMPLATE,
+      accountSize: 50000,
+      balanceBefore: 50000,
+      tradeNet: -2000,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.isDayPaused).toBe(false);
+    expect(r.flags).not.toContain(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+  });
+});
+
+// ============================================
+// calculateDrawdownState — distanceToDD
+// ============================================
+describe('calculateDrawdownState — distanceToDD', () => {
+  const tpl = APEX_INTRADAY_25K; // DD 1500
+  const accountSize = 25000;
+
+  it('inicial: distância 100% (1.0)', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: 0,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.distanceToDD).toBe(1);
+  });
+
+  it('loss de metade do DD: distância ~50%', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -750,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.distanceToDD).toBeCloseTo(0.5, 2);
+  });
+
+  it('distância < 20% → flag DD_NEAR', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -1300, // distância (23700-23500)/1500 = 0.133
+      tradeDate: '2026-04-09'
+    });
+    expect(r.distanceToDD).toBeLessThan(DD_NEAR_THRESHOLD);
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.DD_NEAR);
+  });
+
+  it('distância exatamente 20%: SEM flag (threshold é estrito <)', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -1200, // distância 0.20 exato
+      tradeDate: '2026-04-09'
+    });
+    expect(r.distanceToDD).toBeCloseTo(0.2, 2);
+    expect(r.flags).not.toContain(DRAWDOWN_FLAGS.DD_NEAR);
+  });
+
+  it('bust → distância 0', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize,
+      balanceBefore: 25000,
+      tradeNet: -1500,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.distanceToDD).toBe(0);
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  });
+});
+
+// ============================================
+// calculateDrawdownState — edge cases / validações
+// ============================================
+describe('calculateDrawdownState — edge cases', () => {
+  const tpl = APEX_INTRADAY_25K;
+
+  it('lança erro sem template.drawdown', () => {
+    expect(() => calculateDrawdownState({
+      propFirm: {}, template: null, accountSize: 25000,
+      balanceBefore: 25000, tradeNet: 0, tradeDate: '2026-04-09'
+    })).toThrow();
+  });
+
+  it('lança erro sem accountSize válido', () => {
+    expect(() => calculateDrawdownState({
+      propFirm: {}, template: tpl, accountSize: 0,
+      balanceBefore: 25000, tradeNet: 0, tradeDate: '2026-04-09'
+    })).toThrow();
+  });
+
+  it('lança erro sem tradeDate', () => {
+    expect(() => calculateDrawdownState({
+      propFirm: {}, template: tpl, accountSize: 25000,
+      balanceBefore: 25000, tradeNet: 0, tradeDate: null
+    })).toThrow();
+  });
+
+  it('primeiro trade ever (lastTradeDate null): isNewDay true, tradingDays 1', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize: 25000,
+      balanceBefore: 25000,
+      tradeNet: 100,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.isNewDay).toBe(true);
+    expect(r.tradingDays).toBe(1);
+    expect(r.dailyPnL).toBe(100);
+  });
+
+  it('mesmo dia (segundo trade): isNewDay false, tradingDays não incrementa', () => {
+    let state = freshState(tpl);
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize: 25000,
+      balanceBefore: 25000, tradeNet: 100, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize: 25000,
+      balanceBefore: 25100, tradeNet: 200, tradeDate: '2026-04-09'
+    });
+    expect(r.isNewDay).toBe(false);
+    expect(r.tradingDays).toBe(1); // ainda 1
+    expect(r.dailyPnL).toBe(300); // soma dos dois
+  });
+
+  it('tradeNet 0: estado quase imutável, mas tradingDays incrementa se isNewDay', () => {
+    const r = calculateDrawdownState({
+      propFirm: freshState(tpl),
+      template: tpl,
+      accountSize: 25000,
+      balanceBefore: 25000,
+      tradeNet: 0,
+      tradeDate: '2026-04-09'
+    });
+    expect(r.newBalance).toBe(25000);
+    expect(r.dailyPnL).toBe(0);
+    expect(r.tradingDays).toBe(1);
+  });
+});
+
+// ============================================
+// calculateEvalDaysRemaining + isEvalDeadlineNear
+// ============================================
+describe('calculateEvalDaysRemaining', () => {
+  it('deadline em 10 dias corridos: retorna 10', () => {
+    const start = new Date('2026-04-09');
+    const now = new Date('2026-04-09');
+    expect(calculateEvalDaysRemaining(start, 10, now)).toBe(10);
+  });
+
+  it('5 dias após início, eval 30: retorna 25', () => {
+    const start = new Date('2026-04-01');
+    const now = new Date('2026-04-06');
+    expect(calculateEvalDaysRemaining(start, 30, now)).toBe(25);
+  });
+
+  it('expirado: retorna 0 (não negativo)', () => {
+    const start = new Date('2026-03-01');
+    const now = new Date('2026-04-09');
+    expect(calculateEvalDaysRemaining(start, 30, now)).toBe(0);
+  });
+
+  it('inputs inválidos: retorna null', () => {
+    expect(calculateEvalDaysRemaining(null, 30)).toBeNull();
+    expect(calculateEvalDaysRemaining('2026-04-01', 0)).toBeNull();
+    expect(calculateEvalDaysRemaining('not-a-date', 30)).toBeNull();
+  });
+
+  it('aceita string ISO', () => {
+    const now = new Date('2026-04-09');
+    expect(calculateEvalDaysRemaining('2026-04-01', 30, now)).toBe(22);
+  });
+});
+
+describe('isEvalDeadlineNear', () => {
+  it('null/undefined → false', () => {
+    expect(isEvalDeadlineNear(null)).toBe(false);
+    expect(isEvalDeadlineNear(undefined)).toBe(false);
+  });
+
+  it('expirado (0) → false (não é "near", já passou)', () => {
+    expect(isEvalDeadlineNear(0)).toBe(false);
+  });
+
+  it('5 dias com threshold 7 → true', () => {
+    expect(isEvalDeadlineNear(5, 7)).toBe(true);
+  });
+
+  it('7 dias com threshold 7 → true (limite incluso)', () => {
+    expect(isEvalDeadlineNear(7, 7)).toBe(true);
+  });
+
+  it('10 dias com threshold 7 → false', () => {
+    expect(isEvalDeadlineNear(10, 7)).toBe(false);
+  });
+});
+
+// ============================================
+// Cenário integrado — Apex 25K eval realista
+// ============================================
+describe('Cenário integrado — Apex EOD 25K eval realista', () => {
+  it('5 dias de trading com mix de wins/losses, sem disparar nada', () => {
+    const tpl = APEX_EOD_25K;
+    const accountSize = 25000;
+    let state = freshState(tpl);
+    let balance = accountSize;
+
+    const days = [
+      { date: '2026-04-09', trades: [+150, +100] },     // +250
+      { date: '2026-04-10', trades: [-200, +300] },     // +100
+      { date: '2026-04-13', trades: [+200] },            // +200
+      { date: '2026-04-14', trades: [-100, -150] },     // -250
+      { date: '2026-04-15', trades: [+250, +200] }      // +450
+    ];
+
+    for (const day of days) {
+      for (const net of day.trades) {
+        const r = calculateDrawdownState({
+          propFirm: state, template: tpl, accountSize,
+          balanceBefore: balance, tradeNet: net, tradeDate: day.date
+        });
+        state = { ...state, ...r };
+        balance = r.newBalance;
+      }
+    }
+
+    expect(balance).toBe(25750); // 25K + 750
+    expect(state.tradingDays).toBe(5);
+    expect(state.peakBalance).toBeGreaterThan(25000);
+    expect(state.lockLevel).toBeNull(); // longe do lockAt 26100
+    expect(state.flags).not.toContain(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+    expect(state.flags).not.toContain(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+  });
+
+  it('dia ruim que estoura daily loss + bust no mesmo dia', () => {
+    const tpl = APEX_EOD_25K;
+    const accountSize = 25000;
+    let state = freshState(tpl);
+    let balance = accountSize;
+
+    // -300 -250 = -550 (estoura daily loss)
+    let r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: balance, tradeNet: -300, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    balance = r.newBalance;
+    expect(state.isDayPaused).toBe(false);
+
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: balance, tradeNet: -250, tradeDate: '2026-04-09'
+    });
+    state = { ...state, ...r };
+    balance = r.newBalance;
+    expect(state.isDayPaused).toBe(true);
+    expect(state.flags).toContain(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+
+    // Trader segue operando mesmo com isDayPaused (engine não bloqueia)
+    // Trade adicional empurra para bust: balance 24450 → -500 = 23950
+    // threshold inicial 24000, então 23950 < 24000 → bust
+    r = calculateDrawdownState({
+      propFirm: state, template: tpl, accountSize,
+      balanceBefore: balance, tradeNet: -500, tradeDate: '2026-04-09'
+    });
+    expect(r.flags).toContain(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  });
+});

--- a/src/components/AddAccountModal.jsx
+++ b/src/components/AddAccountModal.jsx
@@ -20,7 +20,7 @@ import {
   PROP_FIRM_PHASE_LABELS,
   ATTACK_PLAN_PROFILES,
   ATTACK_PLAN_PROFILE_LABELS,
-  DEFAULT_TEMPLATES,
+  DEFAULT_TEMPLATES_ENRICHED,
   getTemplatesByFirm as groupByFirm
 } from '../constants/propFirmDefaults';
 import { calculateAttackPlan } from '../utils/attackPlanCalculator';
@@ -35,9 +35,9 @@ const AddAccountModal = ({
   const { brokers, currencies, loading: masterDataLoading } = useMasterData();
   const { templates: firestoreTemplates } = usePropFirmTemplates();
 
-  // Fallback: se Firestore está vazio, usar DEFAULT_TEMPLATES
+  // Fallback: se Firestore está vazio, usar DEFAULT_TEMPLATES_ENRICHED (com restrictedInstruments derivado)
   const allTemplates = useMemo(
-    () => firestoreTemplates.length > 0 ? firestoreTemplates : DEFAULT_TEMPLATES,
+    () => firestoreTemplates.length > 0 ? firestoreTemplates : DEFAULT_TEMPLATES_ENRICHED,
     [firestoreTemplates]
   );
 
@@ -432,26 +432,24 @@ const AddAccountModal = ({
                   </div>
                 )}
 
-                {/* Preview do plano de ataque */}
-                {attackPlan && (
+                {/* Preview do plano de ataque (Fase 1.5: instrument-aware, modo abstract) */}
+                {attackPlan && attackPlan.mode === 'abstract' && (
                   <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
                     <div className="flex items-center gap-1 mb-2">
                       <Info className="w-3 h-3 text-slate-400" />
-                      <span className="text-xs text-slate-400">Plano de ataque sugerido (baseado em defaults)</span>
+                      <span className="text-xs text-slate-400">Constraints da mesa (sem instrumento)</span>
                     </div>
                     <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-                      <div className="text-slate-500">RO por trade:</div>
-                      <div className="text-slate-300">${attackPlan.roPerTrade.toFixed(2)}</div>
-                      <div className="text-slate-500">Stop por trade:</div>
-                      <div className="text-slate-300">${attackPlan.stopPerTrade.toFixed(2)}</div>
+                      <div className="text-slate-500">DD total:</div>
+                      <div className="text-slate-300">${attackPlan.drawdownMax?.toLocaleString() ?? '—'}</div>
+                      <div className="text-slate-500">Daily loss:</div>
+                      <div className="text-slate-300">${attackPlan.dailyLossLimit?.toLocaleString() ?? '—'}</div>
+                      <div className="text-slate-500">Profit target:</div>
+                      <div className="text-slate-300">${attackPlan.profitTarget?.toLocaleString() ?? '—'}</div>
+                      <div className="text-slate-500">Meta diária:</div>
+                      <div className="text-slate-300">${attackPlan.dailyTarget?.toLocaleString() ?? '—'}</div>
                       <div className="text-slate-500">RR mínimo:</div>
                       <div className="text-slate-300">{attackPlan.rrMinimum}:1</div>
-                      <div className="text-slate-500">Max trades/dia:</div>
-                      <div className="text-slate-300">{attackPlan.maxTradesPerDay}</div>
-                      <div className="text-slate-500">Target diário:</div>
-                      <div className="text-slate-300">${attackPlan.dailyTarget.toFixed(2)}</div>
-                      <div className="text-slate-500">Dias estimados:</div>
-                      <div className="text-slate-300">{attackPlan.daysToTarget} dias ({attackPlan.bufferDays} de margem)</div>
                       <div className="text-slate-500">Sizing:</div>
                       <div className="text-slate-400 italic text-[10px]">a definir conforme instrumento</div>
                     </div>

--- a/src/components/AddAccountModal.jsx
+++ b/src/components/AddAccountModal.jsx
@@ -18,8 +18,9 @@ import {
   PROP_FIRM_LABELS,
   PROP_FIRM_PHASES,
   PROP_FIRM_PHASE_LABELS,
-  ATTACK_PLAN_PROFILES,
-  ATTACK_PLAN_PROFILE_LABELS,
+  ATTACK_PROFILES,
+  DEFAULT_ATTACK_PROFILE,
+  normalizeAttackProfile,
   DEFAULT_TEMPLATES_ENRICHED,
   getTemplatesByFirm as groupByFirm
 } from '../constants/propFirmDefaults';
@@ -54,7 +55,7 @@ const AddAccountModal = ({
     selectedFirm: '',
     selectedTemplateId: '',
     phase: PROP_FIRM_PHASES.EVALUATION,
-    attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE
+    attackProfile: DEFAULT_ATTACK_PROFILE
   });
 
   const [errors, setErrors] = useState({});
@@ -114,7 +115,7 @@ const AddAccountModal = ({
           selectedFirm: editAccount.propFirm.firmName || '',
           selectedTemplateId: editAccount.propFirm.templateId || '',
           phase: editAccount.propFirm.phase || PROP_FIRM_PHASES.EVALUATION,
-          attackProfile: editAccount.propFirm.suggestedPlan?.profile || ATTACK_PLAN_PROFILES.CONSERVATIVE
+          attackProfile: normalizeAttackProfile(editAccount.propFirm.suggestedPlan?.profile)
         });
       }
     } else {
@@ -129,7 +130,7 @@ const AddAccountModal = ({
         selectedFirm: '',
         selectedTemplateId: '',
         phase: PROP_FIRM_PHASES.EVALUATION,
-        attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE
+        attackProfile: DEFAULT_ATTACK_PROFILE
       });
     }
     setErrors({});
@@ -407,28 +408,36 @@ const AddAccountModal = ({
                   </select>
                 </div>
 
-                {/* Perfil do plano de ataque */}
+                {/* Perfil do plano de ataque (5 perfis) */}
                 {selectedTemplate && (
                   <div className="input-group">
                     <label className="input-label text-xs">Perfil do Plano de Ataque</label>
-                    <div className="grid grid-cols-2 gap-2">
-                      {Object.entries(ATTACK_PLAN_PROFILE_LABELS).map(([key, label]) => (
-                        <button
-                          key={key}
-                          type="button"
-                          onClick={() => setPropFirmData(prev => ({ ...prev, attackProfile: key }))}
-                          className={`p-2 rounded-lg border text-xs font-medium transition-all ${
-                            propFirmData.attackProfile === key
-                              ? key === 'conservative'
-                                ? 'bg-blue-500/20 border-blue-500/50 text-blue-300'
-                                : 'bg-orange-500/20 border-orange-500/50 text-orange-300'
-                              : 'bg-slate-800/50 border-slate-700/50 text-slate-400 hover:bg-slate-700/50'
-                          }`}
-                        >
-                          {label}
-                        </button>
-                      ))}
+                    <div className="grid grid-cols-5 gap-1.5">
+                      {Object.values(ATTACK_PROFILES).map((p) => {
+                        const selected = propFirmData.attackProfile === p.code;
+                        const isCons = p.family === 'conservative';
+                        return (
+                          <button
+                            key={p.code}
+                            type="button"
+                            onClick={() => setPropFirmData(prev => ({ ...prev, attackProfile: p.code }))}
+                            title={`${p.name} — ${p.description}\nRO: ${(p.roPct * 100).toFixed(0)}% do DD · ${p.maxTradesPerDay} trade(s)/dia\n${p.idealFor}`}
+                            className={`p-1.5 rounded-md border text-[10px] font-semibold transition-all ${
+                              selected
+                                ? (isCons ? 'bg-blue-500/20 border-blue-500/60 text-blue-200' : 'bg-orange-500/20 border-orange-500/60 text-orange-200')
+                                : 'bg-slate-800/50 border-slate-700/50 text-slate-400 hover:bg-slate-700/50'
+                            }`}
+                          >
+                            <div>{(p.roPct * 100).toFixed(0)}%</div>
+                            <div className="text-[9px] opacity-70 mt-0.5">{p.code}</div>
+                            {p.recommended && <div className="text-[8px] text-emerald-400 mt-0.5">★</div>}
+                          </button>
+                        );
+                      })}
                     </div>
+                    <p className="text-[10px] text-slate-500 mt-1">
+                      {ATTACK_PROFILES[propFirmData.attackProfile]?.description ?? ''}
+                    </p>
                   </div>
                 )}
 

--- a/src/components/AddAccountModal.jsx
+++ b/src/components/AddAccountModal.jsx
@@ -1,16 +1,29 @@
-import { useState, useEffect } from 'react';
-import { 
-  X, 
-  Loader2, 
+import { useState, useEffect, useMemo } from 'react';
+import {
+  X,
+  Loader2,
   AlertCircle,
   Wallet,
   Building2,
   Coins,
   Tag,
-  DollarSign
+  DollarSign,
+  Trophy,
+  Info
 } from 'lucide-react';
 import { ACCOUNT_TYPES } from '../firebase';
 import { useMasterData } from '../hooks/useMasterData';
+import { usePropFirmTemplates } from '../hooks/usePropFirmTemplates';
+import {
+  PROP_FIRM_LABELS,
+  PROP_FIRM_PHASES,
+  PROP_FIRM_PHASE_LABELS,
+  ATTACK_PLAN_PROFILES,
+  ATTACK_PLAN_PROFILE_LABELS,
+  DEFAULT_TEMPLATES,
+  getTemplatesByFirm as groupByFirm
+} from '../constants/propFirmDefaults';
+import { calculateAttackPlan } from '../utils/attackPlanCalculator';
 
 const AddAccountModal = ({ 
   isOpen, 
@@ -20,7 +33,14 @@ const AddAccountModal = ({
   loading = false 
 }) => {
   const { brokers, currencies, loading: masterDataLoading } = useMasterData();
-  
+  const { templates: firestoreTemplates } = usePropFirmTemplates();
+
+  // Fallback: se Firestore está vazio, usar DEFAULT_TEMPLATES
+  const allTemplates = useMemo(
+    () => firestoreTemplates.length > 0 ? firestoreTemplates : DEFAULT_TEMPLATES,
+    [firestoreTemplates]
+  );
+
   const [formData, setFormData] = useState({
     name: '',
     broker: '',
@@ -28,8 +48,56 @@ const AddAccountModal = ({
     initialBalance: '',
     currency: 'BRL',
   });
-  
+
+  // Prop firm state (separado para clareza)
+  const [propFirmData, setPropFirmData] = useState({
+    selectedFirm: '',
+    selectedTemplateId: '',
+    phase: PROP_FIRM_PHASES.EVALUATION,
+    attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE
+  });
+
   const [errors, setErrors] = useState({});
+
+  // Templates agrupados por firma
+  const firmGroups = useMemo(() => groupByFirm(allTemplates), [allTemplates]);
+  const firmList = useMemo(() => Object.keys(firmGroups), [firmGroups]);
+  const productsForFirm = useMemo(
+    () => firmGroups[propFirmData.selectedFirm] ?? [],
+    [firmGroups, propFirmData.selectedFirm]
+  );
+  const selectedTemplate = useMemo(
+    () => allTemplates.find(t => t.id === propFirmData.selectedTemplateId) ?? null,
+    [allTemplates, propFirmData.selectedTemplateId]
+  );
+
+  // Plano de ataque calculado (sem 4D/indicadores na criação — usa defaults)
+  const attackPlan = useMemo(() => {
+    if (!selectedTemplate) return null;
+    try {
+      return calculateAttackPlan(
+        selectedTemplate,
+        null,
+        null,
+        propFirmData.attackProfile,
+        propFirmData.phase
+      );
+    } catch {
+      return null;
+    }
+  }, [selectedTemplate, propFirmData.attackProfile, propFirmData.phase]);
+
+  // Auto-fill currency (USD), balance (accountSize) e nome quando template selecionado
+  useEffect(() => {
+    if (selectedTemplate && formData.type === 'PROP') {
+      setFormData(prev => ({
+        ...prev,
+        currency: 'USD',
+        initialBalance: selectedTemplate.accountSize?.toString() ?? prev.initialBalance,
+        name: prev.name || selectedTemplate.name
+      }));
+    }
+  }, [selectedTemplate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Preencher dados para edição
   useEffect(() => {
@@ -41,14 +109,27 @@ const AddAccountModal = ({
         initialBalance: editAccount.initialBalance?.toString() || '',
         currency: editAccount.currency || 'BRL',
       });
+      if (editAccount.propFirm) {
+        setPropFirmData({
+          selectedFirm: editAccount.propFirm.firmName || '',
+          selectedTemplateId: editAccount.propFirm.templateId || '',
+          phase: editAccount.propFirm.phase || PROP_FIRM_PHASES.EVALUATION,
+          attackProfile: editAccount.propFirm.suggestedPlan?.profile || ATTACK_PLAN_PROFILES.CONSERVATIVE
+        });
+      }
     } else {
-      // Reset form
       setFormData({
         name: '',
         broker: '',
         type: 'REAL',
         initialBalance: '',
         currency: 'BRL',
+      });
+      setPropFirmData({
+        selectedFirm: '',
+        selectedTemplateId: '',
+        phase: PROP_FIRM_PHASES.EVALUATION,
+        attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE
       });
     }
     setErrors({});
@@ -80,13 +161,18 @@ const AddAccountModal = ({
       newErrors.initialBalance = 'Saldo não pode ser negativo';
     }
 
+    // Validação prop firm
+    if (formData.type === 'PROP' && !propFirmData.selectedTemplateId) {
+      newErrors.propFirm = 'Selecione a mesa e o produto';
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
     if (!validate()) return;
 
     try {
@@ -94,7 +180,23 @@ const AddAccountModal = ({
         ...formData,
         initialBalance: parseFloat(formData.initialBalance),
       };
-      
+
+      // Montar propFirm se tipo PROP
+      if (formData.type === 'PROP' && selectedTemplate) {
+        const evalDays = selectedTemplate.evalTimeLimit;
+        accountData.propFirm = {
+          templateId: selectedTemplate.id,
+          firmName: selectedTemplate.firm,
+          productName: selectedTemplate.name,
+          phase: propFirmData.phase,
+          drawdownMax: selectedTemplate.drawdown?.maxAmount ?? 0,
+          evalDeadline: evalDays
+            ? new Date(Date.now() + evalDays * 24 * 60 * 60 * 1000).toISOString()
+            : null,
+          suggestedPlan: attackPlan
+        };
+      }
+
       await onSubmit(accountData, editAccount?.id);
       onClose();
     } catch (err) {
@@ -242,6 +344,136 @@ const AddAccountModal = ({
                 {accountTypeConfig[formData.type]?.description}
               </p>
             </div>
+
+            {/* Prop Firm — seletor condicional (#52) */}
+            {console.log('[AddAccountModal] formData.type:', formData.type, '| isPROP:', formData.type === 'PROP', '| firmList:', firmList)}
+            {formData.type === 'PROP' && (
+              <div className="mb-4 p-4 bg-purple-500/5 border border-purple-500/20 rounded-xl space-y-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Trophy className="w-4 h-4 text-purple-400" />
+                  <span className="text-sm font-medium text-purple-300">Configuração da Mesa</span>
+                </div>
+
+                {/* Firma */}
+                <div className="input-group">
+                  <label className="input-label text-xs">Mesa Proprietária *</label>
+                  <select
+                    value={propFirmData.selectedFirm}
+                    onChange={(e) => setPropFirmData(prev => ({
+                      ...prev,
+                      selectedFirm: e.target.value,
+                      selectedTemplateId: ''
+                    }))}
+                    className={errors.propFirm ? 'ring-2 ring-red-500/50' : ''}
+                  >
+                    <option value="">Selecione a mesa</option>
+                    {firmList.map(firm => (
+                      <option key={firm} value={firm}>
+                        {PROP_FIRM_LABELS[firm] ?? firm}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Produto */}
+                {propFirmData.selectedFirm && (
+                  <div className="input-group">
+                    <label className="input-label text-xs">Produto *</label>
+                    <select
+                      value={propFirmData.selectedTemplateId}
+                      onChange={(e) => setPropFirmData(prev => ({
+                        ...prev,
+                        selectedTemplateId: e.target.value
+                      }))}
+                    >
+                      <option value="">Selecione o produto</option>
+                      {productsForFirm.map(t => (
+                        <option key={t.id} value={t.id}>{t.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
+                {/* Fase */}
+                <div className="input-group">
+                  <label className="input-label text-xs">Fase da Conta</label>
+                  <select
+                    value={propFirmData.phase}
+                    onChange={(e) => setPropFirmData(prev => ({ ...prev, phase: e.target.value }))}
+                  >
+                    {Object.entries(PROP_FIRM_PHASE_LABELS).map(([key, label]) => (
+                      <option key={key} value={key}>{label}</option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Perfil do plano de ataque */}
+                {selectedTemplate && (
+                  <div className="input-group">
+                    <label className="input-label text-xs">Perfil do Plano de Ataque</label>
+                    <div className="grid grid-cols-2 gap-2">
+                      {Object.entries(ATTACK_PLAN_PROFILE_LABELS).map(([key, label]) => (
+                        <button
+                          key={key}
+                          type="button"
+                          onClick={() => setPropFirmData(prev => ({ ...prev, attackProfile: key }))}
+                          className={`p-2 rounded-lg border text-xs font-medium transition-all ${
+                            propFirmData.attackProfile === key
+                              ? key === 'conservative'
+                                ? 'bg-blue-500/20 border-blue-500/50 text-blue-300'
+                                : 'bg-orange-500/20 border-orange-500/50 text-orange-300'
+                              : 'bg-slate-800/50 border-slate-700/50 text-slate-400 hover:bg-slate-700/50'
+                          }`}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Preview do plano de ataque */}
+                {attackPlan && (
+                  <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
+                    <div className="flex items-center gap-1 mb-2">
+                      <Info className="w-3 h-3 text-slate-400" />
+                      <span className="text-xs text-slate-400">Plano de ataque sugerido (baseado em defaults)</span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                      <div className="text-slate-500">RO por trade:</div>
+                      <div className="text-slate-300">${attackPlan.roPerTrade.toFixed(2)}</div>
+                      <div className="text-slate-500">Stop por trade:</div>
+                      <div className="text-slate-300">${attackPlan.stopPerTrade.toFixed(2)}</div>
+                      <div className="text-slate-500">RR mínimo:</div>
+                      <div className="text-slate-300">{attackPlan.rrMinimum}:1</div>
+                      <div className="text-slate-500">Max trades/dia:</div>
+                      <div className="text-slate-300">{attackPlan.maxTradesPerDay}</div>
+                      <div className="text-slate-500">Target diário:</div>
+                      <div className="text-slate-300">${attackPlan.dailyTarget.toFixed(2)}</div>
+                      <div className="text-slate-500">Dias estimados:</div>
+                      <div className="text-slate-300">{attackPlan.daysToTarget} dias ({attackPlan.bufferDays} de margem)</div>
+                      <div className="text-slate-500">Sizing:</div>
+                      <div className="text-slate-400 italic text-[10px]">a definir conforme instrumento</div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Template info */}
+                {selectedTemplate && (
+                  <div className="text-xs text-slate-500 space-y-0.5">
+                    <div>DD máx: ${selectedTemplate.drawdown?.maxAmount?.toLocaleString()} ({selectedTemplate.drawdown?.type})</div>
+                    <div>Target: ${selectedTemplate.profitTarget?.toLocaleString()}</div>
+                    {selectedTemplate.evalTimeLimit && <div>Prazo eval: {selectedTemplate.evalTimeLimit} dias corridos</div>}
+                    {selectedTemplate.dailyLossLimit && <div>Daily loss: ${selectedTemplate.dailyLossLimit?.toLocaleString()}</div>}
+                    {selectedTemplate.restrictedInstruments?.length > 0 && (
+                      <div className="text-amber-400/80">⚠ Instrumentos restritos: {selectedTemplate.restrictedInstruments.join(', ')}</div>
+                    )}
+                  </div>
+                )}
+
+                {errors.propFirm && <span className="text-xs text-red-400">{errors.propFirm}</span>}
+              </div>
+            )}
 
             {/* Corretora */}
             <div className="input-group mb-4">

--- a/src/components/PlanManagementModal.jsx
+++ b/src/components/PlanManagementModal.jsx
@@ -95,14 +95,29 @@ const PlanManagementModal = ({
     }
   }, [isOpen, editingPlan, accounts, defaultAccountId]);
 
-  const selectedAccount = useMemo(() => 
-    accounts.find(a => a.id === formData.accountId), 
+  const selectedAccount = useMemo(() =>
+    accounts.find(a => a.id === formData.accountId),
     [accounts, formData.accountId]
   );
 
+  // Currency: tenta da conta carregada, senão do editingPlan (defaults pré-criação)
+  const accountCurrency = selectedAccount?.currency || editingPlan?.currency || 'BRL';
+  const currencySymbol = accountCurrency === 'USD' ? 'US$' : accountCurrency === 'EUR' ? '€' : 'R$';
+
   const availableCapital = useMemo(() => {
-    if (!selectedAccount) return 0;
-    const currentPlanPl = editingPlan && editingPlan.accountId === selectedAccount.id ? (editingPlan.pl || 0) : 0;
+    if (!selectedAccount) {
+      // Conta ainda não apareceu no snapshot — usa pl do editingPlan (defaults pós-criação)
+      return editingPlan?.pl ?? 0;
+    }
+    // Defaults pré-preenchidos (criação pós-conta PROP) — NÃO devolver pl ao freePl
+    // Sem essa guard, o cálculo dobraria o saldo (freePl + propPlanDefaults.pl).
+    if (editingPlan && editingPlan.__isDefaults) {
+      return getAvailablePl(selectedAccount.id, selectedAccount.currentBalance);
+    }
+    // Edição real de plano existente — devolver o pl ocupado por este plano ao free
+    const currentPlanPl = editingPlan && editingPlan.id && editingPlan.accountId === selectedAccount.id
+      ? (editingPlan.pl || 0)
+      : 0;
     const freePl = getAvailablePl(selectedAccount.id, selectedAccount.currentBalance);
     return freePl + currentPlanPl;
   }, [selectedAccount, getAvailablePl, editingPlan]);
@@ -134,7 +149,7 @@ const PlanManagementModal = ({
       if (isInvalidNum(formData.pl)) {
         newErrors.pl = 'Capital inválido';
       } else if (plValue > availableCapital + 0.1) {
-         newErrors.pl = `Saldo insuficiente (Disp: ${formatCurrency(availableCapital)})`;
+         newErrors.pl = `Saldo insuficiente (Disp: ${formatCurrency(availableCapital, accountCurrency)})`;
       }
     }
 
@@ -265,12 +280,12 @@ const PlanManagementModal = ({
                   <div className="col-span-2 bg-slate-800/50 p-4 rounded-xl border border-slate-700/50">
                     <label className="input-label flex justify-between mb-2">
                       <span className="flex items-center gap-2"><Wallet className="w-4 h-4 text-emerald-400"/> Capital Alocado (PL)</span>
-                      <span className="text-xs text-emerald-400 font-mono">Disponível: {formatCurrency(availableCapital)}</span>
+                      <span className="text-xs text-emerald-400 font-mono">Disponível: {formatCurrency(availableCapital, accountCurrency)}</span>
                     </label>
                     
                     <div className={`flex items-stretch rounded-lg overflow-hidden border ${errors.pl ? 'border-red-500' : 'border-slate-600'}`}>
                       <div className="bg-slate-700/50 px-4 flex items-center justify-center border-r border-slate-600">
-                        <span className="text-slate-300 font-bold">R$</span>
+                        <span className="text-slate-300 font-bold">{currencySymbol}</span>
                       </div>
                       <input type="number" name="pl" value={formData.pl} onChange={handleChange} className="flex-1 bg-slate-900 text-white p-3 outline-none font-bold text-lg" placeholder="0.00" />
                     </div>
@@ -350,18 +365,18 @@ const PlanManagementModal = ({
                   <div className="space-y-3 text-sm bg-slate-800/30 p-4 rounded-lg">
                     <div className="flex justify-between">
                       <span className="text-slate-400">Capital (PL):</span>
-                      <span className="text-white font-mono font-bold">{formatCurrency(formData.pl)}</span>
+                      <span className="text-white font-mono font-bold">{formatCurrency(formData.pl, accountCurrency)}</span>
                     </div>
                     <div className="border-t border-slate-700/50 pt-2 mt-2">
                       <p className="text-[10px] text-slate-500 uppercase tracking-wider font-bold mb-2">Período ({formData.operationPeriod})</p>
                       <div className="grid grid-cols-2 gap-2">
                         <div className="flex justify-between">
                           <span className="text-emerald-400/70 text-xs">Meta:</span>
-                          <span className="text-emerald-400 font-mono text-xs">{formData.periodGoal}% · {formatCurrency(calcValue(formData.periodGoal))}</span>
+                          <span className="text-emerald-400 font-mono text-xs">{formData.periodGoal}% · {formatCurrency(calcValue(formData.periodGoal), accountCurrency)}</span>
                         </div>
                         <div className="flex justify-between">
                           <span className="text-red-400/70 text-xs">Stop:</span>
-                          <span className="text-red-400 font-mono text-xs">{formData.periodStop}% · -{formatCurrency(calcValue(formData.periodStop))}</span>
+                          <span className="text-red-400 font-mono text-xs">{formData.periodStop}% · -{formatCurrency(calcValue(formData.periodStop), accountCurrency)}</span>
                         </div>
                       </div>
                     </div>
@@ -370,11 +385,11 @@ const PlanManagementModal = ({
                       <div className="grid grid-cols-2 gap-2">
                         <div className="flex justify-between">
                           <span className="text-emerald-400/70 text-xs">Meta:</span>
-                          <span className="text-emerald-400 font-mono text-xs">{formData.cycleGoal}% · {formatCurrency(calcValue(formData.cycleGoal))}</span>
+                          <span className="text-emerald-400 font-mono text-xs">{formData.cycleGoal}% · {formatCurrency(calcValue(formData.cycleGoal), accountCurrency)}</span>
                         </div>
                         <div className="flex justify-between">
                           <span className="text-red-400/70 text-xs">Stop:</span>
-                          <span className="text-red-400 font-mono text-xs">{formData.cycleStop}% · -{formatCurrency(calcValue(formData.cycleStop))}</span>
+                          <span className="text-red-400 font-mono text-xs">{formData.cycleStop}% · -{formatCurrency(calcValue(formData.cycleStop), accountCurrency)}</span>
                         </div>
                       </div>
                     </div>
@@ -383,7 +398,7 @@ const PlanManagementModal = ({
                       <div className="grid grid-cols-2 gap-2">
                         <div className="flex justify-between">
                           <span className="text-amber-400/70 text-xs">RO Máx:</span>
-                          <span className="text-amber-400 font-mono text-xs">{formData.riskPerOperation}% · {formatCurrency(calcValue(formData.riskPerOperation))}</span>
+                          <span className="text-amber-400 font-mono text-xs">{formData.riskPerOperation}% · {formatCurrency(calcValue(formData.riskPerOperation), accountCurrency)}</span>
                         </div>
                         <div className="flex justify-between">
                           <span className="text-blue-400/70 text-xs">RR Mín:</span>

--- a/src/constants/instrumentsTable.js
+++ b/src/constants/instrumentsTable.js
@@ -5,8 +5,9 @@
 // Volume baixo, mudança trimestral → hardcoded em código (não em masterData).
 // Revisão trimestral recomendada para ATR.
 //
-// Ref: issue #52 Fase 1.5, Temp/instruments-table-prop-firms.md v1.0
-// Fonte ATR: estimativas baseadas em dados dos últimos 12 meses
+// Ref: issue #52 Fase 1.5, Temp/instruments-table-v2-atr-real.md v2.0
+// Fonte ATR (09/04/2026): TradingView ATR(14) diário, captura real
+// Versão v1 tinha valores ALUCINADOS (ES 55 vs real 123, GC 40 vs real 180, etc.)
 // Fonte Session Profile: AM Trades framework — dados estatísticos de sessões CME
 
 // ============================================
@@ -99,7 +100,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'ES', name: 'S&P 500 E-mini', exchange: 'CME', type: 'equity_index',
     tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
     micro: 'MES', microPointValue: 5.00, microTickValue: 1.25,
-    avgDailyRange: 55,
+    avgDailyRange: 123,
     minStopPoints: 4, // ~$200 full / ~$20 micro
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -107,7 +108,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'NQ', name: 'Nasdaq 100 E-mini', exchange: 'CME', type: 'equity_index',
     tickSize: 0.25, tickValue: 5.00, pointValue: 20.00,
     micro: 'MNQ', microPointValue: 2.00, microTickValue: 0.50,
-    avgDailyRange: 400,
+    avgDailyRange: 549,
     minStopPoints: 20, // ~$400 full / ~$40 micro
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -115,7 +116,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'YM', name: 'Dow Jones E-mini', exchange: 'CBOT', type: 'equity_index',
     tickSize: 1.00, tickValue: 5.00, pointValue: 5.00,
     micro: 'MYM', microPointValue: 0.50, microTickValue: 0.50,
-    avgDailyRange: 420,
+    avgDailyRange: 856,
     minStopPoints: 25, // ~$125 full / ~$12.50 micro
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -123,7 +124,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'RTY', name: 'Russell 2000 E-mini', exchange: 'CME', type: 'equity_index',
     tickSize: 0.10, tickValue: 5.00, pointValue: 50.00,
     micro: 'M2K', microPointValue: 5.00, microTickValue: 0.50,
-    avgDailyRange: 30,
+    avgDailyRange: 70,
     minStopPoints: 3, // ~$150 full / ~$15 micro
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -133,7 +134,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'CL', name: 'Crude Oil WTI', exchange: 'NYMEX', type: 'energy',
     tickSize: 0.01, tickValue: 10.00, pointValue: 1000.00,
     micro: 'MCL', microPointValue: 100.00, microTickValue: 1.00,
-    avgDailyRange: 2.5,
+    avgDailyRange: 9.11,
     minStopPoints: 0.20, // ~$200 full / ~$20 micro
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -141,6 +142,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'NG', name: 'Natural Gas', exchange: 'NYMEX', type: 'energy',
     tickSize: 0.001, tickValue: 10.00, pointValue: 10000.00,
     micro: null, microPointValue: null, microTickValue: null,
+    // ATR pendente de recaptura no TradingView (não incluído em v2 09/04/2026)
     avgDailyRange: 0.20,
     minStopPoints: 0.020, // ~$200
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
@@ -151,7 +153,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'GC', name: 'Gold', exchange: 'COMEX', type: 'metals',
     tickSize: 0.10, tickValue: 10.00, pointValue: 100.00,
     micro: 'MGC', microPointValue: 10.00, microTickValue: 1.00,
-    avgDailyRange: 40,
+    avgDailyRange: 180,
     minStopPoints: 3, // ~$300 full / ~$30 micro
     availability: { apex: false, mff: true, lucid: true, tradeify: true },
     note: 'Suspenso na Apex desde Abr/2026 por volatilidade extrema'
@@ -160,7 +162,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'SI', name: 'Silver', exchange: 'COMEX', type: 'metals',
     tickSize: 0.005, tickValue: 25.00, pointValue: 5000.00,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 0.60,
+    avgDailyRange: 5.69,
     minStopPoints: 0.05, // ~$250
     availability: { apex: false, mff: true, lucid: true, tradeify: true },
     note: 'Suspenso na Apex desde Abr/2026'
@@ -169,6 +171,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'HG', name: 'Copper', exchange: 'COMEX', type: 'metals',
     tickSize: 0.0005, tickValue: 12.50, pointValue: 25000.00,
     micro: null, microPointValue: null, microTickValue: null,
+    // ATR pendente de recaptura no TradingView (não incluído em v2 09/04/2026)
     avgDailyRange: 0.08,
     minStopPoints: 0.005, // ~$125
     availability: { apex: false, mff: false, lucid: true, tradeify: true },
@@ -188,7 +191,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: '6B', name: 'British Pound', exchange: 'CME', type: 'currency',
     tickSize: 0.0001, tickValue: 6.25, pointValue: 62500.00,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 0.0110,
+    avgDailyRange: 0.0117,
     minStopPoints: 0.0010, // ~$62.50
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -196,7 +199,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: '6J', name: 'Japanese Yen', exchange: 'CME', type: 'currency',
     tickSize: 0.0000005, tickValue: 6.25, pointValue: 12500000.00,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 0.00070,
+    avgDailyRange: 0.000046,
     minStopPoints: 0.000060, // ~$750
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -204,6 +207,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: '6A', name: 'Australian Dollar', exchange: 'CME', type: 'currency',
     tickSize: 0.0001, tickValue: 10.00, pointValue: 100000.00,
     micro: null, microPointValue: null, microTickValue: null,
+    // ATR pendente de recaptura no TradingView (não incluído em v2 09/04/2026)
     avgDailyRange: 0.0070,
     minStopPoints: 0.0006, // ~$60
     availability: { apex: true, mff: false, lucid: true, tradeify: false }
@@ -214,7 +218,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'ZC', name: 'Corn', exchange: 'CBOT', type: 'agriculture',
     tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 10,
+    avgDailyRange: 8.87,
     minStopPoints: 1, // ~$50
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -222,7 +226,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'ZW', name: 'Wheat', exchange: 'CBOT', type: 'agriculture',
     tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 15,
+    avgDailyRange: 17.75,
     minStopPoints: 1.5, // ~$75
     availability: { apex: true, mff: true, lucid: false, tradeify: true }
   },
@@ -230,7 +234,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'ZS', name: 'Soybeans', exchange: 'CBOT', type: 'agriculture',
     tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 18,
+    avgDailyRange: 19.15,
     minStopPoints: 2, // ~$100
     availability: { apex: true, mff: true, lucid: true, tradeify: true }
   },
@@ -240,7 +244,7 @@ export const INSTRUMENTS_TABLE = [
     symbol: 'MBT', name: 'Micro Bitcoin', exchange: 'CME', type: 'crypto',
     tickSize: 5.00, tickValue: 0.50, pointValue: 0.10,
     micro: null, microPointValue: null, microTickValue: null,
-    avgDailyRange: 4000,
+    avgDailyRange: 3201,
     minStopPoints: 200, // ~$20
     availability: { apex: true, mff: false, lucid: false, tradeify: true }
   }

--- a/src/constants/instrumentsTable.js
+++ b/src/constants/instrumentsTable.js
@@ -1,0 +1,424 @@
+// ============================================
+// INSTRUMENTS TABLE — Catálogo curado de futuros
+// ============================================
+// Tabela de referência para AI Approach Plan e calculateAttackPlan instrument-aware.
+// Volume baixo, mudança trimestral → hardcoded em código (não em masterData).
+// Revisão trimestral recomendada para ATR.
+//
+// Ref: issue #52 Fase 1.5, Temp/instruments-table-prop-firms.md v1.0
+// Fonte ATR: estimativas baseadas em dados dos últimos 12 meses
+// Fonte Session Profile: AM Trades framework — dados estatísticos de sessões CME
+
+// ============================================
+// SESSION PROFILES — distribuição estatística
+// ============================================
+
+export const SESSION_PROFILES = {
+  asia: {
+    name: 'Ásia',
+    rangePct: 0.17,
+    directionalPct: 0.58,
+    bodyRangePct: 0.40,
+    hours: '18:00-01:00 EST'
+  },
+  london: {
+    name: 'London',
+    rangePct: 0.23,
+    directionalPct: 0.62,
+    bodyRangePct: 0.55,
+    hours: '01:00-08:00 EST'
+  },
+  ny: {
+    name: 'New York',
+    rangePct: 0.60,
+    directionalPct: 0.86,
+    bodyRangePct: 0.65,
+    hours: '08:00-close EST'
+  }
+};
+
+// ============================================
+// DAILY PROFILES FRAMEWORK — padrões operacionais
+// ============================================
+// Usados pela IA (Fase 2.5) como framework operacional no plano de ataque.
+
+export const DAILY_PROFILES = {
+  ASIA_REVERSAL: {
+    id: 'ASIA_REVERSAL',
+    name: '18:00 Reversal',
+    description: 'Ásia faz high/low intraday, London expande, NY continua na direção de London',
+    action: 'NY é continuação. Entrar a favor na primeira retração. Não esperar reteste do extremo de Ásia',
+    conservative: true,
+    aggressive: true
+  },
+  LONDON_REVERSAL: {
+    id: 'LONDON_REVERSAL',
+    name: '01:00 Reversal',
+    description: 'Ásia consolida ou faz run raso contra o bias. London penetra no range de Ásia e reverte',
+    action: 'Profile ideal. London definiu o high/low do dia. NY tem expectativa direcional definida',
+    conservative: true,
+    aggressive: true
+  },
+  NY_REVERSAL: {
+    id: 'NY_REVERSAL',
+    name: '08:00 Reversal',
+    description: 'Nem Ásia nem London estabelecem reversão clara. NY forma a reversão antes de expandir',
+    action: 'Esperar NY reverter antes de entrar. Não antecipar. Exigir confirmação do mercado',
+    conservative: false, // muito arriscado para conservador
+    aggressive: true
+  },
+  INVALIDATION: {
+    id: 'INVALIDATION',
+    name: 'Invalidação',
+    description: 'Ásia + London combinadas já produziram range igual ou maior que o range diário esperado',
+    action: 'Não operar. Independente do bias ou setup. Dia perdido é melhor que conta perdida',
+    conservative: false,
+    aggressive: false
+  }
+};
+
+// ============================================
+// CONSTANTES DE STOP NATURAL
+// ============================================
+// Stop natural em pontos para um setup viável no instrumento.
+// Fórmula: max(ATR × STOP_PERCENT_OF_ATR, minStopPoints da tabela).
+// Razão: ATR escala com volatilidade real, minStop garante chão para casos de baixa volatilidade.
+
+export const STOP_PERCENT_OF_ATR = 0.05; // 5% do ATR diário
+
+// ============================================
+// TABELA DE INSTRUMENTOS
+// ============================================
+// Cada entrada representa o instrumento "full size".
+// Micro variants (quando existem) compartilham ATR e minStopPoints,
+// diferindo apenas em pointValue e tickValue.
+
+export const INSTRUMENTS_TABLE = [
+  // ==================== EQUITY INDEX ====================
+  {
+    symbol: 'ES', name: 'S&P 500 E-mini', exchange: 'CME', type: 'equity_index',
+    tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
+    micro: 'MES', microPointValue: 5.00, microTickValue: 1.25,
+    avgDailyRange: 55,
+    minStopPoints: 4, // ~$200 full / ~$20 micro
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: 'NQ', name: 'Nasdaq 100 E-mini', exchange: 'CME', type: 'equity_index',
+    tickSize: 0.25, tickValue: 5.00, pointValue: 20.00,
+    micro: 'MNQ', microPointValue: 2.00, microTickValue: 0.50,
+    avgDailyRange: 400,
+    minStopPoints: 20, // ~$400 full / ~$40 micro
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: 'YM', name: 'Dow Jones E-mini', exchange: 'CBOT', type: 'equity_index',
+    tickSize: 1.00, tickValue: 5.00, pointValue: 5.00,
+    micro: 'MYM', microPointValue: 0.50, microTickValue: 0.50,
+    avgDailyRange: 420,
+    minStopPoints: 25, // ~$125 full / ~$12.50 micro
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: 'RTY', name: 'Russell 2000 E-mini', exchange: 'CME', type: 'equity_index',
+    tickSize: 0.10, tickValue: 5.00, pointValue: 50.00,
+    micro: 'M2K', microPointValue: 5.00, microTickValue: 0.50,
+    avgDailyRange: 30,
+    minStopPoints: 3, // ~$150 full / ~$15 micro
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+
+  // ==================== ENERGY ====================
+  {
+    symbol: 'CL', name: 'Crude Oil WTI', exchange: 'NYMEX', type: 'energy',
+    tickSize: 0.01, tickValue: 10.00, pointValue: 1000.00,
+    micro: 'MCL', microPointValue: 100.00, microTickValue: 1.00,
+    avgDailyRange: 2.5,
+    minStopPoints: 0.20, // ~$200 full / ~$20 micro
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: 'NG', name: 'Natural Gas', exchange: 'NYMEX', type: 'energy',
+    tickSize: 0.001, tickValue: 10.00, pointValue: 10000.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.20,
+    minStopPoints: 0.020, // ~$200
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+
+  // ==================== METALS (Apex suspended Apr/2026) ====================
+  {
+    symbol: 'GC', name: 'Gold', exchange: 'COMEX', type: 'metals',
+    tickSize: 0.10, tickValue: 10.00, pointValue: 100.00,
+    micro: 'MGC', microPointValue: 10.00, microTickValue: 1.00,
+    avgDailyRange: 40,
+    minStopPoints: 3, // ~$300 full / ~$30 micro
+    availability: { apex: false, mff: true, lucid: true, tradeify: true },
+    note: 'Suspenso na Apex desde Abr/2026 por volatilidade extrema'
+  },
+  {
+    symbol: 'SI', name: 'Silver', exchange: 'COMEX', type: 'metals',
+    tickSize: 0.005, tickValue: 25.00, pointValue: 5000.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.60,
+    minStopPoints: 0.05, // ~$250
+    availability: { apex: false, mff: true, lucid: true, tradeify: true },
+    note: 'Suspenso na Apex desde Abr/2026'
+  },
+  {
+    symbol: 'HG', name: 'Copper', exchange: 'COMEX', type: 'metals',
+    tickSize: 0.0005, tickValue: 12.50, pointValue: 25000.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.08,
+    minStopPoints: 0.005, // ~$125
+    availability: { apex: false, mff: false, lucid: true, tradeify: true },
+    note: 'Suspenso na Apex desde Abr/2026'
+  },
+
+  // ==================== CURRENCY (FX) ====================
+  {
+    symbol: '6E', name: 'Euro FX', exchange: 'CME', type: 'currency',
+    tickSize: 0.00005, tickValue: 6.25, pointValue: 125000.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.0090,
+    minStopPoints: 0.0008, // ~$100
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: '6B', name: 'British Pound', exchange: 'CME', type: 'currency',
+    tickSize: 0.0001, tickValue: 6.25, pointValue: 62500.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.0110,
+    minStopPoints: 0.0010, // ~$62.50
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: '6J', name: 'Japanese Yen', exchange: 'CME', type: 'currency',
+    tickSize: 0.0000005, tickValue: 6.25, pointValue: 12500000.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.00070,
+    minStopPoints: 0.000060, // ~$750
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: '6A', name: 'Australian Dollar', exchange: 'CME', type: 'currency',
+    tickSize: 0.0001, tickValue: 10.00, pointValue: 100000.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 0.0070,
+    minStopPoints: 0.0006, // ~$60
+    availability: { apex: true, mff: false, lucid: true, tradeify: false }
+  },
+
+  // ==================== AGRICULTURE ====================
+  {
+    symbol: 'ZC', name: 'Corn', exchange: 'CBOT', type: 'agriculture',
+    tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 10,
+    minStopPoints: 1, // ~$50
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+  {
+    symbol: 'ZW', name: 'Wheat', exchange: 'CBOT', type: 'agriculture',
+    tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 15,
+    minStopPoints: 1.5, // ~$75
+    availability: { apex: true, mff: true, lucid: false, tradeify: true }
+  },
+  {
+    symbol: 'ZS', name: 'Soybeans', exchange: 'CBOT', type: 'agriculture',
+    tickSize: 0.25, tickValue: 12.50, pointValue: 50.00,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 18,
+    minStopPoints: 2, // ~$100
+    availability: { apex: true, mff: true, lucid: true, tradeify: true }
+  },
+
+  // ==================== CRYPTO ====================
+  {
+    symbol: 'MBT', name: 'Micro Bitcoin', exchange: 'CME', type: 'crypto',
+    tickSize: 5.00, tickValue: 0.50, pointValue: 0.10,
+    micro: null, microPointValue: null, microTickValue: null,
+    avgDailyRange: 4000,
+    minStopPoints: 200, // ~$20
+    availability: { apex: true, mff: false, lucid: false, tradeify: true }
+  }
+];
+
+// ============================================
+// HELPERS
+// ============================================
+
+/**
+ * Busca instrumento por símbolo. Suporta full size E micro variants.
+ * Para micro, retorna o objeto pai com pointValue/tickValue substituídos.
+ *
+ * @param {string} symbol - ex: 'NQ', 'MNQ', 'ES', 'MES'
+ * @returns {Object|null} instrumento ou null se não encontrado
+ */
+export function getInstrument(symbol) {
+  const upper = (symbol || '').toUpperCase();
+
+  // Busca direta (full size)
+  const direct = INSTRUMENTS_TABLE.find(i => i.symbol === upper);
+  if (direct) {
+    return {
+      ...direct,
+      isMicro: false,
+      parentSymbol: null
+    };
+  }
+
+  // Busca como micro
+  const parent = INSTRUMENTS_TABLE.find(i => i.micro === upper);
+  if (parent) {
+    return {
+      ...parent,
+      symbol: parent.micro,
+      name: `Micro ${parent.name.replace('E-mini ', '').replace(' E-mini', '')}`,
+      pointValue: parent.microPointValue,
+      tickValue: parent.microTickValue,
+      isMicro: true,
+      parentSymbol: parent.symbol
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Calcula range esperado de uma sessão para um instrumento.
+ *
+ * @param {string} symbol
+ * @param {string} session - 'asia' | 'london' | 'ny'
+ * @returns {{ rangePoints, rangeUSD, bodyRangePoints, directionalPct, hours, sessionName }|null}
+ */
+export function getSessionRange(symbol, session) {
+  const instrument = getInstrument(symbol);
+  if (!instrument || !SESSION_PROFILES[session]) return null;
+
+  const profile = SESSION_PROFILES[session];
+  const rangePoints = round(instrument.avgDailyRange * profile.rangePct, 4);
+  const rangeUSD = round(rangePoints * instrument.pointValue, 2);
+  const bodyRangePoints = round(rangePoints * profile.bodyRangePct, 4);
+
+  return {
+    rangePoints,
+    rangeUSD,
+    bodyRangePoints,
+    directionalPct: profile.directionalPct,
+    hours: profile.hours,
+    sessionName: profile.name
+  };
+}
+
+/**
+ * Verifica se um instrumento é permitido em uma mesa proprietária.
+ *
+ * @param {string} symbol
+ * @param {string} firm - 'apex' | 'mff' | 'lucid' | 'tradeify'
+ * @returns {boolean}
+ */
+export function isInstrumentAllowed(symbol, firm) {
+  const instrument = getInstrument(symbol);
+  if (!instrument) return false;
+  const firmKey = (firm || '').toLowerCase();
+  return instrument.availability[firmKey] === true;
+}
+
+/**
+ * Retorna lista de símbolos restritos (NÃO permitidos) em uma mesa.
+ * Usado para compatibilidade com UI atual que lê `template.restrictedInstruments`.
+ *
+ * @param {string} firm - 'apex' | 'mff' | 'lucid' | 'tradeify' (case insensitive)
+ * @returns {string[]} símbolos restritos (full + micro). Inclui ambos os símbolos quando o full está restrito.
+ */
+export function getRestrictedInstrumentsForFirm(firm) {
+  const firmKey = (firm || '').toLowerCase();
+  const restricted = [];
+  for (const inst of INSTRUMENTS_TABLE) {
+    if (inst.availability[firmKey] === false) {
+      restricted.push(inst.symbol);
+      if (inst.micro) restricted.push(inst.micro);
+    }
+  }
+  return restricted;
+}
+
+/**
+ * Retorna lista de instrumentos disponíveis em uma mesa.
+ * Inclui full e micro variants quando ambos são permitidos.
+ *
+ * @param {string} firm
+ * @returns {Array<{ symbol, name, type, isMicro, parentSymbol }>}
+ */
+export function getAllowedInstrumentsForFirm(firm) {
+  const firmKey = (firm || '').toLowerCase();
+  const result = [];
+  for (const inst of INSTRUMENTS_TABLE) {
+    if (inst.availability[firmKey] !== true) continue;
+    // Full size
+    result.push({
+      symbol: inst.symbol,
+      name: inst.name,
+      type: inst.type,
+      isMicro: false,
+      parentSymbol: null,
+      pointValue: inst.pointValue,
+      avgDailyRange: inst.avgDailyRange
+    });
+    // Micro variant (se existir)
+    if (inst.micro) {
+      result.push({
+        symbol: inst.micro,
+        name: `Micro ${inst.name.replace('E-mini ', '').replace(' E-mini', '')}`,
+        type: inst.type,
+        isMicro: true,
+        parentSymbol: inst.symbol,
+        pointValue: inst.microPointValue,
+        avgDailyRange: inst.avgDailyRange
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Sugere o micro variant de um instrumento full size, se existir.
+ * Usado quando o stop natural do full excede o orçamento da mesa.
+ *
+ * @param {string} symbol - símbolo full size
+ * @returns {Object|null} micro variant ou null se não há micro disponível
+ */
+export function suggestMicroAlternative(symbol) {
+  const inst = getInstrument(symbol);
+  if (!inst || inst.isMicro || !inst.micro) return null;
+  return getInstrument(inst.micro);
+}
+
+/**
+ * Calcula o stop natural recomendado em pontos para um instrumento.
+ * Fórmula: max(ATR × STOP_PERCENT_OF_ATR, minStopPoints).
+ *
+ * @param {Object} instrument - retorno de getInstrument
+ * @returns {{ stopPoints, stopUSD, source }}
+ *   source: 'atr' (5% do ATR foi maior que minStop) ou 'min' (minStop prevaleceu)
+ */
+export function getRecommendedStop(instrument) {
+  if (!instrument) return null;
+  const atrBased = instrument.avgDailyRange * STOP_PERCENT_OF_ATR;
+  const stopPoints = Math.max(atrBased, instrument.minStopPoints);
+  const source = atrBased >= instrument.minStopPoints ? 'atr' : 'min';
+  return {
+    stopPoints: round(stopPoints, 4),
+    stopUSD: round(stopPoints * instrument.pointValue, 2),
+    source
+  };
+}
+
+// --- internal helper ---
+function round(value, decimals) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}

--- a/src/constants/propFirmDefaults.js
+++ b/src/constants/propFirmDefaults.js
@@ -1,0 +1,670 @@
+// ============================================
+// PROP FIRM — CONSTANTES E TEMPLATES DEFAULT
+// ============================================
+// Catálogo de templates de mesas proprietárias.
+// Collection raiz `propFirmTemplates` (INV-15 aprovado).
+// Ref: issue #52, DEC-053
+
+// --- Fases da conta prop ---
+export const PROP_FIRM_PHASES = {
+  EVALUATION: 'EVALUATION',
+  SIM_FUNDED: 'SIM_FUNDED',
+  LIVE: 'LIVE',
+  EXPIRED: 'EXPIRED'
+};
+
+export const PROP_FIRM_PHASE_LABELS = {
+  EVALUATION: 'Avaliação',
+  SIM_FUNDED: 'Simulado Funded',
+  LIVE: 'Live',
+  EXPIRED: 'Expirada'
+};
+
+// --- Tipos de drawdown ---
+export const DRAWDOWN_TYPES = {
+  TRAILING_INTRADAY: 'TRAILING_INTRADAY',
+  TRAILING_EOD: 'TRAILING_EOD',
+  STATIC: 'STATIC',
+  TRAILING_WITH_LOCK: 'TRAILING_WITH_LOCK'
+};
+
+export const DRAWDOWN_TYPE_LABELS = {
+  TRAILING_INTRADAY: 'Trailing Intraday',
+  TRAILING_EOD: 'Trailing EOD',
+  STATIC: 'Estático',
+  TRAILING_WITH_LOCK: 'Trailing com Lock'
+};
+
+// --- Firmas ---
+export const PROP_FIRMS = {
+  APEX: 'APEX',
+  MFF: 'MFF',
+  LUCID: 'LUCID',
+  TRADEIFY: 'TRADEIFY',
+  CUSTOM: 'CUSTOM'
+};
+
+export const PROP_FIRM_LABELS = {
+  APEX: 'Apex Trader Funding',
+  MFF: 'MyFundedFutures',
+  LUCID: 'Lucid Markets',
+  TRADEIFY: 'Tradeify',
+  CUSTOM: 'Personalizada'
+};
+
+// --- Fee model ---
+export const FEE_MODELS = {
+  ONE_TIME: 'ONE_TIME',
+  RECURRING: 'RECURRING'
+};
+
+// --- Daily loss action ---
+export const DAILY_LOSS_ACTIONS = {
+  PAUSE_DAY: 'PAUSE_DAY',
+  FAIL_ACCOUNT: 'FAIL_ACCOUNT'
+};
+
+// --- Attack plan profiles ---
+export const ATTACK_PLAN_PROFILES = {
+  CONSERVATIVE: 'conservative',
+  AGGRESSIVE: 'aggressive'
+};
+
+export const ATTACK_PLAN_PROFILE_LABELS = {
+  conservative: 'Conservador',
+  aggressive: 'Agressivo'
+};
+
+// --- Attack plan data sources ---
+export const ATTACK_PLAN_DATA_SOURCES = {
+  FULL_4D: '4d_full',
+  INDICATORS: 'indicators',
+  DEFAULTS: 'defaults'
+};
+
+// ============================================
+// TEMPLATES DEFAULT POR MESA
+// ============================================
+// Ref: issue #52 body — comparativo Apex Mar/2026, MFF, Lucid
+
+const APEX_BASE = {
+  firm: PROP_FIRMS.APEX,
+  feeModel: FEE_MODELS.ONE_TIME,
+  bracketOrderRequired: true,
+  newsTrading: true,
+  dcaAllowed: false,
+  restrictedInstruments: ['GC', 'SI', 'MGC', 'HG', 'PL', 'PA'],
+  tradingHours: { close: '16:59', timezone: 'America/New_York' },
+  phases: ['EVALUATION', 'SIM_FUNDED', 'LIVE'],
+  consistency: { evalRule: 0.50, fundedRule: null },
+  payout: {
+    minAmount: 500,
+    minTradingDays: 8,
+    qualifyingDays: { count: 5, minProfit: 100, maxProfit: 300 },
+    split: 0.90,
+    firstTierAmount: 25000,
+    firstTierSplit: 1.00
+  }
+};
+
+const MFF_BASE = {
+  firm: PROP_FIRMS.MFF,
+  feeModel: FEE_MODELS.RECURRING,
+  bracketOrderRequired: false,
+  newsTrading: false,
+  dcaAllowed: true,
+  restrictedInstruments: [],
+  tradingHours: { close: '16:10', timezone: 'America/New_York' },
+  phases: ['EVALUATION', 'SIM_FUNDED', 'LIVE'],
+  payout: {
+    minAmount: 250,
+    minTradingDays: 5,
+    qualifyingDays: { count: null, minProfit: null, maxProfit: null },
+    split: 0.80,
+    firstTierAmount: null,
+    firstTierSplit: null
+  }
+};
+
+const LUCID_BASE = {
+  firm: PROP_FIRMS.LUCID,
+  feeModel: FEE_MODELS.RECURRING,
+  bracketOrderRequired: false,
+  newsTrading: true,
+  dcaAllowed: true,
+  restrictedInstruments: [],
+  tradingHours: { close: '16:45', timezone: 'America/New_York' },
+  phases: ['EVALUATION', 'SIM_FUNDED', 'LIVE'],
+  payout: {
+    minAmount: 500,
+    minTradingDays: 5,
+    qualifyingDays: { count: null, minProfit: null, maxProfit: null },
+    split: 0.90,
+    firstTierAmount: null,
+    firstTierSplit: null
+  }
+};
+
+const TRADEIFY_BASE = {
+  firm: PROP_FIRMS.TRADEIFY,
+  feeModel: FEE_MODELS.RECURRING,
+  bracketOrderRequired: false,
+  newsTrading: true,
+  dcaAllowed: true,
+  restrictedInstruments: [],
+  tradingHours: { close: '16:10', timezone: 'America/New_York' },
+  phases: ['EVALUATION', 'SIM_FUNDED', 'LIVE'],
+  consistency: { evalRule: 0.40, fundedRule: null },
+  payout: {
+    minAmount: 250,
+    minTradingDays: 3,
+    qualifyingDays: { count: null, minProfit: null, maxProfit: null },
+    split: 0.80,
+    firstTierAmount: null,
+    firstTierSplit: null
+  }
+};
+
+// --- Templates concretos ---
+
+export const DEFAULT_TEMPLATES = [
+  // ==================== APEX EOD ====================
+  {
+    id: 'apex-eod-25k',
+    name: 'Apex EOD 25K',
+    ...APEX_BASE,
+    accountSize: 25000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 1000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: 500,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.PAUSE_DAY,
+    profitTarget: 1500,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 4, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-eod-50k',
+    name: 'Apex EOD 50K',
+    ...APEX_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 2500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: 1000,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.PAUSE_DAY,
+    profitTarget: 3000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 10, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-eod-100k',
+    name: 'Apex EOD 100K',
+    ...APEX_BASE,
+    accountSize: 100000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 3000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: 1500,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.PAUSE_DAY,
+    profitTarget: 6000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 14, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-eod-150k',
+    name: 'Apex EOD 150K',
+    ...APEX_BASE,
+    accountSize: 150000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 5000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: 2250,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.PAUSE_DAY,
+    profitTarget: 9000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 17, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-eod-250k',
+    name: 'Apex EOD 250K',
+    ...APEX_BASE,
+    accountSize: 250000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 6500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: 3000,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.PAUSE_DAY,
+    profitTarget: 15000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 27, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-eod-300k',
+    name: 'Apex EOD 300K',
+    ...APEX_BASE,
+    accountSize: 300000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 7500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: 3500,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.PAUSE_DAY,
+    profitTarget: 20000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 35, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+
+  // ==================== APEX INTRADAY ====================
+  {
+    id: 'apex-intraday-25k',
+    name: 'Apex Intraday 25K',
+    ...APEX_BASE,
+    accountSize: 25000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_INTRADAY,
+      maxAmount: 1000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 1500,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 4, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-intraday-50k',
+    name: 'Apex Intraday 50K',
+    ...APEX_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_INTRADAY,
+      maxAmount: 2500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 3000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 10, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-intraday-100k',
+    name: 'Apex Intraday 100K',
+    ...APEX_BASE,
+    accountSize: 100000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_INTRADAY,
+      maxAmount: 3000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 6000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 14, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-intraday-150k',
+    name: 'Apex Intraday 150K',
+    ...APEX_BASE,
+    accountSize: 150000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_INTRADAY,
+      maxAmount: 5000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 9000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 17, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-intraday-250k',
+    name: 'Apex Intraday 250K',
+    ...APEX_BASE,
+    accountSize: 250000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_INTRADAY,
+      maxAmount: 6500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 15000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 27, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+  {
+    id: 'apex-intraday-300k',
+    name: 'Apex Intraday 300K',
+    ...APEX_BASE,
+    accountSize: 300000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_INTRADAY,
+      maxAmount: 7500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 20000,
+    evalTimeLimit: 30,
+    evalMinTradingDays: 0,
+    contracts: { max: 35, scalingRule: '50_PERCENT_UNTIL_SAFETY_NET', scalingThreshold: null }
+  },
+
+  // ==================== MFF ====================
+  {
+    id: 'mff-starter-50k',
+    name: 'MFF Starter 50K',
+    ...MFF_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 2500,
+      lockAt: null,
+      lockFormula: 'BALANCE + 100'
+    },
+    dailyLossLimit: 1200,
+    dailyLossType: 'FIXED',
+    dailyLossAction: DAILY_LOSS_ACTIONS.FAIL_ACCOUNT,
+    profitTarget: 3000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 5,
+    consistency: { evalRule: 0.50, fundedRule: 0.40 },
+    contracts: { max: 10, scalingRule: null, scalingThreshold: null }
+  },
+  {
+    id: 'mff-core-50k',
+    name: 'MFF Core 50K',
+    ...MFF_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 2000,
+      lockAt: null,
+      lockFormula: 'BALANCE + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 3000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 5,
+    consistency: { evalRule: 0.50, fundedRule: 0.40 },
+    contracts: { max: 10, scalingRule: null, scalingThreshold: null }
+  },
+  {
+    id: 'mff-core-100k',
+    name: 'MFF Core 100K',
+    ...MFF_BASE,
+    accountSize: 100000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 3000,
+      lockAt: null,
+      lockFormula: 'BALANCE + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 6000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 5,
+    consistency: { evalRule: 0.50, fundedRule: 0.40 },
+    contracts: { max: 14, scalingRule: null, scalingThreshold: null }
+  },
+  {
+    id: 'mff-scale-150k',
+    name: 'MFF Scale 150K',
+    ...MFF_BASE,
+    accountSize: 150000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 5000,
+      lockAt: null,
+      lockFormula: 'BALANCE + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 9000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 5,
+    consistency: { evalRule: 0.50, fundedRule: 0.40 },
+    contracts: { max: 17, scalingRule: 'DYNAMIC_BY_PROFIT', scalingThreshold: null }
+  },
+
+  // ==================== LUCID ====================
+  {
+    id: 'lucid-pro-50k',
+    name: 'Lucid Pro 50K',
+    ...LUCID_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 2000,
+      lockAt: null,
+      lockFormula: null
+    },
+    dailyLossLimit: 500,
+    dailyLossType: 'PERCENT_PROFIT',
+    dailyLossAction: DAILY_LOSS_ACTIONS.FAIL_ACCOUNT,
+    profitTarget: 2500,
+    evalTimeLimit: null,
+    evalMinTradingDays: 5,
+    consistency: { evalRule: 0.50, fundedRule: 0.35 },
+    contracts: { max: 10, scalingRule: 'DYNAMIC_BY_PROFIT', scalingThreshold: null }
+  },
+  {
+    id: 'lucid-flex-50k',
+    name: 'Lucid Flex 50K',
+    ...LUCID_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 2000,
+      lockAt: null,
+      lockFormula: null
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 2500,
+    evalTimeLimit: null,
+    evalMinTradingDays: 8,
+    consistency: { evalRule: null, fundedRule: null },
+    contracts: { max: 10, scalingRule: 'DYNAMIC_BY_PROFIT', scalingThreshold: null }
+  },
+  {
+    id: 'lucid-pro-100k',
+    name: 'Lucid Pro 100K',
+    ...LUCID_BASE,
+    accountSize: 100000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 3000,
+      lockAt: null,
+      lockFormula: null
+    },
+    dailyLossLimit: 750,
+    dailyLossType: 'PERCENT_PROFIT',
+    dailyLossAction: DAILY_LOSS_ACTIONS.FAIL_ACCOUNT,
+    profitTarget: 5000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 5,
+    consistency: { evalRule: 0.50, fundedRule: 0.35 },
+    contracts: { max: 14, scalingRule: 'DYNAMIC_BY_PROFIT', scalingThreshold: null }
+  },
+
+  // ==================== TRADEIFY SELECT ====================
+  {
+    id: 'tradeify-select-25k',
+    name: 'Tradeify Select 25K',
+    ...TRADEIFY_BASE,
+    accountSize: 25000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 1000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 1500,
+    evalTimeLimit: null,
+    evalMinTradingDays: 3,
+    contracts: { max: 2, scalingRule: null, scalingThreshold: null }
+  },
+  {
+    id: 'tradeify-select-50k',
+    name: 'Tradeify Select 50K',
+    ...TRADEIFY_BASE,
+    accountSize: 50000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 2000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 3000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 3,
+    contracts: { max: 4, scalingRule: null, scalingThreshold: null }
+  },
+  {
+    id: 'tradeify-select-100k',
+    name: 'Tradeify Select 100K',
+    ...TRADEIFY_BASE,
+    accountSize: 100000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 3000,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 6000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 3,
+    contracts: { max: 8, scalingRule: null, scalingThreshold: null }
+  },
+  {
+    id: 'tradeify-select-150k',
+    name: 'Tradeify Select 150K',
+    ...TRADEIFY_BASE,
+    accountSize: 150000,
+    drawdown: {
+      type: DRAWDOWN_TYPES.TRAILING_EOD,
+      maxAmount: 4500,
+      lockAt: null,
+      lockFormula: 'BALANCE + DD + 100'
+    },
+    dailyLossLimit: null,
+    dailyLossType: null,
+    dailyLossAction: null,
+    profitTarget: 9000,
+    evalTimeLimit: null,
+    evalMinTradingDays: 3,
+    contracts: { max: 12, scalingRule: null, scalingThreshold: null }
+  }
+];
+
+// Agrupar templates por firma para o seletor de UI
+export const getTemplatesByFirm = (templates) => {
+  const grouped = {};
+  for (const t of templates) {
+    if (!grouped[t.firm]) grouped[t.firm] = [];
+    grouped[t.firm].push(t);
+  }
+  return grouped;
+};
+
+// Template vazio para criação de mesa custom
+export const EMPTY_TEMPLATE = {
+  name: '',
+  firm: PROP_FIRMS.CUSTOM,
+  accountSize: 0,
+  drawdown: {
+    type: DRAWDOWN_TYPES.TRAILING_EOD,
+    maxAmount: 0,
+    lockAt: null,
+    lockFormula: null
+  },
+  dailyLossLimit: null,
+  dailyLossType: null,
+  dailyLossAction: null,
+  profitTarget: null,
+  evalTimeLimit: null,
+  evalMinTradingDays: 0,
+  consistency: { evalRule: null, fundedRule: null },
+  contracts: { max: 0, scalingRule: null, scalingThreshold: null },
+  tradingHours: { close: '16:59', timezone: 'America/New_York' },
+  payout: {
+    minAmount: 0,
+    minTradingDays: 0,
+    qualifyingDays: { count: null, minProfit: null, maxProfit: null },
+    split: 0.90,
+    firstTierAmount: null,
+    firstTierSplit: null
+  },
+  bracketOrderRequired: false,
+  newsTrading: true,
+  dcaAllowed: true,
+  restrictedInstruments: [],
+  feeModel: FEE_MODELS.ONE_TIME,
+  phases: ['EVALUATION', 'SIM_FUNDED', 'LIVE']
+};

--- a/src/constants/propFirmDefaults.js
+++ b/src/constants/propFirmDefaults.js
@@ -86,6 +86,13 @@ export const ATTACK_PLAN_DATA_SOURCES = {
 // TEMPLATES DEFAULT POR MESA
 // ============================================
 // Ref: issue #52 body — comparativo Apex Mar/2026, MFF, Lucid
+//
+// IMPORTANTE: `restrictedInstruments` é DERIVADO da instrumentsTable via
+// `getRestrictedInstrumentsForFirm()`. NÃO duplicar listas hardcoded aqui.
+// Os helpers `enrichTemplate()` e `enrichTemplates()` no final deste arquivo
+// adicionam o campo dinamicamente quando os templates são consumidos.
+
+import { getRestrictedInstrumentsForFirm } from './instrumentsTable';
 
 const APEX_BASE = {
   firm: PROP_FIRMS.APEX,
@@ -93,7 +100,7 @@ const APEX_BASE = {
   bracketOrderRequired: true,
   newsTrading: true,
   dcaAllowed: false,
-  restrictedInstruments: ['GC', 'SI', 'MGC', 'HG', 'PL', 'PA'],
+  // restrictedInstruments derivado em runtime via enrichTemplate()
   tradingHours: { close: '16:59', timezone: 'America/New_York' },
   phases: ['EVALUATION', 'SIM_FUNDED', 'LIVE'],
   consistency: { evalRule: 0.50, fundedRule: null },
@@ -623,7 +630,47 @@ export const DEFAULT_TEMPLATES = [
   }
 ];
 
+// ============================================
+// ENRICH — adicionar restrictedInstruments derivado da instrumentsTable
+// ============================================
+// Os templates são definidos sem `restrictedInstruments` (fonte de verdade
+// é instrumentsTable.availability). Antes de consumir, enrichTemplate adiciona
+// o campo derivado para manter compatibilidade com UI atual.
+
+/**
+ * Adiciona `restrictedInstruments` derivado a um template.
+ * Se o template já tem o campo (ex: custom criado pelo mentor), preserva.
+ *
+ * @param {Object} template
+ * @returns {Object} template enriquecido
+ */
+export const enrichTemplate = (template) => {
+  if (!template) return template;
+  if (Array.isArray(template.restrictedInstruments)) return template;
+  const firmKey = (template.firm ?? '').toLowerCase();
+  return {
+    ...template,
+    restrictedInstruments: getRestrictedInstrumentsForFirm(firmKey)
+  };
+};
+
+/**
+ * Aplica enrichTemplate a um array de templates.
+ */
+export const enrichTemplates = (templates) => {
+  if (!Array.isArray(templates)) return templates;
+  return templates.map(enrichTemplate);
+};
+
+/**
+ * DEFAULT_TEMPLATES já enriquecido com restrictedInstruments derivado.
+ * Use este nas UIs (fallback do usePropFirmTemplates) para garantir
+ * que o campo restrictedInstruments esteja sempre presente.
+ */
+export const DEFAULT_TEMPLATES_ENRICHED = DEFAULT_TEMPLATES.map(enrichTemplate);
+
 // Agrupar templates por firma para o seletor de UI
+// (assume que templates já vêm enriquecidos do hook)
 export const getTemplatesByFirm = (templates) => {
   const grouped = {};
   for (const t of templates) {

--- a/src/constants/propFirmDefaults.js
+++ b/src/constants/propFirmDefaults.js
@@ -64,16 +64,144 @@ export const DAILY_LOSS_ACTIONS = {
   FAIL_ACCOUNT: 'FAIL_ACCOUNT'
 };
 
-// --- Attack plan profiles ---
+// --- Attack plan profiles (5 perfis) ---
+// Ref: Temp/attack-plan-deterministic-table.md v2.0
+//
+// Lógica invertida: quanto mais arrisca, MENOS opera. Disciplina forçada pelo sizing.
+// RO = percentual fixo do drawdown. RR fixo 1:2.
+//
+// Probabilidades de aprovação (Apex EOD 25K, 21 dias úteis, RR 1:2, 200k simulações):
+//   CONS_A: WR50% → 81.6% aprovação, bust 0.7%
+//   CONS_B: WR50% → 91.2% aprovação, bust 3.4%   ← RECOMENDADO
+//   CONS_C: WR50% → 89.5% aprovação, bust 8.8%
+//   AGRES_A: WR50% → 80.7% aprovação, bust 13.2%
+//   AGRES_B: WR50% → 83.0% aprovação, bust 13.1%
 export const ATTACK_PLAN_PROFILES = {
-  CONSERVATIVE: 'conservative',
-  AGGRESSIVE: 'aggressive'
+  CONS_A: 'CONS_A',
+  CONS_B: 'CONS_B',
+  CONS_C: 'CONS_C',
+  AGRES_A: 'AGRES_A',
+  AGRES_B: 'AGRES_B'
 };
 
 export const ATTACK_PLAN_PROFILE_LABELS = {
-  conservative: 'Conservador',
-  aggressive: 'Agressivo'
+  CONS_A: 'Conservador Leve',
+  CONS_B: 'Conservador Sweet Spot',
+  CONS_C: 'Conservador Firme',
+  AGRES_A: 'Agressivo',
+  AGRES_B: 'Agressivo Máximo'
 };
+
+export const ATTACK_PROFILES = {
+  CONS_A: {
+    code: 'CONS_A',
+    name: 'Conservador Leve',
+    family: 'conservative',
+    roPct: 0.10,             // 10% do drawdown
+    rr: 2,
+    maxTradesPerDay: 2,
+    description: 'Scalp com margem. Máxima resiliência.',
+    idealFor: 'Stage 1-2, emocional baixo, sem histórico consistente',
+    minWR: 0.40
+  },
+  CONS_B: {
+    code: 'CONS_B',
+    name: 'Conservador Sweet Spot',
+    family: 'conservative',
+    roPct: 0.15,             // 15% do drawdown
+    rr: 2,
+    maxTradesPerDay: 2,
+    description: 'Day trade clássico. Melhor relação aprovação/bust/tempo.',
+    idealFor: 'Stage 2-3, WR ≥ 45%',
+    minWR: 0.45,
+    recommended: true
+  },
+  CONS_C: {
+    code: 'CONS_C',
+    name: 'Conservador Firme',
+    family: 'conservative',
+    roPct: 0.20,             // 20% do drawdown
+    rr: 2,
+    maxTradesPerDay: 2,
+    description: 'Swing intraday. Mais rápido mas exige disciplina.',
+    idealFor: 'Stage 3+, WR ≥ 50%',
+    minWR: 0.50
+  },
+  AGRES_A: {
+    code: 'AGRES_A',
+    name: 'Agressivo',
+    family: 'aggressive',
+    roPct: 0.25,             // 25% do drawdown
+    rr: 2,
+    maxTradesPerDay: 1,
+    description: 'Swing com convicção. 1 trade/dia — o melhor setup.',
+    idealFor: 'Stage 3-4, WR ≥ 55%, disciplina comprovada',
+    minWR: 0.55
+  },
+  AGRES_B: {
+    code: 'AGRES_B',
+    name: 'Agressivo Máximo',
+    family: 'aggressive',
+    roPct: 0.30,             // 30% do drawdown
+    rr: 2,
+    maxTradesPerDay: 1,
+    description: 'Trade de convicção máxima. Sem margem para erro.',
+    idealFor: 'Stage 4+, WR ≥ 55%, controle emocional alto',
+    minWR: 0.55
+  }
+};
+
+export const DEFAULT_ATTACK_PROFILE = 'CONS_B';
+
+// --- Viabilidade do stop por tipo de instrumento ---
+// Ref: Temp/attack-plan-deterministic-table.md §3
+// Stop em pontos abaixo desses valores é "ruído" no instrumento — sugerir micro variant.
+export const MIN_VIABLE_STOP = {
+  equity_index: 15,    // pontos — abaixo disso é ruído no MNQ/MES
+  energy: 0.10,        // pontos — CL/MCL
+  metals: 3,           // pontos — GC/MGC
+  currency: 0.0003,    // pontos — 6E/6B/6J
+  agriculture: 3,      // pontos — ZC/ZW/ZS
+  crypto: 500          // pontos — MBT
+};
+
+// Stop > MAX_STOP_NY_PCT do range NY = inviável (vela única consome o stop).
+// Stop < MIN_STOP_NY_PCT do range NY = ruído puro.
+export const MAX_STOP_NY_PCT = 75;
+export const MIN_STOP_NY_PCT = 5;
+
+// Stop < NY_MIN_VIABLE_STOP_PCT do range NY = não viável NA SESSÃO NY,
+// mas viável em sessões mais calmas (Ásia/London).
+// Threshold 12.5% genérico — abaixo disso, NY consome o stop por volatilidade.
+// Calibração com ATR real (v2 09/04/2026): NQ NY range = 549 × 0.60 = 329.4 pts,
+// 12.5% = ~41 pts. Stops menores que 41 pts em NQ → operar Ásia/London.
+export const NY_MIN_VIABLE_STOP_PCT = 12.5;
+
+// Fração do ATR diário consumido pela sessão NY (usado para stopNyPct).
+// Ref: SESSION_PROFILES.ny.rangePct = 0.60.
+export const NY_RANGE_FRACTION = 0.60;
+
+// WR padrão quando o trader não tem indicadores nem 4D.
+export const DEFAULT_ASSUMED_WR = 0.50;
+
+// Breakeven com RR 1:2. Abaixo disso a EV é negativa — plano matematicamente inviável.
+export const RR2_BREAKEVEN_WR = 1 / 3;
+
+/**
+ * Normaliza chave de perfil — aceita os 5 novos códigos E os legados
+ * 'conservative'/'aggressive' (mapeados para CONS_B/AGRES_A respectivamente).
+ *
+ * @param {string|null|undefined} profileKey
+ * @returns {string} código de perfil válido (default: CONS_B)
+ */
+export function normalizeAttackProfile(profileKey) {
+  if (!profileKey) return DEFAULT_ATTACK_PROFILE;
+  if (ATTACK_PROFILES[profileKey]) return profileKey;
+  // Legacy mapping (Fase 1.5 → 5 profiles)
+  if (profileKey === 'conservative') return 'CONS_B';
+  if (profileKey === 'aggressive') return 'AGRES_A';
+  return DEFAULT_ATTACK_PROFILE;
+}
 
 // --- Attack plan data sources ---
 export const ATTACK_PLAN_DATA_SOURCES = {

--- a/src/hooks/useAccounts.js
+++ b/src/hooks/useAccounts.js
@@ -123,7 +123,7 @@ export const useAccounts = (overrideStudentId = null) => {
         updatedAt: serverTimestamp()
       };
 
-      // Prop firm — campo opcional, só para contas PROP (#52)
+      // Prop firm — campo opcional, só para contas PROP (#52 + Fase 1.5)
       if (accountType === 'PROP' && accountData.propFirm) {
         newAccount.propFirm = {
           templateId: accountData.propFirm.templateId ?? null,
@@ -137,6 +137,8 @@ export const useAccounts = (overrideStudentId = null) => {
           lockLevel: null,
           isDayPaused: false,
           tradingDays: 0,
+          // Fase 1.5: instrumento principal selecionado pelo aluno
+          selectedInstrument: accountData.propFirm.selectedInstrument ?? null,
           suggestedPlan: accountData.propFirm.suggestedPlan ?? null
         };
       }

--- a/src/hooks/useAccounts.js
+++ b/src/hooks/useAccounts.js
@@ -123,6 +123,24 @@ export const useAccounts = (overrideStudentId = null) => {
         updatedAt: serverTimestamp()
       };
 
+      // Prop firm — campo opcional, só para contas PROP (#52)
+      if (accountType === 'PROP' && accountData.propFirm) {
+        newAccount.propFirm = {
+          templateId: accountData.propFirm.templateId ?? null,
+          firmName: accountData.propFirm.firmName ?? '',
+          productName: accountData.propFirm.productName ?? '',
+          phase: accountData.propFirm.phase ?? 'EVALUATION',
+          phaseStartDate: serverTimestamp(),
+          evalDeadline: accountData.propFirm.evalDeadline ?? null,
+          peakBalance: initialAmount,
+          currentDrawdownThreshold: initialAmount - (accountData.propFirm.drawdownMax ?? 0),
+          lockLevel: null,
+          isDayPaused: false,
+          tradingDays: 0,
+          suggestedPlan: accountData.propFirm.suggestedPlan ?? null
+        };
+      }
+
       const docRef = await addDoc(collection(db, 'accounts'), newAccount);
       const accountId = docRef.id;
       
@@ -216,13 +234,23 @@ export const useAccounts = (overrideStudentId = null) => {
         }
       }
       
-      await updateDoc(accountRef, { 
-        ...updateData, 
-        updatedAt: serverTimestamp() 
+      // Prop firm — atualizar campos prop se fornecidos (#52)
+      if (updateData.propFirm) {
+        const prefixed = {};
+        for (const [key, value] of Object.entries(updateData.propFirm)) {
+          prefixed[`propFirm.${key}`] = value;
+        }
+        delete updateData.propFirm;
+        Object.assign(updateData, prefixed);
+      }
+
+      await updateDoc(accountRef, {
+        ...updateData,
+        updatedAt: serverTimestamp()
       });
-    } catch (err) { 
+    } catch (err) {
       console.error('[useAccounts] Erro atualizar:', err);
-      throw err; 
+      throw err;
     }
   }, [user, accounts]);
 

--- a/src/hooks/usePropFirmTemplates.js
+++ b/src/hooks/usePropFirmTemplates.js
@@ -21,7 +21,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
-import { DEFAULT_TEMPLATES } from '../constants/propFirmDefaults';
+import { DEFAULT_TEMPLATES, enrichTemplate } from '../constants/propFirmDefaults';
 
 const COLLECTION_NAME = 'propFirmTemplates';
 
@@ -43,7 +43,8 @@ export function usePropFirmTemplates() {
     const unsubscribe = onSnapshot(
       colRef,
       (snapshot) => {
-        const docs = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+        // Enriquecer cada template com restrictedInstruments derivado da instrumentsTable
+        const docs = snapshot.docs.map(d => enrichTemplate({ id: d.id, ...d.data() }));
         docs.sort((a, b) => {
           if (a.firm !== b.firm) return (a.firm ?? '').localeCompare(b.firm ?? '');
           return (a.accountSize ?? 0) - (b.accountSize ?? 0);

--- a/src/hooks/usePropFirmTemplates.js
+++ b/src/hooks/usePropFirmTemplates.js
@@ -1,0 +1,149 @@
+/**
+ * usePropFirmTemplates
+ * @description CRUD para collection raiz `propFirmTemplates` (catálogo de templates de mesas proprietárias)
+ *
+ * PATH FIRESTORE: propFirmTemplates/{templateId} (collection raiz — INV-15 aprovado)
+ *
+ * Catálogo independente de alunos (como tickers). Mentor configura uma vez,
+ * alunos selecionam ao criar conta tipo PROP.
+ *
+ * Ref: issue #52, DEC-053
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  collection,
+  doc,
+  onSnapshot,
+  setDoc,
+  deleteDoc,
+  serverTimestamp
+} from 'firebase/firestore';
+import { db } from '../firebase';
+import { useAuth } from '../contexts/AuthContext';
+import { DEFAULT_TEMPLATES } from '../constants/propFirmDefaults';
+
+const COLLECTION_NAME = 'propFirmTemplates';
+
+export function usePropFirmTemplates() {
+  const { user, isMentor } = useAuth();
+  const [templates, setTemplates] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // --- Real-time listener ---
+  useEffect(() => {
+    if (!user) {
+      setTemplates([]);
+      setLoading(false);
+      return;
+    }
+
+    const colRef = collection(db, COLLECTION_NAME);
+    const unsubscribe = onSnapshot(
+      colRef,
+      (snapshot) => {
+        const docs = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+        docs.sort((a, b) => {
+          if (a.firm !== b.firm) return (a.firm ?? '').localeCompare(b.firm ?? '');
+          return (a.accountSize ?? 0) - (b.accountSize ?? 0);
+        });
+        setTemplates(docs);
+        setLoading(false);
+        setError(null);
+      },
+      (err) => {
+        console.error('[usePropFirmTemplates] listener error:', err);
+        setError(err.message);
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [user]);
+
+  // --- Seed defaults (mentor only) ---
+  const seedDefaults = useCallback(async () => {
+    if (!isMentor()) throw new Error('Apenas mentor pode fazer seed de templates');
+
+    for (const template of DEFAULT_TEMPLATES) {
+      const { id, ...data } = template;
+      await setDoc(doc(db, COLLECTION_NAME, id), {
+        ...data,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+      });
+    }
+  }, [isMentor]);
+
+  // --- Add template ---
+  const addTemplate = useCallback(async (templateData) => {
+    if (!isMentor()) throw new Error('Apenas mentor pode criar templates');
+
+    const docRef = doc(collection(db, COLLECTION_NAME));
+    await setDoc(docRef, {
+      ...templateData,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp()
+    });
+    return docRef.id;
+  }, [isMentor]);
+
+  // --- Update template ---
+  const updateTemplate = useCallback(async (templateId, updates) => {
+    if (!isMentor()) throw new Error('Apenas mentor pode editar templates');
+
+    const docRef = doc(db, COLLECTION_NAME, templateId);
+    await setDoc(docRef, {
+      ...updates,
+      updatedAt: serverTimestamp()
+    }, { merge: true });
+  }, [isMentor]);
+
+  // --- Delete template ---
+  const deleteTemplate = useCallback(async (templateId) => {
+    if (!isMentor()) throw new Error('Apenas mentor pode deletar templates');
+
+    await deleteDoc(doc(db, COLLECTION_NAME, templateId));
+  }, [isMentor]);
+
+  // --- Delete all templates ---
+  const deleteAllTemplates = useCallback(async () => {
+    if (!isMentor()) throw new Error('Apenas mentor pode deletar templates');
+
+    const colRef = collection(db, COLLECTION_NAME);
+    const { getDocs } = await import('firebase/firestore');
+    const snapshot = await getDocs(colRef);
+    const deletes = snapshot.docs.map(d => deleteDoc(d.ref));
+    await Promise.all(deletes);
+  }, [isMentor]);
+
+  // --- Get template by ID ---
+  const getTemplateById = useCallback((templateId) => {
+    return templates.find(t => t.id === templateId) ?? null;
+  }, [templates]);
+
+  // --- Get templates grouped by firm ---
+  const getTemplatesByFirm = useCallback(() => {
+    const grouped = {};
+    for (const t of templates) {
+      const firm = t.firm ?? 'CUSTOM';
+      if (!grouped[firm]) grouped[firm] = [];
+      grouped[firm].push(t);
+    }
+    return grouped;
+  }, [templates]);
+
+  return {
+    templates,
+    loading,
+    error,
+    addTemplate,
+    updateTemplate,
+    deleteTemplate,
+    deleteAllTemplates,
+    seedDefaults,
+    getTemplateById,
+    getTemplatesByFirm
+  };
+}

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -18,6 +18,17 @@ import { useAccounts } from '../hooks/useAccounts';
 import { useMasterData } from '../hooks/useMasterData';
 import { useAuth } from '../contexts/AuthContext';
 import { usePlans } from '../hooks/usePlans';
+import { usePropFirmTemplates } from '../hooks/usePropFirmTemplates';
+import {
+  PROP_FIRM_LABELS,
+  PROP_FIRM_PHASES,
+  PROP_FIRM_PHASE_LABELS,
+  ATTACK_PLAN_PROFILES,
+  ATTACK_PLAN_PROFILE_LABELS,
+  DEFAULT_TEMPLATES,
+  getTemplatesByFirm as groupByFirm
+} from '../constants/propFirmDefaults';
+import { calculateAttackPlan } from '../utils/attackPlanCalculator';
 import AccountDetailPage from './AccountDetailPage';
 import StudentAccountGroup from '../components/StudentAccountGroup';
 import PlanManagementModal from '../components/PlanManagementModal';
@@ -78,7 +89,8 @@ const AccountsPage = () => {
   const { accounts, loading, addAccount, updateAccount, deleteAccount } = useAccounts();
   const { brokers } = useMasterData();
   const { user, isMentor } = useAuth();
-  const { plans, updatePlan } = usePlans();
+  const { plans, addPlan, updatePlan } = usePlans();
+  const { templates: firestoreTemplates } = usePropFirmTemplates();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingAccount, setEditingAccount] = useState(null);
@@ -88,6 +100,7 @@ const AccountsPage = () => {
   const [planSubmitting, setPlanSubmitting] = useState(false);
   const [showPlanModal, setShowPlanModal] = useState(false);
   const [editingPlan, setEditingPlan] = useState(null);
+  const [propPlanDefaults, setPropPlanDefaults] = useState(null); // defaults do attackPlan para criar plano após conta PROP
   
   const [auditState, setAuditState] = useState({ status: 'idle', message: '', issueType: null, ledgerBalance: 0, suggestion: null });
   const [isFixing, setIsFixing] = useState(false);
@@ -103,6 +116,47 @@ const AccountsPage = () => {
     createdAt: '',
     type: 'DEMO',
   });
+
+  // --- Prop firm state (#52) ---
+  const [propFirmData, setPropFirmData] = useState({
+    selectedFirm: '',
+    selectedTemplateId: '',
+    phase: PROP_FIRM_PHASES.EVALUATION,
+    attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE
+  });
+
+  const allTemplates = useMemo(
+    () => firestoreTemplates.length > 0 ? firestoreTemplates : DEFAULT_TEMPLATES,
+    [firestoreTemplates]
+  );
+  const firmGroups = useMemo(() => groupByFirm(allTemplates), [allTemplates]);
+  const firmList = useMemo(() => Object.keys(firmGroups), [firmGroups]);
+  const productsForFirm = useMemo(
+    () => firmGroups[propFirmData.selectedFirm] ?? [],
+    [firmGroups, propFirmData.selectedFirm]
+  );
+  const selectedTemplate = useMemo(
+    () => allTemplates.find(t => t.id === propFirmData.selectedTemplateId) ?? null,
+    [allTemplates, propFirmData.selectedTemplateId]
+  );
+  const attackPlan = useMemo(() => {
+    if (!selectedTemplate) return null;
+    try {
+      return calculateAttackPlan(selectedTemplate, null, null, propFirmData.attackProfile, propFirmData.phase);
+    } catch { return null; }
+  }, [selectedTemplate, propFirmData.attackProfile, propFirmData.phase]);
+
+  // Auto-fill quando template selecionado
+  useEffect(() => {
+    if (selectedTemplate && formData.type === 'PROP') {
+      setFormData(prev => ({
+        ...prev,
+        currency: 'USD',
+        initialBalance: selectedTemplate.accountSize?.toString() ?? prev.initialBalance,
+        name: prev.name || selectedTemplate.name
+      }));
+    }
+  }, [selectedTemplate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const brokerNames = useMemo(() => brokers.map(b => b.name).sort(), [brokers]);
   const filteredBrokers = useMemo(() => {
@@ -154,11 +208,11 @@ const AccountsPage = () => {
   }, [groupedAccounts, searchTerm, isMentor]);
 
   const openModal = (account = null) => {
-    setAuditState({ status: 'idle', message: '', issueType: null, ledgerBalance: 0, suggestion: null }); 
+    setAuditState({ status: 'idle', message: '', issueType: null, ledgerBalance: 0, suggestion: null });
     if (account) {
       setEditingAccount(account);
       const dateObj = account.createdAt ? getDateObject(account.createdAt) : new Date();
-      
+
       setFormData({
         name: account.name || '',
         broker: account.broker || account.brokerName || '',
@@ -168,6 +222,20 @@ const AccountsPage = () => {
         createdAt: dateToInputString(dateObj), // [FIX] Usa helper corrigido
         type: account.type || (account.isReal ? 'REAL' : 'DEMO')
       });
+      // Rehydratação prop firm (#52)
+      if (account.propFirm) {
+        setPropFirmData({
+          selectedFirm: account.propFirm.firmName || '',
+          selectedTemplateId: account.propFirm.templateId || '',
+          phase: account.propFirm.phase || PROP_FIRM_PHASES.EVALUATION,
+          attackProfile: account.propFirm.suggestedPlan?.profile || ATTACK_PLAN_PROFILES.CONSERVATIVE
+        });
+      } else {
+        setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE });
+      }
+      setIsModalOpen(true);
+      setShowBrokerSuggestions(false);
+      return;
     } else {
       setEditingAccount(null);
       setFormData({
@@ -180,6 +248,7 @@ const AccountsPage = () => {
         type: 'DEMO'
       });
     }
+    setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE });
     setIsModalOpen(true);
     setShowBrokerSuggestions(false);
   };
@@ -339,7 +408,69 @@ const AccountsPage = () => {
           initialBalance: Number(formData.initialBalance),
           currentBalance: Number(formData.initialBalance)
         };
-        await addAccount(createPayload);
+        // Prop firm — incluir campo propFirm se tipo PROP (#52)
+        if (formData.type === 'PROP' && selectedTemplate) {
+          const evalDays = selectedTemplate.evalTimeLimit;
+          createPayload.propFirm = {
+            templateId: selectedTemplate.id,
+            firmName: selectedTemplate.firm,
+            productName: selectedTemplate.name,
+            phase: propFirmData.phase,
+            drawdownMax: selectedTemplate.drawdown?.maxAmount ?? 0,
+            evalDeadline: evalDays
+              ? new Date(Date.now() + evalDays * 24 * 60 * 60 * 1000).toISOString()
+              : null,
+            suggestedPlan: attackPlan
+          };
+        }
+        const newAccountId = await addAccount(createPayload);
+
+        // Auto-abrir modal de plano para conta PROP com defaults do attackPlan (#52)
+        if (formData.type === 'PROP' && attackPlan && selectedTemplate && newAccountId) {
+          const pl = Number(formData.initialBalance);
+
+          // Conversão valores absolutos da mesa → percentuais do PL (para o plan modal)
+          // Os valores absolutos são as constraints reais; os % são representação do plano interno.
+          const toPct = (absValue) => pl > 0 && absValue > 0
+            ? Math.round((absValue / pl) * 1000) / 10  // 1 decimal
+            : 0;
+
+          // Mapeamento attackPlan (absoluto) → plan modal (%):
+          // - cycleGoal = profitTarget / pl  (meta total do ciclo)
+          // - cycleStop = drawdownMax / pl   (stop total do ciclo)
+          // - periodGoal = dailyTarget / pl  (meta diária)
+          // - periodStop = dailyLossLimit / pl  (stop diário)
+          // - riskPerOperation = roPerTrade / pl  (risco por trade)
+          const cycleGoalPct = toPct(attackPlan.profitTarget) || 10.0;
+          const cycleStopPct = toPct(attackPlan.drawdownMax) || 10.0;
+          const periodGoalPct = toPct(attackPlan.dailyTarget) || 1.0;
+          const periodStopPct = toPct(attackPlan.dailyLossLimit) || 2.0;
+          const riskPctPerOp = toPct(attackPlan.roPerTrade) || 0.5;
+
+          setPropPlanDefaults({
+            __isDefaults: true,  // flag para o PlanManagementModal não tratar como edit
+            accountId: newAccountId,
+            name: `Plano ${selectedTemplate.name}`,
+            type: 'Day Trade',
+            pl,
+            currency: formData.currency,  // USD para prop
+            adjustmentCycle: 'Mensal',
+            cycleGoal: cycleGoalPct,
+            cycleStop: cycleStopPct,
+            operationPeriod: 'Diário',
+            periodGoal: periodGoalPct,
+            periodStop: periodStopPct,
+            riskPerOperation: riskPctPerOp,
+            rrTarget: attackPlan.rrMinimum ?? 1.5
+          });
+          setIsModalOpen(false);
+          // Aguardar Firestore snapshot atualizar accounts antes de abrir modal de plano
+          setTimeout(() => {
+            setEditingPlan(null);
+            setShowPlanModal(true);
+          }, 800);
+          return;
+        }
       }
       setIsModalOpen(false);
     } catch (err) {
@@ -447,6 +578,74 @@ const AccountsPage = () => {
             
             <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-5">
               <div><label className="input-label mb-3">Tipo de Conta</label><div className="grid grid-cols-3 gap-3">{[{ id: 'REAL', icon: ShieldCheck, label: 'Real', color: 'emerald' }, { id: 'DEMO', icon: FlaskConical, label: 'Demo', color: 'yellow' }, { id: 'PROP', icon: Trophy, label: 'Mesa', color: 'purple' }].map(type => (<div key={type.id} onClick={() => setFormData({ ...formData, type: type.id })} className={`cursor-pointer border rounded-xl p-3 flex flex-col items-center gap-2 transition-all ${formData.type === type.id ? `bg-${type.color}-500/10 border-${type.color}-500/50 text-white` : 'bg-slate-800 border-slate-700 text-slate-400 hover:bg-slate-700'}`}><type.icon className={`w-6 h-6 ${formData.type === type.id ? `text-${type.color}-400` : 'text-slate-500'}`} /><span className="text-xs font-bold uppercase">{type.label}</span></div>))}</div></div>
+              {/* Prop Firm — seletor condicional (#52) */}
+              {formData.type === 'PROP' && (
+                <div className="p-4 bg-purple-500/5 border border-purple-500/20 rounded-xl space-y-3">
+                  <div className="flex items-center gap-2">
+                    <Trophy className="w-4 h-4 text-purple-400" />
+                    <span className="text-xs font-semibold text-purple-300 uppercase">Configuração da Mesa</span>
+                  </div>
+                  <div>
+                    <label className="input-label">Mesa Proprietária *</label>
+                    <select className="input-dark w-full" value={propFirmData.selectedFirm} onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedFirm: e.target.value, selectedTemplateId: '' }))}>
+                      <option value="">Selecione a mesa</option>
+                      {firmList.map(firm => (<option key={firm} value={firm}>{PROP_FIRM_LABELS[firm] ?? firm}</option>))}
+                    </select>
+                  </div>
+                  {propFirmData.selectedFirm && (
+                    <div>
+                      <label className="input-label">Produto *</label>
+                      <select className="input-dark w-full" value={propFirmData.selectedTemplateId} onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedTemplateId: e.target.value }))}>
+                        <option value="">Selecione o produto</option>
+                        {productsForFirm.map(t => (<option key={t.id} value={t.id}>{t.name}</option>))}
+                      </select>
+                    </div>
+                  )}
+                  {selectedTemplate && (
+                    <>
+                      <div>
+                        <label className="input-label">Fase da Conta</label>
+                        <select className="input-dark w-full" value={propFirmData.phase} onChange={(e) => setPropFirmData(prev => ({ ...prev, phase: e.target.value }))}>
+                          {Object.entries(PROP_FIRM_PHASE_LABELS).map(([k, v]) => (<option key={k} value={k}>{v}</option>))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="input-label">Perfil do Plano de Ataque</label>
+                        <div className="grid grid-cols-2 gap-2">
+                          {Object.entries(ATTACK_PLAN_PROFILE_LABELS).map(([k, v]) => (
+                            <button key={k} type="button" onClick={() => setPropFirmData(prev => ({ ...prev, attackProfile: k }))}
+                              className={`p-2 rounded-lg border text-xs font-medium transition-all ${propFirmData.attackProfile === k ? (k === 'conservative' ? 'bg-blue-500/20 border-blue-500/50 text-blue-300' : 'bg-orange-500/20 border-orange-500/50 text-orange-300') : 'bg-slate-800 border-slate-700 text-slate-400 hover:bg-slate-700'}`}
+                            >{v}</button>
+                          ))}
+                        </div>
+                      </div>
+                      {attackPlan && (
+                        <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
+                          <span className="text-[10px] text-slate-500 uppercase font-semibold">Plano de ataque sugerido (defaults)</span>
+                          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
+                            <span className="text-slate-500">RO/trade:</span><span className="text-slate-300">${attackPlan.roPerTrade.toFixed(2)}</span>
+                            <span className="text-slate-500">Stop/trade:</span><span className="text-slate-300">${attackPlan.stopPerTrade.toFixed(2)}</span>
+                            <span className="text-slate-500">RR mínimo:</span><span className="text-slate-300">{attackPlan.rrMinimum}:1</span>
+                            <span className="text-slate-500">Max trades/dia:</span><span className="text-slate-300">{attackPlan.maxTradesPerDay}</span>
+                            <span className="text-slate-500">Target diário:</span><span className="text-slate-300">${attackPlan.dailyTarget.toFixed(2)}</span>
+                            <span className="text-slate-500">Dias estimados:</span><span className="text-slate-300">{attackPlan.daysToTarget} ({attackPlan.bufferDays} margem)</span>
+                            <span className="text-slate-500">Sizing:</span><span className="text-slate-400 italic text-[10px]">a definir conforme instrumento</span>
+                          </div>
+                        </div>
+                      )}
+                      <div className="text-[10px] text-slate-500 space-y-0.5">
+                        <div>DD máx: ${selectedTemplate.drawdown?.maxAmount?.toLocaleString()} ({selectedTemplate.drawdown?.type})</div>
+                        <div>Target: ${selectedTemplate.profitTarget?.toLocaleString()}</div>
+                        {selectedTemplate.evalTimeLimit && <div>Prazo eval: {selectedTemplate.evalTimeLimit} dias corridos</div>}
+                        {selectedTemplate.dailyLossLimit && <div>Daily loss: ${selectedTemplate.dailyLossLimit?.toLocaleString()}</div>}
+                        {selectedTemplate.restrictedInstruments?.length > 0 && (
+                          <div className="text-amber-400/80">⚠ Instrumentos restritos: {selectedTemplate.restrictedInstruments.join(', ')}</div>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
               <div><label className="input-label">Nome da Conta *</label><input required className="input-dark w-full" value={formData.name} onChange={e => setFormData({ ...formData, name: e.target.value })} /></div>
               <div className="relative"><label className="input-label">Corretora / Mesa *</label><div className="relative"><Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" /><input required className="input-dark w-full pl-10" value={formData.broker} onChange={e => { setFormData({ ...formData, broker: e.target.value }); setShowBrokerSuggestions(true); }} /></div>{showBrokerSuggestions && filteredBrokers.length > 0 && (<div className="absolute top-full left-0 right-0 mt-1 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50 max-h-40 overflow-y-auto">{filteredBrokers.map(broker => (<button key={broker} type="button" className="w-full text-left px-4 py-2 text-sm text-slate-300 hover:bg-slate-700 hover:text-white flex items-center gap-2" onClick={() => { setFormData({ ...formData, broker: broker }); setShowBrokerSuggestions(false); }}><Search className="w-3 h-3 opacity-50" /> {broker}</button>))}</div>)}</div>
               
@@ -493,13 +692,35 @@ const AccountsPage = () => {
         </div>
       )}
       <style>{`.badge-account { position: absolute; top: 1rem; right: 1rem; padding: 0.25rem 0.5rem; border-radius: 0.25rem; font-size: 0.625rem; text-transform: uppercase; font-weight: 700; display: flex; align-items: center; gap: 0.25rem; border-width: 1px; } .input-label { display: block; font-size: 0.75rem; color: rgb(148 163 184); margin-bottom: 0.5rem; font-weight: 500; } .input-dark { background: rgb(15 23 42); border: 1px solid rgb(51 65 85); padding: 0.625rem 0.75rem; border-radius: 0.5rem; color: white; outline: none; transition: border-color 0.2s; } .input-dark:focus { border-color: rgb(59 130 246); }`}</style>
-      {/* Modal edição de plano pelo mentor (via accordion) */}
-      {isMentor() && showPlanModal && (
+      {/* Modal de plano — mentor (edição) ou aluno (criação pós conta PROP) */}
+      {showPlanModal && (
         <PlanManagementModal
           isOpen={showPlanModal}
-          onClose={() => { setShowPlanModal(false); setEditingPlan(null); }}
-          onSubmit={handleMentorSavePlan}
-          editingPlan={editingPlan}
+          onClose={() => { setShowPlanModal(false); setEditingPlan(null); setPropPlanDefaults(null); }}
+          onSubmit={async (planData) => {
+            setPlanSubmitting(true);
+            try {
+              if (editingPlan) {
+                await updatePlan(editingPlan.id, planData, {
+                  editedBy: isMentor() ? 'mentor' : 'student',
+                  email: user?.email || 'unknown',
+                  editedAt: new Date().toISOString(),
+                  source: 'AccountsPage',
+                });
+              } else {
+                await addPlan(planData);
+              }
+              setShowPlanModal(false);
+              setEditingPlan(null);
+              setPropPlanDefaults(null);
+            } catch (error) {
+              console.error('Erro ao salvar plano:', error);
+              alert('Erro: ' + error.message);
+            }
+            setPlanSubmitting(false);
+          }}
+          editingPlan={editingPlan ?? propPlanDefaults}
+          defaultAccountId={propPlanDefaults?.accountId}
           isSubmitting={planSubmitting}
         />
       )}

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -25,10 +25,11 @@ import {
   PROP_FIRM_PHASE_LABELS,
   ATTACK_PLAN_PROFILES,
   ATTACK_PLAN_PROFILE_LABELS,
-  DEFAULT_TEMPLATES,
+  DEFAULT_TEMPLATES_ENRICHED,
   getTemplatesByFirm as groupByFirm
 } from '../constants/propFirmDefaults';
 import { calculateAttackPlan } from '../utils/attackPlanCalculator';
+import { getAllowedInstrumentsForFirm, getInstrument } from '../constants/instrumentsTable';
 import AccountDetailPage from './AccountDetailPage';
 import StudentAccountGroup from '../components/StudentAccountGroup';
 import PlanManagementModal from '../components/PlanManagementModal';
@@ -122,11 +123,12 @@ const AccountsPage = () => {
     selectedFirm: '',
     selectedTemplateId: '',
     phase: PROP_FIRM_PHASES.EVALUATION,
-    attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE
+    attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE,
+    selectedInstrument: '' // #52 Fase 1.5 — instrumento principal da conta
   });
 
   const allTemplates = useMemo(
-    () => firestoreTemplates.length > 0 ? firestoreTemplates : DEFAULT_TEMPLATES,
+    () => firestoreTemplates.length > 0 ? firestoreTemplates : DEFAULT_TEMPLATES_ENRICHED,
     [firestoreTemplates]
   );
   const firmGroups = useMemo(() => groupByFirm(allTemplates), [allTemplates]);
@@ -139,12 +141,24 @@ const AccountsPage = () => {
     () => allTemplates.find(t => t.id === propFirmData.selectedTemplateId) ?? null,
     [allTemplates, propFirmData.selectedTemplateId]
   );
+  // Lista de instrumentos permitidos para a firma selecionada (#52 Fase 1.5)
+  const allowedInstruments = useMemo(() => {
+    if (!selectedTemplate?.firm) return [];
+    return getAllowedInstrumentsForFirm(selectedTemplate.firm);
+  }, [selectedTemplate]);
   const attackPlan = useMemo(() => {
     if (!selectedTemplate) return null;
     try {
-      return calculateAttackPlan(selectedTemplate, null, null, propFirmData.attackProfile, propFirmData.phase);
+      return calculateAttackPlan(
+        selectedTemplate,
+        null,
+        null,
+        propFirmData.attackProfile,
+        propFirmData.phase,
+        propFirmData.selectedInstrument || null
+      );
     } catch { return null; }
-  }, [selectedTemplate, propFirmData.attackProfile, propFirmData.phase]);
+  }, [selectedTemplate, propFirmData.attackProfile, propFirmData.phase, propFirmData.selectedInstrument]);
 
   // Auto-fill quando template selecionado
   useEffect(() => {
@@ -228,10 +242,11 @@ const AccountsPage = () => {
           selectedFirm: account.propFirm.firmName || '',
           selectedTemplateId: account.propFirm.templateId || '',
           phase: account.propFirm.phase || PROP_FIRM_PHASES.EVALUATION,
-          attackProfile: account.propFirm.suggestedPlan?.profile || ATTACK_PLAN_PROFILES.CONSERVATIVE
+          attackProfile: account.propFirm.suggestedPlan?.profile || ATTACK_PLAN_PROFILES.CONSERVATIVE,
+          selectedInstrument: account.propFirm.selectedInstrument?.symbol || ''
         });
       } else {
-        setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE });
+        setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE, selectedInstrument: '' });
       }
       setIsModalOpen(true);
       setShowBrokerSuggestions(false);
@@ -248,7 +263,7 @@ const AccountsPage = () => {
         type: 'DEMO'
       });
     }
-    setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE });
+    setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE, selectedInstrument: '' });
     setIsModalOpen(true);
     setShowBrokerSuggestions(false);
   };
@@ -408,9 +423,25 @@ const AccountsPage = () => {
           initialBalance: Number(formData.initialBalance),
           currentBalance: Number(formData.initialBalance)
         };
-        // Prop firm — incluir campo propFirm se tipo PROP (#52)
+        // Prop firm — incluir campo propFirm se tipo PROP (#52 + Fase 1.5)
         if (formData.type === 'PROP' && selectedTemplate) {
           const evalDays = selectedTemplate.evalTimeLimit;
+          // selectedInstrument inline (Fase 1.5)
+          let instrumentField = null;
+          if (propFirmData.selectedInstrument) {
+            const inst = getInstrument(propFirmData.selectedInstrument);
+            if (inst) {
+              instrumentField = {
+                symbol: inst.symbol,
+                name: inst.name,
+                type: inst.type,
+                isMicro: inst.isMicro,
+                pointValue: inst.pointValue,
+                avgDailyRange: inst.avgDailyRange,
+                minStopPoints: inst.minStopPoints
+              };
+            }
+          }
           createPayload.propFirm = {
             templateId: selectedTemplate.id,
             firmName: selectedTemplate.firm,
@@ -420,40 +451,40 @@ const AccountsPage = () => {
             evalDeadline: evalDays
               ? new Date(Date.now() + evalDays * 24 * 60 * 60 * 1000).toISOString()
               : null,
+            selectedInstrument: instrumentField,
             suggestedPlan: attackPlan
           };
         }
         const newAccountId = await addAccount(createPayload);
 
-        // Auto-abrir modal de plano para conta PROP com defaults do attackPlan (#52)
+        // Auto-abrir modal de plano para conta PROP com defaults do attackPlan (#52 + Fase 1.5)
         if (formData.type === 'PROP' && attackPlan && selectedTemplate && newAccountId) {
           const pl = Number(formData.initialBalance);
+          const isExecution = attackPlan.mode === 'execution' && !attackPlan.incompatible;
 
-          // Conversão valores absolutos da mesa → percentuais do PL (para o plan modal)
-          // Os valores absolutos são as constraints reais; os % são representação do plano interno.
+          // Conversão valores absolutos → percentuais do PL (para o plan modal)
           const toPct = (absValue) => pl > 0 && absValue > 0
-            ? Math.round((absValue / pl) * 1000) / 10  // 1 decimal
+            ? Math.round((absValue / pl) * 1000) / 10
             : 0;
 
-          // Mapeamento attackPlan (absoluto) → plan modal (%):
-          // - cycleGoal = profitTarget / pl  (meta total do ciclo)
-          // - cycleStop = drawdownMax / pl   (stop total do ciclo)
-          // - periodGoal = dailyTarget / pl  (meta diária)
-          // - periodStop = dailyLossLimit / pl  (stop diário)
-          // - riskPerOperation = roPerTrade / pl  (risco por trade)
+          // Constraints da mesa sempre presentes (mode abstract OU execution)
           const cycleGoalPct = toPct(attackPlan.profitTarget) || 10.0;
           const cycleStopPct = toPct(attackPlan.drawdownMax) || 10.0;
           const periodGoalPct = toPct(attackPlan.dailyTarget) || 1.0;
           const periodStopPct = toPct(attackPlan.dailyLossLimit) || 2.0;
-          const riskPctPerOp = toPct(attackPlan.roPerTrade) || 0.5;
+
+          // riskPerOperation: se execution, usa roPerTrade real; se abstract, default conservador
+          const riskPctPerOp = isExecution
+            ? toPct(attackPlan.roPerTrade) || 0.5
+            : 0.5; // sem instrumento → default 0.5% até refinar
 
           setPropPlanDefaults({
-            __isDefaults: true,  // flag para o PlanManagementModal não tratar como edit
+            __isDefaults: true,
             accountId: newAccountId,
             name: `Plano ${selectedTemplate.name}`,
             type: 'Day Trade',
             pl,
-            currency: formData.currency,  // USD para prop
+            currency: formData.currency,
             adjustmentCycle: 'Mensal',
             cycleGoal: cycleGoalPct,
             cycleStop: cycleStopPct,
@@ -464,7 +495,6 @@ const AccountsPage = () => {
             rrTarget: attackPlan.rrMinimum ?? 1.5
           });
           setIsModalOpen(false);
-          // Aguardar Firestore snapshot atualizar accounts antes de abrir modal de plano
           setTimeout(() => {
             setEditingPlan(null);
             setShowPlanModal(true);
@@ -619,20 +649,82 @@ const AccountsPage = () => {
                           ))}
                         </div>
                       </div>
-                      {attackPlan && (
+                      {/* Seletor de instrumento (Fase 1.5) */}
+                      <div>
+                        <label className="input-label">Instrumento Principal</label>
+                        <select
+                          className="input-dark w-full"
+                          value={propFirmData.selectedInstrument}
+                          onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedInstrument: e.target.value }))}
+                        >
+                          <option value="">— Sem instrumento (plano abstrato)</option>
+                          {allowedInstruments.map(inst => (
+                            <option key={inst.symbol} value={inst.symbol}>
+                              {inst.symbol} {inst.isMicro ? '(Micro)' : ''} — {inst.name}
+                            </option>
+                          ))}
+                        </select>
+                        <p className="text-[10px] text-slate-500 mt-1">
+                          O instrumento define o stop natural realista para o cálculo do plano.
+                        </p>
+                      </div>
+
+                      {attackPlan && attackPlan.mode === 'abstract' && (
                         <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
-                          <span className="text-[10px] text-slate-500 uppercase font-semibold">Plano de ataque sugerido (defaults)</span>
+                          <span className="text-[10px] text-slate-500 uppercase font-semibold">Constraints da mesa (abstrato — sem instrumento)</span>
                           <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
+                            <span className="text-slate-500">DD total:</span><span className="text-slate-300">${attackPlan.drawdownMax.toLocaleString()}</span>
+                            <span className="text-slate-500">Daily loss limit:</span><span className="text-slate-300">${attackPlan.dailyLossLimit.toLocaleString()}</span>
+                            <span className="text-slate-500">Profit target:</span><span className="text-slate-300">${attackPlan.profitTarget.toLocaleString()}</span>
+                            <span className="text-slate-500">Meta diária:</span><span className="text-slate-300">${attackPlan.dailyTarget.toLocaleString()}</span>
+                            <span className="text-slate-500">Dias úteis:</span><span className="text-slate-300">{attackPlan.evalBusinessDays}</span>
+                            <span className="text-slate-500">RR mínimo:</span><span className="text-slate-300">{attackPlan.rrMinimum}:1</span>
+                          </div>
+                          <p className="text-[10px] text-amber-400/80 mt-1 italic">{attackPlan.message}</p>
+                        </div>
+                      )}
+
+                      {attackPlan && attackPlan.mode === 'execution' && !attackPlan.incompatible && (
+                        <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
+                          <span className="text-[10px] text-slate-500 uppercase font-semibold">
+                            Plano de execução — {attackPlan.instrument.symbol} ({attackPlan.instrument.name})
+                          </span>
+                          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
+                            <span className="text-slate-500">Stop sugerido:</span><span className="text-slate-300">{attackPlan.stopPoints} pts (${attackPlan.stopPerTrade.toFixed(2)})</span>
                             <span className="text-slate-500">RO/trade:</span><span className="text-slate-300">${attackPlan.roPerTrade.toFixed(2)}</span>
-                            <span className="text-slate-500">Stop/trade:</span><span className="text-slate-300">${attackPlan.stopPerTrade.toFixed(2)}</span>
+                            <span className="text-slate-500">Target/trade:</span><span className="text-slate-300">${attackPlan.targetPerTrade.toFixed(2)}</span>
                             <span className="text-slate-500">RR mínimo:</span><span className="text-slate-300">{attackPlan.rrMinimum}:1</span>
                             <span className="text-slate-500">Max trades/dia:</span><span className="text-slate-300">{attackPlan.maxTradesPerDay}</span>
-                            <span className="text-slate-500">Target diário:</span><span className="text-slate-300">${attackPlan.dailyTarget.toFixed(2)}</span>
-                            <span className="text-slate-500">Dias estimados:</span><span className="text-slate-300">{attackPlan.daysToTarget} ({attackPlan.bufferDays} margem)</span>
-                            <span className="text-slate-500">Sizing:</span><span className="text-slate-400 italic text-[10px]">a definir conforme instrumento</span>
+                            <span className="text-slate-500">Meta diária:</span><span className="text-slate-300">${attackPlan.dailyTarget.toFixed(2)}</span>
+                            <span className="text-slate-500">Dias úteis:</span><span className="text-slate-300">{attackPlan.evalBusinessDays}</span>
+                            <span className="text-slate-500">Sizing:</span><span className="text-slate-300">{attackPlan.sizing} contrato</span>
                           </div>
                         </div>
                       )}
+
+                      {attackPlan && attackPlan.mode === 'execution' && attackPlan.incompatible && (
+                        <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg space-y-1">
+                          <div className="flex items-center gap-2">
+                            <AlertTriangle className="w-4 h-4 text-red-400" />
+                            <span className="text-xs font-semibold text-red-300">Instrumento incompatível com tamanho da conta</span>
+                          </div>
+                          <p className="text-[11px] text-red-200/80">
+                            O stop natural de <strong>{attackPlan.instrument.symbol}</strong> ({attackPlan.stopPoints} pts × ${attackPlan.instrument.pointValue}/pt = ${attackPlan.stopPerTrade.toFixed(2)})
+                            excede o daily loss limit de ${attackPlan.dailyLossLimit.toLocaleString()}.
+                            Um único trade pode estourar o dia inteiro.
+                          </p>
+                          {attackPlan.microSuggestion && (
+                            <button
+                              type="button"
+                              onClick={() => setPropFirmData(prev => ({ ...prev, selectedInstrument: attackPlan.microSuggestion }))}
+                              className="text-[11px] text-emerald-400 hover:text-emerald-300 underline"
+                            >
+                              ↳ Sugestão: usar {attackPlan.microSuggestion} (micro variant)
+                            </button>
+                          )}
+                        </div>
+                      )}
+
                       <div className="text-[10px] text-slate-500 space-y-0.5">
                         <div>DD máx: ${selectedTemplate.drawdown?.maxAmount?.toLocaleString()} ({selectedTemplate.drawdown?.type})</div>
                         <div>Target: ${selectedTemplate.profitTarget?.toLocaleString()}</div>

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -23,7 +23,9 @@ import {
   PROP_FIRM_LABELS,
   PROP_FIRM_PHASES,
   PROP_FIRM_PHASE_LABELS,
-  ATTACK_PLAN_PROFILES,
+  ATTACK_PROFILES,
+  DEFAULT_ATTACK_PROFILE,
+  normalizeAttackProfile,
   ATTACK_PLAN_PROFILE_LABELS,
   DEFAULT_TEMPLATES_ENRICHED,
   getTemplatesByFirm as groupByFirm
@@ -123,7 +125,7 @@ const AccountsPage = () => {
     selectedFirm: '',
     selectedTemplateId: '',
     phase: PROP_FIRM_PHASES.EVALUATION,
-    attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE,
+    attackProfile: DEFAULT_ATTACK_PROFILE,
     selectedInstrument: '' // #52 Fase 1.5 — instrumento principal da conta
   });
 
@@ -242,11 +244,11 @@ const AccountsPage = () => {
           selectedFirm: account.propFirm.firmName || '',
           selectedTemplateId: account.propFirm.templateId || '',
           phase: account.propFirm.phase || PROP_FIRM_PHASES.EVALUATION,
-          attackProfile: account.propFirm.suggestedPlan?.profile || ATTACK_PLAN_PROFILES.CONSERVATIVE,
+          attackProfile: normalizeAttackProfile(account.propFirm.suggestedPlan?.profile),
           selectedInstrument: account.propFirm.selectedInstrument?.symbol || ''
         });
       } else {
-        setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE, selectedInstrument: '' });
+        setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: DEFAULT_ATTACK_PROFILE, selectedInstrument: '' });
       }
       setIsModalOpen(true);
       setShowBrokerSuggestions(false);
@@ -263,7 +265,7 @@ const AccountsPage = () => {
         type: 'DEMO'
       });
     }
-    setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: ATTACK_PLAN_PROFILES.CONSERVATIVE, selectedInstrument: '' });
+    setPropFirmData({ selectedFirm: '', selectedTemplateId: '', phase: PROP_FIRM_PHASES.EVALUATION, attackProfile: DEFAULT_ATTACK_PROFILE, selectedInstrument: '' });
     setIsModalOpen(true);
     setShowBrokerSuggestions(false);
   };
@@ -600,13 +602,13 @@ const AccountsPage = () => {
 
       {isModalOpen && (
         <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-slate-900 border border-slate-700 rounded-2xl w-full max-w-lg shadow-2xl flex flex-col max-h-[90vh]">
+          <div className="bg-slate-900 border border-slate-700 rounded-2xl w-full max-w-4xl shadow-2xl flex flex-col max-h-[90vh]">
             <div className="flex justify-between items-center p-6 border-b border-slate-800">
               <h3 className="text-xl font-bold text-white">{editingAccount ? 'Editar Conta' : 'Nova Conta'}</h3>
               <button onClick={() => setIsModalOpen(false)}><X className="text-slate-400 hover:text-white" /></button>
             </div>
-            
-            <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-5">
+
+            <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-6 space-y-4">
               <div><label className="input-label mb-3">Tipo de Conta</label><div className="grid grid-cols-3 gap-3">{[{ id: 'REAL', icon: ShieldCheck, label: 'Real', color: 'emerald' }, { id: 'DEMO', icon: FlaskConical, label: 'Demo', color: 'yellow' }, { id: 'PROP', icon: Trophy, label: 'Mesa', color: 'purple' }].map(type => (<div key={type.id} onClick={() => setFormData({ ...formData, type: type.id })} className={`cursor-pointer border rounded-xl p-3 flex flex-col items-center gap-2 transition-all ${formData.type === type.id ? `bg-${type.color}-500/10 border-${type.color}-500/50 text-white` : 'bg-slate-800 border-slate-700 text-slate-400 hover:bg-slate-700'}`}><type.icon className={`w-6 h-6 ${formData.type === type.id ? `text-${type.color}-400` : 'text-slate-500'}`} /><span className="text-xs font-bold uppercase">{type.label}</span></div>))}</div></div>
               {/* Prop Firm — seletor condicional (#52) */}
               {formData.type === 'PROP' && (
@@ -615,90 +617,124 @@ const AccountsPage = () => {
                     <Trophy className="w-4 h-4 text-purple-400" />
                     <span className="text-xs font-semibold text-purple-300 uppercase">Configuração da Mesa</span>
                   </div>
-                  <div>
-                    <label className="input-label">Mesa Proprietária *</label>
-                    <select className="input-dark w-full" value={propFirmData.selectedFirm} onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedFirm: e.target.value, selectedTemplateId: '' }))}>
-                      <option value="">Selecione a mesa</option>
-                      {firmList.map(firm => (<option key={firm} value={firm}>{PROP_FIRM_LABELS[firm] ?? firm}</option>))}
-                    </select>
-                  </div>
-                  {propFirmData.selectedFirm && (
+                  <div className="grid grid-cols-2 gap-3">
                     <div>
-                      <label className="input-label">Produto *</label>
-                      <select className="input-dark w-full" value={propFirmData.selectedTemplateId} onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedTemplateId: e.target.value }))}>
-                        <option value="">Selecione o produto</option>
-                        {productsForFirm.map(t => (<option key={t.id} value={t.id}>{t.name}</option>))}
+                      <label className="input-label">Mesa Proprietária *</label>
+                      <select className="input-dark w-full" value={propFirmData.selectedFirm} onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedFirm: e.target.value, selectedTemplateId: '' }))}>
+                        <option value="">Selecione a mesa</option>
+                        {firmList.map(firm => (<option key={firm} value={firm}>{PROP_FIRM_LABELS[firm] ?? firm}</option>))}
                       </select>
                     </div>
-                  )}
+                    {propFirmData.selectedFirm && (
+                      <div>
+                        <label className="input-label">Produto *</label>
+                        <select className="input-dark w-full" value={propFirmData.selectedTemplateId} onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedTemplateId: e.target.value }))}>
+                          <option value="">Selecione o produto</option>
+                          {productsForFirm.map(t => (<option key={t.id} value={t.id}>{t.name}</option>))}
+                        </select>
+                      </div>
+                    )}
+                  </div>
                   {selectedTemplate && (
                     <>
-                      <div>
-                        <label className="input-label">Fase da Conta</label>
-                        <select className="input-dark w-full" value={propFirmData.phase} onChange={(e) => setPropFirmData(prev => ({ ...prev, phase: e.target.value }))}>
-                          {Object.entries(PROP_FIRM_PHASE_LABELS).map(([k, v]) => (<option key={k} value={k}>{v}</option>))}
-                        </select>
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="input-label">Fase da Conta</label>
+                          <select className="input-dark w-full" value={propFirmData.phase} onChange={(e) => setPropFirmData(prev => ({ ...prev, phase: e.target.value }))}>
+                            {Object.entries(PROP_FIRM_PHASE_LABELS).map(([k, v]) => (<option key={k} value={k}>{v}</option>))}
+                          </select>
+                        </div>
+                        <div>
+                          <label className="input-label">Instrumento Principal</label>
+                          <select
+                            className="input-dark w-full"
+                            value={propFirmData.selectedInstrument}
+                            onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedInstrument: e.target.value }))}
+                          >
+                            <option value="">— Sem instrumento (plano abstrato)</option>
+                            {allowedInstruments.map(inst => (
+                              <option key={inst.symbol} value={inst.symbol}>
+                                {inst.symbol} {inst.isMicro ? '(Micro)' : ''} — {inst.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
                       </div>
                       <div>
                         <label className="input-label">Perfil do Plano de Ataque</label>
-                        <div className="grid grid-cols-2 gap-2">
-                          {Object.entries(ATTACK_PLAN_PROFILE_LABELS).map(([k, v]) => (
-                            <button key={k} type="button" onClick={() => setPropFirmData(prev => ({ ...prev, attackProfile: k }))}
-                              className={`p-2 rounded-lg border text-xs font-medium transition-all ${propFirmData.attackProfile === k ? (k === 'conservative' ? 'bg-blue-500/20 border-blue-500/50 text-blue-300' : 'bg-orange-500/20 border-orange-500/50 text-orange-300') : 'bg-slate-800 border-slate-700 text-slate-400 hover:bg-slate-700'}`}
-                            >{v}</button>
-                          ))}
+                        <div className="grid grid-cols-5 gap-1.5">
+                          {Object.values(ATTACK_PROFILES).map((p) => {
+                            const selected = propFirmData.attackProfile === p.code;
+                            const isCons = p.family === 'conservative';
+                            return (
+                              <button
+                                key={p.code}
+                                type="button"
+                                onClick={() => setPropFirmData(prev => ({ ...prev, attackProfile: p.code }))}
+                                title={`${p.name} — ${p.description}\nRO: ${(p.roPct * 100).toFixed(0)}% do DD · ${p.maxTradesPerDay} trade${p.maxTradesPerDay > 1 ? 's' : ''}/dia\n${p.idealFor}`}
+                                className={`p-1.5 rounded-md border text-[10px] font-semibold transition-all ${
+                                  selected
+                                    ? (isCons ? 'bg-blue-500/20 border-blue-500/60 text-blue-200' : 'bg-orange-500/20 border-orange-500/60 text-orange-200')
+                                    : 'bg-slate-800 border-slate-700 text-slate-400 hover:bg-slate-700'
+                                }`}
+                              >
+                                <div>{(p.roPct * 100).toFixed(0)}%</div>
+                                <div className="text-[9px] opacity-70 mt-0.5">{p.code}</div>
+                                {p.recommended && <div className="text-[8px] text-emerald-400 mt-0.5">★</div>}
+                              </button>
+                            );
+                          })}
                         </div>
-                      </div>
-                      {/* Seletor de instrumento (Fase 1.5) */}
-                      <div>
-                        <label className="input-label">Instrumento Principal</label>
-                        <select
-                          className="input-dark w-full"
-                          value={propFirmData.selectedInstrument}
-                          onChange={(e) => setPropFirmData(prev => ({ ...prev, selectedInstrument: e.target.value }))}
-                        >
-                          <option value="">— Sem instrumento (plano abstrato)</option>
-                          {allowedInstruments.map(inst => (
-                            <option key={inst.symbol} value={inst.symbol}>
-                              {inst.symbol} {inst.isMicro ? '(Micro)' : ''} — {inst.name}
-                            </option>
-                          ))}
-                        </select>
                         <p className="text-[10px] text-slate-500 mt-1">
-                          O instrumento define o stop natural realista para o cálculo do plano.
+                          {ATTACK_PROFILES[propFirmData.attackProfile]?.description ?? ''}
+                          {' · '}{ATTACK_PROFILES[propFirmData.attackProfile]?.maxTradesPerDay ?? '—'} trade(s)/dia · RR 1:2
                         </p>
                       </div>
 
                       {attackPlan && attackPlan.mode === 'abstract' && (
-                        <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
+                        <div className="p-3 bg-slate-800/50 rounded-lg space-y-2">
                           <span className="text-[10px] text-slate-500 uppercase font-semibold">Constraints da mesa (abstrato — sem instrumento)</span>
-                          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
-                            <span className="text-slate-500">DD total:</span><span className="text-slate-300">${attackPlan.drawdownMax.toLocaleString()}</span>
-                            <span className="text-slate-500">Daily loss limit:</span><span className="text-slate-300">${attackPlan.dailyLossLimit.toLocaleString()}</span>
-                            <span className="text-slate-500">Profit target:</span><span className="text-slate-300">${attackPlan.profitTarget.toLocaleString()}</span>
-                            <span className="text-slate-500">Meta diária:</span><span className="text-slate-300">${attackPlan.dailyTarget.toLocaleString()}</span>
-                            <span className="text-slate-500">Dias úteis:</span><span className="text-slate-300">{attackPlan.evalBusinessDays}</span>
-                            <span className="text-slate-500">RR mínimo:</span><span className="text-slate-300">{attackPlan.rrMinimum}:1</span>
+                          <div className="grid grid-cols-3 gap-x-4 gap-y-1.5 text-xs">
+                            <div><div className="text-slate-500 text-[10px]">DD total</div><div className="text-slate-200 font-mono">${attackPlan.drawdownMax.toLocaleString()}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Daily loss limit</div><div className="text-slate-200 font-mono">${attackPlan.dailyLossLimit.toLocaleString()}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Profit target</div><div className="text-slate-200 font-mono">${attackPlan.profitTarget.toLocaleString()}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Meta diária</div><div className="text-slate-200 font-mono">${attackPlan.dailyTarget.toLocaleString()}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Dias úteis</div><div className="text-slate-200 font-mono">{attackPlan.evalBusinessDays}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">RR mínimo</div><div className="text-slate-200 font-mono">{attackPlan.rrMinimum}:1</div></div>
                           </div>
-                          <p className="text-[10px] text-amber-400/80 mt-1 italic">{attackPlan.message}</p>
+                          <p className="text-[10px] text-amber-400/80 italic">{attackPlan.message}</p>
                         </div>
                       )}
 
                       {attackPlan && attackPlan.mode === 'execution' && !attackPlan.incompatible && (
-                        <div className="p-3 bg-slate-800/50 rounded-lg space-y-1">
+                        <div className="p-3 bg-slate-800/50 rounded-lg space-y-2">
                           <span className="text-[10px] text-slate-500 uppercase font-semibold">
-                            Plano de execução — {attackPlan.instrument.symbol} ({attackPlan.instrument.name})
+                            Plano de execução — {attackPlan.instrument.symbol} ({attackPlan.instrument.name}) · {attackPlan.profileName}
                           </span>
-                          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-xs">
-                            <span className="text-slate-500">Stop sugerido:</span><span className="text-slate-300">{attackPlan.stopPoints} pts (${attackPlan.stopPerTrade.toFixed(2)})</span>
-                            <span className="text-slate-500">RO/trade:</span><span className="text-slate-300">${attackPlan.roPerTrade.toFixed(2)}</span>
-                            <span className="text-slate-500">Target/trade:</span><span className="text-slate-300">${attackPlan.targetPerTrade.toFixed(2)}</span>
-                            <span className="text-slate-500">RR mínimo:</span><span className="text-slate-300">{attackPlan.rrMinimum}:1</span>
-                            <span className="text-slate-500">Max trades/dia:</span><span className="text-slate-300">{attackPlan.maxTradesPerDay}</span>
-                            <span className="text-slate-500">Meta diária:</span><span className="text-slate-300">${attackPlan.dailyTarget.toFixed(2)}</span>
-                            <span className="text-slate-500">Dias úteis:</span><span className="text-slate-300">{attackPlan.evalBusinessDays}</span>
-                            <span className="text-slate-500">Sizing:</span><span className="text-slate-300">{attackPlan.sizing} contrato</span>
+                          <div className="grid grid-cols-3 gap-x-4 gap-y-1.5 text-xs">
+                            <div><div className="text-slate-500 text-[10px]">RO/trade</div><div className="text-slate-200 font-mono">${attackPlan.roPerTrade.toFixed(2)} <span className="text-slate-500 text-[10px]">({(attackPlan.roPct * 100).toFixed(0)}% DD)</span></div></div>
+                            <div><div className="text-slate-500 text-[10px]">Stop</div><div className="text-slate-200 font-mono">{attackPlan.stopPoints} pts <span className="text-slate-500 text-[10px]">${attackPlan.stopPerTrade.toFixed(0)}</span></div></div>
+                            <div><div className="text-slate-500 text-[10px]">Target</div><div className="text-slate-200 font-mono">{attackPlan.targetPoints} pts <span className="text-slate-500 text-[10px]">${attackPlan.targetPerTrade.toFixed(0)}</span></div></div>
+                            <div><div className="text-slate-500 text-[10px]">RR</div><div className="text-slate-200 font-mono">1:{attackPlan.rrMinimum}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Stop / range NY</div><div className="text-slate-200 font-mono">{attackPlan.stopNyPct}%</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Max trades/dia</div><div className="text-slate-200 font-mono">{attackPlan.maxTradesPerDay}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Losses até bust</div><div className="text-slate-200 font-mono">{attackPlan.lossesToBust}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">EV/trade @ WR {(attackPlan.assumedWR * 100).toFixed(0)}%</div><div className={`font-mono ${attackPlan.evPerTrade >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>${attackPlan.evPerTrade.toFixed(2)}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Sizing</div><div className="text-slate-200 font-mono">{attackPlan.sizing} contrato</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Meta diária</div><div className="text-slate-200 font-mono">${attackPlan.dailyTarget.toFixed(0)}</div></div>
+                            <div><div className="text-slate-500 text-[10px]">Dias úteis</div><div className="text-slate-200 font-mono">{attackPlan.evalBusinessDays}</div></div>
                           </div>
+                          {attackPlan.wrBelowBreakeven && (
+                            <p className="text-[10px] text-amber-400 mt-1">⚠ WR assumido abaixo do breakeven (33.3%). EV negativa — plano matematicamente inviável.</p>
+                          )}
+                          {attackPlan.sessionRestricted && (
+                            <p className="text-[10px] text-amber-400 mt-1">
+                              ⚠ Stop {attackPlan.stopPoints} pts ({attackPlan.stopNyPct}% do range NY) — <strong>operar somente Ásia/London</strong>. NY consome esse stop por volatilidade.
+                            </p>
+                          )}
+                          {attackPlan.stopIsNoise && (
+                            <p className="text-[10px] text-amber-400/80 mt-1">⚠ Stop muito pequeno relativo ao range NY ({attackPlan.stopNyPct}%) — risco de ruído.</p>
+                          )}
                         </div>
                       )}
 
@@ -706,12 +742,11 @@ const AccountsPage = () => {
                         <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-lg space-y-1">
                           <div className="flex items-center gap-2">
                             <AlertTriangle className="w-4 h-4 text-red-400" />
-                            <span className="text-xs font-semibold text-red-300">Instrumento incompatível com tamanho da conta</span>
+                            <span className="text-xs font-semibold text-red-300">Instrumento incompatível com este perfil/conta</span>
                           </div>
                           <p className="text-[11px] text-red-200/80">
-                            O stop natural de <strong>{attackPlan.instrument.symbol}</strong> ({attackPlan.stopPoints} pts × ${attackPlan.instrument.pointValue}/pt = ${attackPlan.stopPerTrade.toFixed(2)})
-                            excede o daily loss limit de ${attackPlan.dailyLossLimit.toLocaleString()}.
-                            Um único trade pode estourar o dia inteiro.
+                            <strong>{attackPlan.instrument.symbol}</strong>: RO ${attackPlan.roPerTrade.toFixed(0)} resulta em stop {attackPlan.stopPoints} pts.
+                            {' '}{attackPlan.inviabilityReason}.
                           </p>
                           {attackPlan.microSuggestion && (
                             <button
@@ -738,15 +773,16 @@ const AccountsPage = () => {
                   )}
                 </div>
               )}
-              <div><label className="input-label">Nome da Conta *</label><input required className="input-dark w-full" value={formData.name} onChange={e => setFormData({ ...formData, name: e.target.value })} /></div>
-              <div className="relative"><label className="input-label">Corretora / Mesa *</label><div className="relative"><Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" /><input required className="input-dark w-full pl-10" value={formData.broker} onChange={e => { setFormData({ ...formData, broker: e.target.value }); setShowBrokerSuggestions(true); }} /></div>{showBrokerSuggestions && filteredBrokers.length > 0 && (<div className="absolute top-full left-0 right-0 mt-1 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50 max-h-40 overflow-y-auto">{filteredBrokers.map(broker => (<button key={broker} type="button" className="w-full text-left px-4 py-2 text-sm text-slate-300 hover:bg-slate-700 hover:text-white flex items-center gap-2" onClick={() => { setFormData({ ...formData, broker: broker }); setShowBrokerSuggestions(false); }}><Search className="w-3 h-3 opacity-50" /> {broker}</button>))}</div>)}</div>
-              
               <div className="grid grid-cols-2 gap-4">
-                <div><label className="input-label">Moeda</label><select className="input-dark w-full" value={formData.currency} onChange={e => setFormData({ ...formData, currency: e.target.value })}><option value="BRL">BRL (R$)</option><option value="USD">USD ($)</option><option value="EUR">EUR (€)</option></select></div>
-                <div><label className="input-label">Saldo Inicial *</label><input required type="number" step="0.01" min="0" className="input-dark w-full" value={formData.initialBalance} onChange={e => setFormData({ ...formData, initialBalance: e.target.value })} /></div>
+                <div><label className="input-label">Nome da Conta *</label><input required className="input-dark w-full" value={formData.name} onChange={e => setFormData({ ...formData, name: e.target.value })} /></div>
+                <div className="relative"><label className="input-label">Corretora / Mesa *</label><div className="relative"><Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" /><input required className="input-dark w-full pl-10" value={formData.broker} onChange={e => { setFormData({ ...formData, broker: e.target.value }); setShowBrokerSuggestions(true); }} /></div>{showBrokerSuggestions && filteredBrokers.length > 0 && (<div className="absolute top-full left-0 right-0 mt-1 bg-slate-800 border border-slate-700 rounded-lg shadow-xl z-50 max-h-40 overflow-y-auto">{filteredBrokers.map(broker => (<button key={broker} type="button" className="w-full text-left px-4 py-2 text-sm text-slate-300 hover:bg-slate-700 hover:text-white flex items-center gap-2" onClick={() => { setFormData({ ...formData, broker: broker }); setShowBrokerSuggestions(false); }}><Search className="w-3 h-3 opacity-50" /> {broker}</button>))}</div>)}</div>
               </div>
 
-              <div><label className="input-label flex items-center gap-2"><Calendar className="w-3 h-3" /> Data de Abertura / Início</label><input type="date" className="input-dark w-full" value={formData.createdAt} onChange={e => setFormData({ ...formData, createdAt: e.target.value })} /></div>
+              <div className="grid grid-cols-3 gap-4">
+                <div><label className="input-label">Moeda</label><select className="input-dark w-full" value={formData.currency} onChange={e => setFormData({ ...formData, currency: e.target.value })}><option value="BRL">BRL (R$)</option><option value="USD">USD ($)</option><option value="EUR">EUR (€)</option></select></div>
+                <div><label className="input-label">Saldo Inicial *</label><input required type="number" step="0.01" min="0" className="input-dark w-full" value={formData.initialBalance} onChange={e => setFormData({ ...formData, initialBalance: e.target.value })} /></div>
+                <div><label className="input-label flex items-center gap-2"><Calendar className="w-3 h-3" /> Data de Abertura</label><input type="date" className="input-dark w-full" value={formData.createdAt} onChange={e => setFormData({ ...formData, createdAt: e.target.value })} /></div>
+              </div>
 
               {editingAccount && (
                 <div className={`mt-4 border rounded-xl p-4 transition-all ${auditState.status === 'issue' ? 'bg-amber-500/10 border-amber-500/30' : auditState.status === 'ok' ? 'bg-emerald-500/10 border-emerald-500/30' : 'bg-slate-800/50 border-slate-700'}`}>

--- a/src/pages/PropFirmConfigPage.jsx
+++ b/src/pages/PropFirmConfigPage.jsx
@@ -1,0 +1,435 @@
+/**
+ * PropFirmConfigPage
+ * @description Configuração de templates de mesas proprietárias (prop firms)
+ *
+ * Catálogo de templates reutilizáveis (collection raiz propFirmTemplates).
+ * Mentor configura uma vez, alunos selecionam ao criar conta tipo PROP.
+ *
+ * Suporta embedded mode (dentro do SettingsPage) e standalone.
+ * Ref: issue #52, DEC-053
+ */
+
+import { useState } from 'react';
+import {
+  Trophy, Plus, Trash2, Edit3, Save, Loader2,
+  AlertTriangle, CheckCircle, Upload, ChevronDown, ChevronUp
+} from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { usePropFirmTemplates } from '../hooks/usePropFirmTemplates';
+import {
+  PROP_FIRM_LABELS,
+  DRAWDOWN_TYPE_LABELS,
+  DAILY_LOSS_ACTIONS,
+  FEE_MODELS,
+  DEFAULT_TEMPLATES,
+  EMPTY_TEMPLATE
+} from '../constants/propFirmDefaults';
+import DebugBadge from '../components/DebugBadge';
+
+const PropFirmConfigPage = ({ embedded = false }) => {
+  const { isMentor } = useAuth();
+  const {
+    templates,
+    loading,
+    error,
+    addTemplate,
+    updateTemplate,
+    deleteTemplate,
+    deleteAllTemplates,
+    seedDefaults
+  } = usePropFirmTemplates();
+
+  const [editingId, setEditingId] = useState(null);
+  const [editForm, setEditForm] = useState(null);
+  const [expandedId, setExpandedId] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [seeding, setSeeding] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [feedback, setFeedback] = useState(null);
+
+  if (!isMentor()) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <p className="text-slate-400">Acesso restrito ao mentor.</p>
+      </div>
+    );
+  }
+
+  const showFeedback = (msg, type = 'success') => {
+    setFeedback({ msg, type });
+    setTimeout(() => setFeedback(null), 3000);
+  };
+
+  const handleSeedDefaults = async () => {
+    if (templates.length > 0) {
+      if (!window.confirm(`Já existem ${templates.length} templates. Seed vai sobrescrever os defaults. Continuar?`)) return;
+    }
+    setSeeding(true);
+    try {
+      await seedDefaults();
+      showFeedback(`${DEFAULT_TEMPLATES.length} templates carregados`);
+    } catch (err) {
+      showFeedback(err.message, 'error');
+    }
+    setSeeding(false);
+  };
+
+  const handleStartEdit = (template) => {
+    setEditingId(template.id);
+    setEditForm({ ...template });
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditForm(null);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editForm) return;
+    setSaving(true);
+    try {
+      const { id, createdAt, updatedAt, ...data } = editForm;
+      await updateTemplate(editingId, data);
+      showFeedback('Template atualizado');
+      handleCancelEdit();
+    } catch (err) {
+      showFeedback(err.message, 'error');
+    }
+    setSaving(false);
+  };
+
+  const handleDelete = async (templateId, templateName) => {
+    if (!window.confirm(`Deletar template "${templateName}"? Esta ação não pode ser desfeita.`)) return;
+    try {
+      await deleteTemplate(templateId);
+      showFeedback('Template removido');
+    } catch (err) {
+      showFeedback(err.message, 'error');
+    }
+  };
+
+  const handleAddCustom = async () => {
+    setSaving(true);
+    try {
+      const id = await addTemplate({ ...EMPTY_TEMPLATE, name: 'Novo Template Custom' });
+      setEditingId(id);
+      setEditForm({ ...EMPTY_TEMPLATE, id, name: 'Novo Template Custom' });
+      showFeedback('Template criado — edite os campos');
+    } catch (err) {
+      showFeedback(err.message, 'error');
+    }
+    setSaving(false);
+  };
+
+  // Agrupar por firma para exibição
+  const grouped = {};
+  for (const t of templates) {
+    const firm = t.firm ?? 'CUSTOM';
+    if (!grouped[firm]) grouped[firm] = [];
+    grouped[firm].push(t);
+  }
+
+  const content = (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-xl bg-purple-500/15 ring-1 ring-purple-500/20">
+            <Trophy className="w-5 h-5 text-purple-400" />
+          </div>
+          <div>
+            <h2 className="text-lg font-display font-bold text-white">Templates de Mesas Proprietárias</h2>
+            <p className="text-xs text-slate-500">{templates.length} templates configurados</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleAddCustom}
+            disabled={saving}
+            className="btn-secondary text-sm flex items-center gap-1.5"
+          >
+            <Plus className="w-4 h-4" />
+            Custom
+          </button>
+          <button
+            onClick={handleSeedDefaults}
+            disabled={seeding}
+            className="btn-secondary text-sm flex items-center gap-1.5"
+          >
+            {seeding ? <Loader2 className="w-4 h-4 animate-spin" /> : <Upload className="w-4 h-4" />}
+            Seed Defaults
+          </button>
+          {templates.length > 0 && (
+            <button
+              onClick={async () => {
+                if (!window.confirm(`Deletar todos os ${templates.length} templates? Esta ação não pode ser desfeita.`)) return;
+                setClearing(true);
+                try {
+                  await deleteAllTemplates();
+                  showFeedback(`${templates.length} templates removidos`);
+                } catch (err) {
+                  showFeedback(err.message, 'error');
+                }
+                setClearing(false);
+              }}
+              disabled={clearing}
+              className="btn-secondary text-sm flex items-center gap-1.5 text-red-400 hover:text-red-300"
+            >
+              {clearing ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+              Limpar Todos
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Feedback */}
+      {feedback && (
+        <div className={`p-3 rounded-xl flex items-center gap-2 text-sm ${
+          feedback.type === 'error'
+            ? 'bg-red-500/10 border border-red-500/30 text-red-400'
+            : 'bg-emerald-500/10 border border-emerald-500/30 text-emerald-400'
+        }`}>
+          {feedback.type === 'error'
+            ? <AlertTriangle className="w-4 h-4" />
+            : <CheckCircle className="w-4 h-4" />
+          }
+          {feedback.msg}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center p-12">
+          <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && templates.length === 0 && (
+        <div className="text-center p-12 bg-slate-900/40 rounded-2xl border border-slate-800/40">
+          <Trophy className="w-12 h-12 text-slate-600 mx-auto mb-3" />
+          <h3 className="text-white font-medium mb-1">Nenhum template configurado</h3>
+          <p className="text-sm text-slate-500 mb-4">
+            Clique em "Seed Defaults" para carregar templates pré-configurados (Apex, MFF, Lucid).
+          </p>
+        </div>
+      )}
+
+      {/* Templates agrupados por firma */}
+      {Object.entries(grouped).map(([firm, firmTemplates]) => (
+        <div key={firm} className="bg-slate-900/60 backdrop-blur-sm border border-slate-800/60 rounded-2xl overflow-hidden">
+          <div className="px-5 py-3 border-b border-slate-800/40">
+            <h3 className="text-sm font-semibold text-purple-300">
+              {PROP_FIRM_LABELS[firm] ?? firm}
+              <span className="text-slate-500 font-normal ml-2">({firmTemplates.length} produtos)</span>
+            </h3>
+          </div>
+
+          <div className="divide-y divide-slate-800/40">
+            {firmTemplates.map(template => {
+              const isEditing = editingId === template.id;
+              const isExpanded = expandedId === template.id;
+
+              return (
+                <div key={template.id} className="px-5 py-3">
+                  {/* Row header */}
+                  <div className="flex items-center justify-between">
+                    <button
+                      type="button"
+                      onClick={() => setExpandedId(isExpanded ? null : template.id)}
+                      className="flex items-center gap-2 text-left flex-1 min-w-0"
+                    >
+                      {isExpanded ? <ChevronUp className="w-4 h-4 text-slate-500" /> : <ChevronDown className="w-4 h-4 text-slate-500" />}
+                      <span className="text-sm text-white font-medium truncate">{template.name}</span>
+                      <span className="text-xs text-slate-500">
+                        ${template.accountSize?.toLocaleString()} · {DRAWDOWN_TYPE_LABELS[template.drawdown?.type] ?? template.drawdown?.type}
+                      </span>
+                    </button>
+                    <div className="flex items-center gap-1.5 ml-2">
+                      <button
+                        onClick={() => handleStartEdit(template)}
+                        className="p-1.5 text-slate-500 hover:text-blue-400 hover:bg-blue-500/10 rounded-lg transition-colors"
+                        title="Editar"
+                      >
+                        <Edit3 className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        onClick={() => handleDelete(template.id, template.name)}
+                        className="p-1.5 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+                        title="Deletar"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Expanded details */}
+                  {isExpanded && !isEditing && (
+                    <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-xs pl-6">
+                      <div className="text-slate-500">DD máximo:</div>
+                      <div className="text-slate-300">${template.drawdown?.maxAmount?.toLocaleString()}</div>
+                      <div className="text-slate-500">Profit target:</div>
+                      <div className="text-slate-300">${template.profitTarget?.toLocaleString() ?? '—'}</div>
+                      <div className="text-slate-500">Daily loss:</div>
+                      <div className="text-slate-300">{template.dailyLossLimit ? `$${template.dailyLossLimit.toLocaleString()} (${template.dailyLossAction === 'PAUSE_DAY' ? 'pausa dia' : 'falha conta'})` : '—'}</div>
+                      <div className="text-slate-500">Eval prazo:</div>
+                      <div className="text-slate-300">{template.evalTimeLimit ? `${template.evalTimeLimit} dias` : 'Sem limite'}</div>
+                      <div className="text-slate-500">Min trading days:</div>
+                      <div className="text-slate-300">{template.evalMinTradingDays ?? 0}</div>
+                      <div className="text-slate-500">Consistency:</div>
+                      <div className="text-slate-300">{template.consistency?.evalRule ? `${(template.consistency.evalRule * 100).toFixed(0)}%` : '—'}</div>
+                      <div className="text-slate-500">Max contratos:</div>
+                      <div className="text-slate-300">{template.contracts?.max ?? '—'}</div>
+                      <div className="text-slate-500">Payout split:</div>
+                      <div className="text-slate-300">{template.payout?.split ? `${(template.payout.split * 100).toFixed(0)}%` : '—'}</div>
+                      <div className="text-slate-500">Fee model:</div>
+                      <div className="text-slate-300">{template.feeModel === 'ONE_TIME' ? 'Pagamento único' : 'Recorrente'}</div>
+                      <div className="text-slate-500">Bracket orders:</div>
+                      <div className="text-slate-300">{template.bracketOrderRequired ? 'Obrigatório' : 'Não'}</div>
+                      <div className="text-slate-500">Horário limite:</div>
+                      <div className="text-slate-300">{template.tradingHours?.close ?? '—'} {template.tradingHours?.timezone ?? ''}</div>
+                      {template.restrictedInstruments?.length > 0 && (
+                        <>
+                          <div className="text-amber-400/80">Restritos:</div>
+                          <div className="text-amber-400/80">{template.restrictedInstruments.join(', ')}</div>
+                        </>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Edit form (inline) */}
+                  {isEditing && editForm && (
+                    <div className="mt-3 pl-6 space-y-3">
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <label className="text-xs text-slate-500">Nome</label>
+                          <input
+                            type="text"
+                            value={editForm.name ?? ''}
+                            onChange={(e) => setEditForm(prev => ({ ...prev, name: e.target.value }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">Account Size ($)</label>
+                          <input
+                            type="number"
+                            value={editForm.accountSize ?? 0}
+                            onChange={(e) => setEditForm(prev => ({ ...prev, accountSize: parseInt(e.target.value) || 0 }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">DD Máximo ($)</label>
+                          <input
+                            type="number"
+                            value={editForm.drawdown?.maxAmount ?? 0}
+                            onChange={(e) => setEditForm(prev => ({
+                              ...prev,
+                              drawdown: { ...prev.drawdown, maxAmount: parseInt(e.target.value) || 0 }
+                            }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">Tipo DD</label>
+                          <select
+                            value={editForm.drawdown?.type ?? 'TRAILING_EOD'}
+                            onChange={(e) => setEditForm(prev => ({
+                              ...prev,
+                              drawdown: { ...prev.drawdown, type: e.target.value }
+                            }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          >
+                            {Object.entries(DRAWDOWN_TYPE_LABELS).map(([k, v]) => (
+                              <option key={k} value={k}>{v}</option>
+                            ))}
+                          </select>
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">Profit Target ($)</label>
+                          <input
+                            type="number"
+                            value={editForm.profitTarget ?? ''}
+                            onChange={(e) => setEditForm(prev => ({ ...prev, profitTarget: parseInt(e.target.value) || null }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">Daily Loss Limit ($)</label>
+                          <input
+                            type="number"
+                            value={editForm.dailyLossLimit ?? ''}
+                            onChange={(e) => setEditForm(prev => ({ ...prev, dailyLossLimit: parseInt(e.target.value) || null }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">Eval Prazo (dias)</label>
+                          <input
+                            type="number"
+                            value={editForm.evalTimeLimit ?? ''}
+                            onChange={(e) => setEditForm(prev => ({ ...prev, evalTimeLimit: parseInt(e.target.value) || null }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                        <div>
+                          <label className="text-xs text-slate-500">Max Contratos</label>
+                          <input
+                            type="number"
+                            value={editForm.contracts?.max ?? 0}
+                            onChange={(e) => setEditForm(prev => ({
+                              ...prev,
+                              contracts: { ...prev.contracts, max: parseInt(e.target.value) || 0 }
+                            }))}
+                            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-2.5 py-1.5 text-white text-sm"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 pt-2">
+                        <button
+                          onClick={handleSaveEdit}
+                          disabled={saving}
+                          className="btn-primary text-xs flex items-center gap-1.5"
+                        >
+                          {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
+                          Salvar
+                        </button>
+                        <button
+                          onClick={handleCancelEdit}
+                          className="btn-secondary text-xs"
+                        >
+                          Cancelar
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      {error && (
+        <div className="p-3 rounded-xl bg-red-500/10 border border-red-500/30 text-sm text-red-400">
+          Erro: {error}
+        </div>
+      )}
+    </div>
+  );
+
+  if (embedded) return content;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6">
+      {!embedded && <DebugBadge component="PropFirmConfigPage" />}
+      <div className="max-w-4xl mx-auto">
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export default PropFirmConfigPage;

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -19,6 +19,7 @@ import { useTrades } from '../hooks/useTrades';
 import { runSeed, forceSeed, updateTickers } from '../utils/seedData';
 import { seedTestExtract, cleanupTestExtract } from '../utils/seedTestExtract';
 import ComplianceConfigPage from './ComplianceConfigPage';
+import PropFirmConfigPage from './PropFirmConfigPage';
 import DebugBadge from '../components/DebugBadge';
 
 const TABS = [
@@ -29,6 +30,7 @@ const TABS = [
   { id: 'currencies', label: 'Moedas', icon: DollarSign, color: 'amber' },
   { id: 'emotions', label: 'Emoções', icon: Heart, color: 'rose' },
   { id: 'compliance', label: 'Compliance', icon: Shield, color: 'cyan' },
+  { id: 'propfirm', label: 'Prop Firms', icon: TrendingUp, color: 'purple' },
   { id: 'admin', label: 'Admin', icon: Database, color: 'slate' },
 ];
 
@@ -525,6 +527,8 @@ const SettingsPage = () => {
       {/* ====== COMPLIANCE CONFIG ====== */}
       {activeTab === 'compliance' ? (
         <ComplianceConfigPage embedded={true} />
+      ) : activeTab === 'propfirm' ? (
+        <PropFirmConfigPage embedded={true} />
       ) : activeTab === 'admin' ? (
         <div className="max-w-2xl space-y-4">
           {adminResult && (

--- a/src/utils/attackPlanCalculator.js
+++ b/src/utils/attackPlanCalculator.js
@@ -1,0 +1,276 @@
+// ============================================
+// ATTACK PLAN CALCULATOR — Hard Constraints
+// ============================================
+// Plano de ataque para conta prop firm. 100% rule-based.
+//
+// PRINCÍPIO FUNDAMENTAL:
+// As regras da mesa (drawdownMax, dailyLossLimit, profitTarget) são HARD CONSTRAINTS
+// absolutas — NUNCA inputs para fórmulas de percentual genérico.
+//
+// CONSTRAINTS INVIOLÁVEIS:
+//   1. roPerTrade NUNCA pode exceder dailyLossLimit
+//   2. stopPerTrade NUNCA pode exceder dailyLossLimit
+//   3. roPerTrade × maxTradesPerDay NUNCA pode exceder dailyLossLimit
+//   4. metaDiaria × diasUteis deve ser >= profitTarget
+//
+// Ref: issue #52, sessão revisão crítica 06/04/2026
+// Spec aprovada: AccountsPage → calculateAttackPlan(template, profile4D, indicators, planProfile, phase)
+
+import {
+  ATTACK_PLAN_PROFILES,
+  ATTACK_PLAN_DATA_SOURCES,
+  PROP_FIRM_PHASES
+} from '../constants/propFirmDefaults';
+
+// --- Fator do RO sobre dailyLossLimit, por perfil ---
+// RO por trade = dailyLossLimit × fator. Conservador usa fração menor.
+const RO_FACTOR_RANGES = {
+  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: { min: 0.08, max: 0.12 }, // 8-12% do daily loss
+  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: { min: 0.15, max: 0.20 }    // 15-20% do daily loss
+};
+
+// --- Cap operacional de trades/dia ---
+const MAX_TRADES_CAP = {
+  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 8,
+  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 10
+};
+
+// --- RR mínimo por perfil ---
+const RR_MINIMUM = {
+  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 1.5,
+  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 2.0
+};
+
+// --- Defaults de adjustmentFactor (sem 4D nem indicadores) ---
+const DEFAULT_ADJUSTMENT_FACTORS = {
+  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 0.3, // pessimista
+  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 0.6    // moderado
+};
+
+// --- Quando mesa não tem dailyLossLimit, usar fração do drawdown como proxy ---
+// Apex Intraday e MFF Core não têm daily loss explícito → conservador: 25% do drawdown.
+const DEFAULT_DAILY_LOSS_FRACTION = 0.25;
+
+// --- Conversão dias corridos → dias úteis (5 dias úteis a cada 7) ---
+const BUSINESS_DAYS_RATIO = 5 / 7;
+
+/**
+ * Resolve fonte de dados e calcula adjustmentFactor (0..1).
+ * Cascata: 4D completo > indicadores > defaults.
+ */
+export function resolveDataSource(profile4D, indicators, planProfile) {
+  // 1ª prioridade: Perfil 4D completo
+  if (profile4D &&
+      typeof profile4D.emotionalScore === 'number' &&
+      typeof profile4D.stage === 'number' &&
+      typeof profile4D.coefficientOfVariation === 'number') {
+    const emotionalFactor = profile4D.emotionalScore / 100;
+    const maturityFactor = profile4D.stage / 5;
+    const consistencyFactor = Math.max(0, 1 - profile4D.coefficientOfVariation);
+
+    const adjustmentFactor =
+      (emotionalFactor * 0.4) +
+      (maturityFactor * 0.3) +
+      (consistencyFactor * 0.3);
+
+    return {
+      dataSource: ATTACK_PLAN_DATA_SOURCES.FULL_4D,
+      adjustmentFactor: clamp(adjustmentFactor, 0, 1)
+    };
+  }
+
+  // 2ª prioridade: Indicadores sem 4D
+  if (indicators &&
+      typeof indicators.winRate === 'number' &&
+      typeof indicators.coefficientOfVariation === 'number') {
+    const maturityProxy = indicators.winRate;
+    const consistencyFactor = Math.max(0, 1 - indicators.coefficientOfVariation);
+    const emotionalDefault = 0.5;
+
+    const adjustmentFactor =
+      (emotionalDefault * 0.4) +
+      (maturityProxy * 0.3) +
+      (consistencyFactor * 0.3);
+
+    return {
+      dataSource: ATTACK_PLAN_DATA_SOURCES.INDICATORS,
+      adjustmentFactor: clamp(adjustmentFactor, 0, 1)
+    };
+  }
+
+  // 3ª prioridade: Defaults
+  return {
+    dataSource: ATTACK_PLAN_DATA_SOURCES.DEFAULTS,
+    adjustmentFactor: DEFAULT_ADJUSTMENT_FACTORS[planProfile]
+  };
+}
+
+/**
+ * Calcula plano de ataque com hard constraints da mesa.
+ *
+ * @param {Object} templateRules - Template da mesa (propFirmTemplates doc)
+ * @param {Object|null} profile4D - Perfil 4D do aluno
+ * @param {Object|null} indicators - Indicadores derivados de trades
+ * @param {string} planProfile - 'conservative' | 'aggressive'
+ * @param {string} phase - Fase atual da conta (EVALUATION, SIM_FUNDED, LIVE)
+ * @returns {Object} Plano de ataque
+ */
+export function calculateAttackPlan(templateRules, profile4D, indicators, planProfile, phase) {
+  if (!templateRules) {
+    throw new Error('templateRules é obrigatório');
+  }
+
+  // Normalizar perfil/fase com defaults seguros
+  const validProfile = Object.values(ATTACK_PLAN_PROFILES).includes(planProfile)
+    ? planProfile
+    : ATTACK_PLAN_PROFILES.CONSERVATIVE;
+
+  const validPhase = Object.values(PROP_FIRM_PHASES).includes(phase)
+    ? phase
+    : PROP_FIRM_PHASES.EVALUATION;
+
+  // ============================================
+  // HARD CONSTRAINTS DA MESA (valores absolutos)
+  // ============================================
+  const drawdownMax = templateRules.drawdown?.maxAmount ?? 0;
+  const profitTarget = templateRules.profitTarget ?? 0;
+  const evalTimeLimit = templateRules.evalTimeLimit ?? 30;
+
+  // Daily loss limit: usar valor da mesa se existir, senão proxy
+  // Mínimo absoluto de $1 para evitar divisão por zero / RO inválido
+  const rawDailyLossLimit = templateRules.dailyLossLimit;
+  const effectiveDailyLossLimit = rawDailyLossLimit && rawDailyLossLimit > 0
+    ? rawDailyLossLimit
+    : Math.max(1, Math.round(drawdownMax * DEFAULT_DAILY_LOSS_FRACTION));
+
+  // ============================================
+  // CALIBRAGEM POR PERFIL DO ALUNO
+  // ============================================
+  const { dataSource, adjustmentFactor } = resolveDataSource(profile4D, indicators, validProfile);
+
+  // Fator do RO = % do daily loss, escalado pelo adjustment
+  const range = RO_FACTOR_RANGES[validProfile];
+  const roFactor = range.min + (adjustmentFactor * (range.max - range.min));
+
+  // ============================================
+  // CÁLCULO COM CONSTRAINTS
+  // ============================================
+
+  // 1. RO por trade = % do daily loss limit (NUNCA do drawdown)
+  let roPerTrade = Math.max(1, Math.floor(effectiveDailyLossLimit * roFactor));
+
+  // 2. Max trades por dia: cap operacional + constraint
+  const operationalCap = MAX_TRADES_CAP[validProfile];
+  let maxTradesPerDay = Math.min(
+    operationalCap,
+    Math.max(1, Math.floor(effectiveDailyLossLimit / roPerTrade))
+  );
+
+  // 3. CONSTRAINT: roPerTrade × maxTradesPerDay ≤ dailyLossLimit
+  // Já garantido pela divisão acima (floor garante que ⌊x/y⌋ × y ≤ x).
+  // Mas verificar explicitamente por segurança:
+  if (roPerTrade * maxTradesPerDay > effectiveDailyLossLimit) {
+    roPerTrade = Math.floor(effectiveDailyLossLimit / maxTradesPerDay);
+  }
+
+  // 4. CONSTRAINT: roPerTrade ≤ dailyLossLimit (trivialmente garantido pelo cálculo)
+  if (roPerTrade > effectiveDailyLossLimit) {
+    roPerTrade = effectiveDailyLossLimit;
+    maxTradesPerDay = 1;
+  }
+
+  // 5. RR mínimo por perfil (conservador 1.5:1, agressivo 2:1)
+  const rrMinimum = RR_MINIMUM[validProfile];
+
+  // 6. Stop por trade = roPerTrade / rrMinimum (spec literal do user)
+  // Interpretação: roPerTrade é o "orçamento" do trade, stopPerTrade é o stop loss real
+  // proporcional ao RR desejado. Stop sempre ≤ RO.
+  const stopPerTrade = Math.max(1, Math.floor(roPerTrade / rrMinimum));
+
+  // CONSTRAINT: stopPerTrade ≤ dailyLossLimit (trivialmente garantido)
+  // (stopPerTrade < roPerTrade < dailyLossLimit por construção)
+
+  // ============================================
+  // META DIÁRIA — derivada do profitTarget e dias úteis
+  // ============================================
+
+  // Dias úteis efetivos no prazo de avaliação
+  const evalBusinessDays = evalTimeLimit > 0
+    ? Math.max(1, Math.floor(evalTimeLimit * BUSINESS_DAYS_RATIO))
+    : 21;
+
+  // Meta diária: usar Math.ceil para garantir constraint metaDiaria × diasUteis >= profitTarget
+  const dailyTarget = profitTarget > 0
+    ? Math.ceil(profitTarget / evalBusinessDays)
+    : 0;
+
+  // Days to target — quantos dias bem-sucedidos para bater o profit
+  const daysToTarget = dailyTarget > 0
+    ? Math.ceil(profitTarget / dailyTarget)
+    : evalBusinessDays;
+
+  // Buffer = margem de segurança em dias
+  const bufferDays = Math.max(0, evalBusinessDays - daysToTarget);
+
+  // ============================================
+  // VALIDAÇÃO DAS CONSTRAINTS (sanity check)
+  // ============================================
+  const constraintsViolated = [];
+  if (roPerTrade > effectiveDailyLossLimit) {
+    constraintsViolated.push('roPerTrade excede dailyLossLimit');
+  }
+  if (stopPerTrade > effectiveDailyLossLimit) {
+    constraintsViolated.push('stopPerTrade excede dailyLossLimit');
+  }
+  if (roPerTrade * maxTradesPerDay > effectiveDailyLossLimit) {
+    constraintsViolated.push('roPerTrade × maxTradesPerDay excede dailyLossLimit');
+  }
+  if (dailyTarget * evalBusinessDays < profitTarget) {
+    constraintsViolated.push('metaDiaria × diasUteis < profitTarget');
+  }
+
+  return {
+    profile: validProfile,
+    dataSource,
+    adjustmentFactor: round(adjustmentFactor, 4),
+
+    // Hard limits da mesa (valores absolutos, referência para alerta)
+    drawdownMax,
+    dailyLossLimit: effectiveDailyLossLimit,
+    profitTarget,
+
+    // Por trade (valores absolutos em USD)
+    roPerTrade,        // ex: $50
+    stopPerTrade,      // ex: $33 (= roPerTrade / rrMinimum)
+    rrMinimum,         // ex: 1.5
+    roFactor: round(roFactor, 4), // ex: 0.10
+
+    // Diário
+    maxTradesPerDay,   // ex: 8 (cap operacional)
+    dailyTarget,       // ex: $72 (profitTarget / dias úteis)
+
+    // Total avaliação
+    evalBusinessDays,  // ex: 21 dias úteis
+    daysToTarget,      // ex: 21 dias
+    bufferDays,        // ex: 0 dias
+
+    // Sizing depende do instrumento (calculado depois)
+    sizing: null,
+
+    // Validação
+    constraintsViolated,
+
+    generatedAt: new Date().toISOString()
+  };
+}
+
+// --- Helpers ---
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function round(value, decimals) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}

--- a/src/utils/attackPlanCalculator.js
+++ b/src/utils/attackPlanCalculator.js
@@ -1,11 +1,12 @@
 // ============================================
-// ATTACK PLAN CALCULATOR — Hard Constraints
+// ATTACK PLAN CALCULATOR — Instrument-Aware
 // ============================================
 // Plano de ataque para conta prop firm. 100% rule-based.
 //
 // PRINCÍPIO FUNDAMENTAL:
 // As regras da mesa (drawdownMax, dailyLossLimit, profitTarget) são HARD CONSTRAINTS
-// absolutas — NUNCA inputs para fórmulas de percentual genérico.
+// absolutas. O instrumento operado define o stop natural realista (via ATR + minStop).
+// O plano back-calcula RO real partindo do stop natural × pointValue.
 //
 // CONSTRAINTS INVIOLÁVEIS:
 //   1. roPerTrade NUNCA pode exceder dailyLossLimit
@@ -13,32 +14,34 @@
 //   3. roPerTrade × maxTradesPerDay NUNCA pode exceder dailyLossLimit
 //   4. metaDiaria × diasUteis deve ser >= profitTarget
 //
-// Ref: issue #52, sessão revisão crítica 06/04/2026
-// Spec aprovada: AccountsPage → calculateAttackPlan(template, profile4D, indicators, planProfile, phase)
+// MODOS DE OPERAÇÃO:
+//   - SEM instrumento: retorna apenas constraints da mesa (modo 'abstract')
+//   - COM instrumento: retorna plano completo de execução (modo 'execution')
+//
+// Ref: issue #52 Fase 1.5, sessão revisão 06/04/2026
 
 import {
   ATTACK_PLAN_PROFILES,
   ATTACK_PLAN_DATA_SOURCES,
   PROP_FIRM_PHASES
 } from '../constants/propFirmDefaults';
-
-// --- Fator do RO sobre dailyLossLimit, por perfil ---
-// RO por trade = dailyLossLimit × fator. Conservador usa fração menor.
-const RO_FACTOR_RANGES = {
-  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: { min: 0.08, max: 0.12 }, // 8-12% do daily loss
-  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: { min: 0.15, max: 0.20 }    // 15-20% do daily loss
-};
-
-// --- Cap operacional de trades/dia ---
-const MAX_TRADES_CAP = {
-  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 8,
-  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 10
-};
+import {
+  getInstrument,
+  getRecommendedStop,
+  suggestMicroAlternative,
+  isInstrumentAllowed
+} from '../constants/instrumentsTable';
 
 // --- RR mínimo por perfil ---
 const RR_MINIMUM = {
   [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 1.5,
   [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 2.0
+};
+
+// --- Cap operacional de trades/dia (independe da fórmula matemática) ---
+const MAX_TRADES_CAP = {
+  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 8,
+  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 10
 };
 
 // --- Defaults de adjustmentFactor (sem 4D nem indicadores) ---
@@ -47,16 +50,25 @@ const DEFAULT_ADJUSTMENT_FACTORS = {
   [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 0.6    // moderado
 };
 
+// --- Margem do RO sobre o stop natural (gordura para slippage) ---
+// roPerTrade = stopUSD × (1 + ROUND_UP_FACTOR). Ex: stop $40 + 25% = RO $50
+const RO_OVERHEAD = {
+  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 0.10, // +10% conservador (pouca gordura)
+  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 0.20    // +20% agressivo (mais espaço)
+};
+
 // --- Quando mesa não tem dailyLossLimit, usar fração do drawdown como proxy ---
-// Apex Intraday e MFF Core não têm daily loss explícito → conservador: 25% do drawdown.
 const DEFAULT_DAILY_LOSS_FRACTION = 0.25;
 
-// --- Conversão dias corridos → dias úteis (5 dias úteis a cada 7) ---
+// --- Conversão dias corridos → dias úteis ---
 const BUSINESS_DAYS_RATIO = 5 / 7;
+
+// ============================================
+// resolveDataSource — cascata 4D > indicadores > defaults
+// ============================================
 
 /**
  * Resolve fonte de dados e calcula adjustmentFactor (0..1).
- * Cascata: 4D completo > indicadores > defaults.
  */
 export function resolveDataSource(profile4D, indicators, planProfile) {
   // 1ª prioridade: Perfil 4D completo
@@ -105,22 +117,71 @@ export function resolveDataSource(profile4D, indicators, planProfile) {
   };
 }
 
+// ============================================
+// calculateMesaConstraints — modo abstract (sem instrumento)
+// ============================================
+
 /**
- * Calcula plano de ataque com hard constraints da mesa.
+ * Calcula apenas as constraints da mesa, sem entrar em sizing/stop/RO.
+ * Útil quando o aluno ainda não selecionou instrumento.
+ *
+ * @param {Object} templateRules - template da mesa
+ * @returns {Object} constraints abstratas + dailyTarget
+ */
+export function calculateMesaConstraints(templateRules) {
+  if (!templateRules) {
+    throw new Error('templateRules é obrigatório');
+  }
+
+  const drawdownMax = templateRules.drawdown?.maxAmount ?? 0;
+  const profitTarget = templateRules.profitTarget ?? 0;
+  const evalTimeLimit = templateRules.evalTimeLimit ?? 30;
+
+  const rawDailyLossLimit = templateRules.dailyLossLimit;
+  const effectiveDailyLossLimit = rawDailyLossLimit && rawDailyLossLimit > 0
+    ? rawDailyLossLimit
+    : Math.max(1, Math.round(drawdownMax * DEFAULT_DAILY_LOSS_FRACTION));
+
+  const evalBusinessDays = evalTimeLimit > 0
+    ? Math.max(1, Math.floor(evalTimeLimit * BUSINESS_DAYS_RATIO))
+    : 21;
+
+  const dailyTarget = profitTarget > 0
+    ? Math.ceil(profitTarget / evalBusinessDays)
+    : 0;
+
+  return {
+    drawdownMax,
+    dailyLossLimit: effectiveDailyLossLimit,
+    profitTarget,
+    evalTimeLimit,
+    evalBusinessDays,
+    dailyTarget
+  };
+}
+
+// ============================================
+// calculateAttackPlan — modo execution (com instrumento) ou abstract (sem)
+// ============================================
+
+/**
+ * Calcula plano de ataque.
  *
  * @param {Object} templateRules - Template da mesa (propFirmTemplates doc)
  * @param {Object|null} profile4D - Perfil 4D do aluno
  * @param {Object|null} indicators - Indicadores derivados de trades
  * @param {string} planProfile - 'conservative' | 'aggressive'
- * @param {string} phase - Fase atual da conta (EVALUATION, SIM_FUNDED, LIVE)
+ * @param {string} phase - Fase atual da conta
+ * @param {string|null} instrumentSymbol - símbolo do instrumento (ex: 'MNQ', 'NQ', 'ES')
+ *                                          OU null/undefined para modo abstract
  * @returns {Object} Plano de ataque
  */
-export function calculateAttackPlan(templateRules, profile4D, indicators, planProfile, phase) {
+export function calculateAttackPlan(templateRules, profile4D, indicators, planProfile, phase, instrumentSymbol = null) {
   if (!templateRules) {
     throw new Error('templateRules é obrigatório');
   }
 
-  // Normalizar perfil/fase com defaults seguros
+  // Normalizar perfil/fase
   const validProfile = Object.values(ATTACK_PLAN_PROFILES).includes(planProfile)
     ? planProfile
     : ATTACK_PLAN_PROFILES.CONSERVATIVE;
@@ -129,133 +190,190 @@ export function calculateAttackPlan(templateRules, profile4D, indicators, planPr
     ? phase
     : PROP_FIRM_PHASES.EVALUATION;
 
-  // ============================================
-  // HARD CONSTRAINTS DA MESA (valores absolutos)
-  // ============================================
-  const drawdownMax = templateRules.drawdown?.maxAmount ?? 0;
-  const profitTarget = templateRules.profitTarget ?? 0;
-  const evalTimeLimit = templateRules.evalTimeLimit ?? 30;
+  // Constraints da mesa (sempre presentes)
+  const mesaConstraints = calculateMesaConstraints(templateRules);
+  const { drawdownMax, dailyLossLimit, profitTarget, evalBusinessDays, dailyTarget } = mesaConstraints;
 
-  // Daily loss limit: usar valor da mesa se existir, senão proxy
-  // Mínimo absoluto de $1 para evitar divisão por zero / RO inválido
-  const rawDailyLossLimit = templateRules.dailyLossLimit;
-  const effectiveDailyLossLimit = rawDailyLossLimit && rawDailyLossLimit > 0
-    ? rawDailyLossLimit
-    : Math.max(1, Math.round(drawdownMax * DEFAULT_DAILY_LOSS_FRACTION));
-
-  // ============================================
-  // CALIBRAGEM POR PERFIL DO ALUNO
-  // ============================================
+  // Calibragem por perfil do aluno
   const { dataSource, adjustmentFactor } = resolveDataSource(profile4D, indicators, validProfile);
 
-  // Fator do RO = % do daily loss, escalado pelo adjustment
-  const range = RO_FACTOR_RANGES[validProfile];
-  const roFactor = range.min + (adjustmentFactor * (range.max - range.min));
-
   // ============================================
-  // CÁLCULO COM CONSTRAINTS
+  // MODO ABSTRACT — sem instrumento selecionado
   // ============================================
+  if (!instrumentSymbol) {
+    return {
+      mode: 'abstract',
+      profile: validProfile,
+      dataSource,
+      adjustmentFactor: round(adjustmentFactor, 4),
 
-  // 1. RO por trade = % do daily loss limit (NUNCA do drawdown)
-  let roPerTrade = Math.max(1, Math.floor(effectiveDailyLossLimit * roFactor));
+      // Constraints da mesa (sempre presentes)
+      drawdownMax,
+      dailyLossLimit,
+      profitTarget,
+      evalBusinessDays,
+      dailyTarget,
 
-  // 2. Max trades por dia: cap operacional + constraint
-  const operationalCap = MAX_TRADES_CAP[validProfile];
-  let maxTradesPerDay = Math.min(
-    operationalCap,
-    Math.max(1, Math.floor(effectiveDailyLossLimit / roPerTrade))
-  );
+      // Sem instrumento, valores de execução são null
+      instrument: null,
+      stopPoints: null,
+      stopPerTrade: null,
+      roPerTrade: null,
+      rrMinimum: RR_MINIMUM[validProfile],
+      maxTradesPerDay: null,
+      sizing: null,
 
-  // 3. CONSTRAINT: roPerTrade × maxTradesPerDay ≤ dailyLossLimit
-  // Já garantido pela divisão acima (floor garante que ⌊x/y⌋ × y ≤ x).
-  // Mas verificar explicitamente por segurança:
-  if (roPerTrade * maxTradesPerDay > effectiveDailyLossLimit) {
-    roPerTrade = Math.floor(effectiveDailyLossLimit / maxTradesPerDay);
+      // Mensagem informativa
+      message: 'Selecione um instrumento para gerar o plano de execução completo.',
+
+      constraintsViolated: [],
+      generatedAt: new Date().toISOString()
+    };
   }
 
-  // 4. CONSTRAINT: roPerTrade ≤ dailyLossLimit (trivialmente garantido pelo cálculo)
-  if (roPerTrade > effectiveDailyLossLimit) {
-    roPerTrade = effectiveDailyLossLimit;
-    maxTradesPerDay = 1;
+  // ============================================
+  // MODO EXECUTION — com instrumento
+  // ============================================
+  const instrument = getInstrument(instrumentSymbol);
+  if (!instrument) {
+    return {
+      mode: 'error',
+      profile: validProfile,
+      dataSource,
+      error: `Instrumento '${instrumentSymbol}' não encontrado na tabela`,
+      constraintsViolated: ['instrument_not_found'],
+      generatedAt: new Date().toISOString()
+    };
   }
 
-  // 5. RR mínimo por perfil (conservador 1.5:1, agressivo 2:1)
+  // Verificar disponibilidade na mesa
+  const firm = (templateRules.firm ?? '').toLowerCase();
+  const allowed = !firm || isInstrumentAllowed(instrumentSymbol, firm);
+
+  // Stop natural recomendado (max(ATR×5%, minStop))
+  const stop = getRecommendedStop(instrument);
+  const stopPoints = stop.stopPoints;
+  const stopUSD = stop.stopUSD;
+
+  // RR mínimo por perfil
   const rrMinimum = RR_MINIMUM[validProfile];
 
-  // 6. Stop por trade = roPerTrade / rrMinimum (spec literal do user)
-  // Interpretação: roPerTrade é o "orçamento" do trade, stopPerTrade é o stop loss real
-  // proporcional ao RR desejado. Stop sempre ≤ RO.
-  const stopPerTrade = Math.max(1, Math.floor(roPerTrade / rrMinimum));
-
-  // CONSTRAINT: stopPerTrade ≤ dailyLossLimit (trivialmente garantido)
-  // (stopPerTrade < roPerTrade < dailyLossLimit por construção)
+  // RO por trade = stop natural + overhead (gordura para slippage/comissão)
+  const overhead = RO_OVERHEAD[validProfile];
+  const adjustedOverhead = overhead * (1 + (1 - adjustmentFactor) * 0.5); // aluno fraco = mais gordura
+  let roPerTrade = Math.ceil(stopUSD * (1 + adjustedOverhead));
 
   // ============================================
-  // META DIÁRIA — derivada do profitTarget e dias úteis
+  // VERIFICAR FACTIBILIDADE
   // ============================================
+  // Se RO por trade > daily loss limit, instrumento é incompatível
+  // (1 trade já estoura o dia inteiro)
+  let incompatible = false;
+  let microSuggestion = null;
 
-  // Dias úteis efetivos no prazo de avaliação
-  const evalBusinessDays = evalTimeLimit > 0
-    ? Math.max(1, Math.floor(evalTimeLimit * BUSINESS_DAYS_RATIO))
-    : 21;
+  if (roPerTrade > dailyLossLimit) {
+    incompatible = true;
+    // Sugerir micro variant se disponível
+    if (!instrument.isMicro) {
+      const micro = suggestMicroAlternative(instrumentSymbol);
+      if (micro && (!firm || isInstrumentAllowed(micro.symbol, firm))) {
+        microSuggestion = micro.symbol;
+      }
+    }
+  }
 
-  // Meta diária: usar Math.ceil para garantir constraint metaDiaria × diasUteis >= profitTarget
-  const dailyTarget = profitTarget > 0
-    ? Math.ceil(profitTarget / evalBusinessDays)
-    : 0;
+  // Max trades por dia: cap operacional + constraint do daily loss
+  const operationalCap = MAX_TRADES_CAP[validProfile];
+  let maxTradesPerDay = incompatible
+    ? 0
+    : Math.min(
+        operationalCap,
+        Math.max(1, Math.floor(dailyLossLimit / roPerTrade))
+      );
 
-  // Days to target — quantos dias bem-sucedidos para bater o profit
+  // CONSTRAINT: roPerTrade × maxTradesPerDay ≤ dailyLossLimit
+  // (já garantido pela divisão acima — sanity check)
+  if (!incompatible && roPerTrade * maxTradesPerDay > dailyLossLimit) {
+    roPerTrade = Math.floor(dailyLossLimit / maxTradesPerDay);
+  }
+
+  // Sizing: 1 contrato é o default seguro
+  // (escalar para mais contratos = aumentar pointValue efetivo, não entra na Fase 1.5)
+  const sizing = incompatible ? 0 : 1;
+
+  // Days to target
   const daysToTarget = dailyTarget > 0
     ? Math.ceil(profitTarget / dailyTarget)
     : evalBusinessDays;
-
-  // Buffer = margem de segurança em dias
   const bufferDays = Math.max(0, evalBusinessDays - daysToTarget);
 
   // ============================================
-  // VALIDAÇÃO DAS CONSTRAINTS (sanity check)
+  // VALIDAÇÃO DAS CONSTRAINTS
   // ============================================
   const constraintsViolated = [];
-  if (roPerTrade > effectiveDailyLossLimit) {
-    constraintsViolated.push('roPerTrade excede dailyLossLimit');
+  if (!incompatible) {
+    if (roPerTrade > dailyLossLimit) {
+      constraintsViolated.push('roPerTrade excede dailyLossLimit');
+    }
+    if (stopUSD > dailyLossLimit) {
+      constraintsViolated.push('stopPerTrade excede dailyLossLimit');
+    }
+    if (roPerTrade * maxTradesPerDay > dailyLossLimit) {
+      constraintsViolated.push('roPerTrade × maxTradesPerDay excede dailyLossLimit');
+    }
+    if (dailyTarget * evalBusinessDays < profitTarget) {
+      constraintsViolated.push('metaDiaria × diasUteis < profitTarget');
+    }
   }
-  if (stopPerTrade > effectiveDailyLossLimit) {
-    constraintsViolated.push('stopPerTrade excede dailyLossLimit');
-  }
-  if (roPerTrade * maxTradesPerDay > effectiveDailyLossLimit) {
-    constraintsViolated.push('roPerTrade × maxTradesPerDay excede dailyLossLimit');
-  }
-  if (dailyTarget * evalBusinessDays < profitTarget) {
-    constraintsViolated.push('metaDiaria × diasUteis < profitTarget');
+
+  if (!allowed) {
+    constraintsViolated.push(`instrumento '${instrumentSymbol}' não permitido na mesa '${firm}'`);
   }
 
   return {
+    mode: 'execution',
     profile: validProfile,
     dataSource,
     adjustmentFactor: round(adjustmentFactor, 4),
 
-    // Hard limits da mesa (valores absolutos, referência para alerta)
+    // Hard limits da mesa
     drawdownMax,
-    dailyLossLimit: effectiveDailyLossLimit,
+    dailyLossLimit,
     profitTarget,
 
-    // Por trade (valores absolutos em USD)
-    roPerTrade,        // ex: $50
-    stopPerTrade,      // ex: $33 (= roPerTrade / rrMinimum)
-    rrMinimum,         // ex: 1.5
-    roFactor: round(roFactor, 4), // ex: 0.10
+    // Instrumento
+    instrument: {
+      symbol: instrument.symbol,
+      name: instrument.name,
+      isMicro: instrument.isMicro,
+      pointValue: instrument.pointValue,
+      avgDailyRange: instrument.avgDailyRange,
+      type: instrument.type
+    },
+
+    // Por trade (instrument-aware)
+    stopPoints,                          // pontos no instrumento (ex: 20 pts MNQ)
+    stopPerTrade: round(stopUSD, 2),     // USD (ex: $40 MNQ, $400 NQ)
+    stopSource: stop.source,             // 'atr' ou 'min'
+    roPerTrade,                          // USD (stop + overhead, ex: $44 ou $48)
+    rrMinimum,
+    targetPerTrade: round(stopUSD * rrMinimum, 2), // USD esperado por trade ganho
 
     // Diário
-    maxTradesPerDay,   // ex: 8 (cap operacional)
-    dailyTarget,       // ex: $72 (profitTarget / dias úteis)
+    maxTradesPerDay,
+    dailyTarget,
 
     // Total avaliação
-    evalBusinessDays,  // ex: 21 dias úteis
-    daysToTarget,      // ex: 21 dias
-    bufferDays,        // ex: 0 dias
+    evalBusinessDays,
+    daysToTarget,
+    bufferDays,
 
-    // Sizing depende do instrumento (calculado depois)
-    sizing: null,
+    // Sizing (1 contrato fixo na Fase 1.5)
+    sizing,
+
+    // Factibilidade
+    incompatible,
+    microSuggestion,
 
     // Validação
     constraintsViolated,

--- a/src/utils/attackPlanCalculator.js
+++ b/src/utils/attackPlanCalculator.js
@@ -1,76 +1,73 @@
 // ============================================
-// ATTACK PLAN CALCULATOR — Instrument-Aware
+// ATTACK PLAN CALCULATOR — Determinístico (5 perfis)
 // ============================================
 // Plano de ataque para conta prop firm. 100% rule-based.
 //
-// PRINCÍPIO FUNDAMENTAL:
-// As regras da mesa (drawdownMax, dailyLossLimit, profitTarget) são HARD CONSTRAINTS
-// absolutas. O instrumento operado define o stop natural realista (via ATR + minStop).
-// O plano back-calcula RO real partindo do stop natural × pointValue.
+// MODELO (Fase 1.5 v2 — 07/04/2026):
+//   RO por trade = drawdownMax × profile.roPct (10%, 15%, 20%, 25%, 30%)
+//   stopPoints   = roUSD / instrument.pointValue   ← back-calculado do RO
+//   targetPoints = stopPoints × profile.rr (RR fixo 1:2)
+//   maxTradesPerDay = profile.maxTradesPerDay (2 conservadores, 1 agressivos)
 //
-// CONSTRAINTS INVIOLÁVEIS:
-//   1. roPerTrade NUNCA pode exceder dailyLossLimit
-//   2. stopPerTrade NUNCA pode exceder dailyLossLimit
-//   3. roPerTrade × maxTradesPerDay NUNCA pode exceder dailyLossLimit
-//   4. metaDiaria × diasUteis deve ser >= profitTarget
+// INVERSÃO INTENCIONAL: quanto mais arrisca, MENOS opera.
+// Disciplina forçada pelo sizing.
 //
-// MODOS DE OPERAÇÃO:
-//   - SEM instrumento: retorna apenas constraints da mesa (modo 'abstract')
-//   - COM instrumento: retorna plano completo de execução (modo 'execution')
+// VIABILIDADE:
+//   - Se stopPoints < MIN_VIABLE_STOP[type] → INVIÁVEL → sugere micro
+//   - Se stopNyPct > MAX_STOP_NY_PCT (75%) → INVIÁVEL (vela única consome stop)
+//   - Se roUSD > dailyLossLimit → INVIÁVEL
+//   - Se roUSD × maxTradesPerDay > dailyLossLimit → reduz maxTradesPerDay
 //
-// Ref: issue #52 Fase 1.5, sessão revisão 06/04/2026
+// MODOS:
+//   - SEM instrumento: modo 'abstract' (apenas constraints da mesa + perfil)
+//   - COM instrumento: modo 'execution' (plano completo com sizing/stop/RO)
+//
+// Ref: issue #52 Fase 1.5, Temp/attack-plan-deterministic-table.md v2.0
 
 import {
-  ATTACK_PLAN_PROFILES,
+  ATTACK_PROFILES,
   ATTACK_PLAN_DATA_SOURCES,
-  PROP_FIRM_PHASES
+  PROP_FIRM_PHASES,
+  MIN_VIABLE_STOP,
+  MAX_STOP_NY_PCT,
+  MIN_STOP_NY_PCT,
+  NY_MIN_VIABLE_STOP_PCT,
+  NY_RANGE_FRACTION,
+  DEFAULT_ASSUMED_WR,
+  RR2_BREAKEVEN_WR,
+  DEFAULT_ATTACK_PROFILE,
+  normalizeAttackProfile
 } from '../constants/propFirmDefaults';
 import {
   getInstrument,
-  getRecommendedStop,
   suggestMicroAlternative,
   isInstrumentAllowed
 } from '../constants/instrumentsTable';
 
-// --- RR mínimo por perfil ---
-const RR_MINIMUM = {
-  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 1.5,
-  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 2.0
-};
-
-// --- Cap operacional de trades/dia (independe da fórmula matemática) ---
-const MAX_TRADES_CAP = {
-  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 8,
-  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 10
-};
-
-// --- Defaults de adjustmentFactor (sem 4D nem indicadores) ---
-const DEFAULT_ADJUSTMENT_FACTORS = {
-  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 0.3, // pessimista
-  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 0.6    // moderado
-};
-
-// --- Margem do RO sobre o stop natural (gordura para slippage) ---
-// roPerTrade = stopUSD × (1 + ROUND_UP_FACTOR). Ex: stop $40 + 25% = RO $50
-const RO_OVERHEAD = {
-  [ATTACK_PLAN_PROFILES.CONSERVATIVE]: 0.10, // +10% conservador (pouca gordura)
-  [ATTACK_PLAN_PROFILES.AGGRESSIVE]: 0.20    // +20% agressivo (mais espaço)
-};
-
-// --- Quando mesa não tem dailyLossLimit, usar fração do drawdown como proxy ---
+// Quando mesa não tem dailyLossLimit, usar fração do drawdown como proxy
 const DEFAULT_DAILY_LOSS_FRACTION = 0.25;
 
-// --- Conversão dias corridos → dias úteis ---
+// Conversão dias corridos → dias úteis
 const BUSINESS_DAYS_RATIO = 5 / 7;
+
+// Defaults de adjustmentFactor (transparência da calibragem, não usado no cálculo principal)
+const DEFAULT_ADJUSTMENT_FACTORS = {
+  conservative: 0.3, // pessimista
+  aggressive: 0.6    // moderado
+};
 
 // ============================================
 // resolveDataSource — cascata 4D > indicadores > defaults
 // ============================================
 
 /**
- * Resolve fonte de dados e calcula adjustmentFactor (0..1).
+ * Resolve fonte de dados, adjustmentFactor (0..1) e WR efetivo (para EV).
+ *
+ * @param {Object|null} profile4D
+ * @param {Object|null} indicators
+ * @param {string} profileFamily - 'conservative' | 'aggressive'
  */
-export function resolveDataSource(profile4D, indicators, planProfile) {
+export function resolveDataSource(profile4D, indicators, profileFamily = 'conservative') {
   // 1ª prioridade: Perfil 4D completo
   if (profile4D &&
       typeof profile4D.emotionalScore === 'number' &&
@@ -85,9 +82,15 @@ export function resolveDataSource(profile4D, indicators, planProfile) {
       (maturityFactor * 0.3) +
       (consistencyFactor * 0.3);
 
+    // WR pode vir de indicators se disponível, senão default
+    const assumedWR = (indicators && typeof indicators.winRate === 'number')
+      ? indicators.winRate
+      : DEFAULT_ASSUMED_WR;
+
     return {
       dataSource: ATTACK_PLAN_DATA_SOURCES.FULL_4D,
-      adjustmentFactor: clamp(adjustmentFactor, 0, 1)
+      adjustmentFactor: clamp(adjustmentFactor, 0, 1),
+      assumedWR
     };
   }
 
@@ -106,28 +109,23 @@ export function resolveDataSource(profile4D, indicators, planProfile) {
 
     return {
       dataSource: ATTACK_PLAN_DATA_SOURCES.INDICATORS,
-      adjustmentFactor: clamp(adjustmentFactor, 0, 1)
+      adjustmentFactor: clamp(adjustmentFactor, 0, 1),
+      assumedWR: indicators.winRate
     };
   }
 
   // 3ª prioridade: Defaults
   return {
     dataSource: ATTACK_PLAN_DATA_SOURCES.DEFAULTS,
-    adjustmentFactor: DEFAULT_ADJUSTMENT_FACTORS[planProfile]
+    adjustmentFactor: DEFAULT_ADJUSTMENT_FACTORS[profileFamily] ?? 0.3,
+    assumedWR: DEFAULT_ASSUMED_WR
   };
 }
 
 // ============================================
-// calculateMesaConstraints — modo abstract (sem instrumento)
+// calculateMesaConstraints — apenas constraints da mesa
 // ============================================
 
-/**
- * Calcula apenas as constraints da mesa, sem entrar em sizing/stop/RO.
- * Útil quando o aluno ainda não selecionou instrumento.
- *
- * @param {Object} templateRules - template da mesa
- * @returns {Object} constraints abstratas + dailyTarget
- */
 export function calculateMesaConstraints(templateRules) {
   if (!templateRules) {
     throw new Error('templateRules é obrigatório');
@@ -161,41 +159,47 @@ export function calculateMesaConstraints(templateRules) {
 }
 
 // ============================================
-// calculateAttackPlan — modo execution (com instrumento) ou abstract (sem)
+// calculateAttackPlan — modos abstract / execution
 // ============================================
 
 /**
- * Calcula plano de ataque.
+ * Calcula plano de ataque determinístico.
  *
- * @param {Object} templateRules - Template da mesa (propFirmTemplates doc)
- * @param {Object|null} profile4D - Perfil 4D do aluno
- * @param {Object|null} indicators - Indicadores derivados de trades
- * @param {string} planProfile - 'conservative' | 'aggressive'
- * @param {string} phase - Fase atual da conta
- * @param {string|null} instrumentSymbol - símbolo do instrumento (ex: 'MNQ', 'NQ', 'ES')
- *                                          OU null/undefined para modo abstract
- * @returns {Object} Plano de ataque
+ * @param {Object} templateRules - template da mesa
+ * @param {Object|null} profile4D
+ * @param {Object|null} indicators - { winRate, coefficientOfVariation, ... }
+ * @param {string} planProfile - código do perfil (CONS_A..AGRES_B). Aceita legados 'conservative'/'aggressive'
+ * @param {string} phase - fase da conta (EVALUATION/SIM_FUNDED/LIVE)
+ * @param {string|null} instrumentSymbol - símbolo do instrumento (null = modo abstract)
  */
 export function calculateAttackPlan(templateRules, profile4D, indicators, planProfile, phase, instrumentSymbol = null) {
   if (!templateRules) {
     throw new Error('templateRules é obrigatório');
   }
 
-  // Normalizar perfil/fase
-  const validProfile = Object.values(ATTACK_PLAN_PROFILES).includes(planProfile)
-    ? planProfile
-    : ATTACK_PLAN_PROFILES.CONSERVATIVE;
+  // Normalizar perfil (suporta legados) e fase
+  const profileKey = normalizeAttackProfile(planProfile);
+  const profile = ATTACK_PROFILES[profileKey] ?? ATTACK_PROFILES[DEFAULT_ATTACK_PROFILE];
 
   const validPhase = Object.values(PROP_FIRM_PHASES).includes(phase)
     ? phase
     : PROP_FIRM_PHASES.EVALUATION;
 
-  // Constraints da mesa (sempre presentes)
+  // Constraints da mesa
   const mesaConstraints = calculateMesaConstraints(templateRules);
   const { drawdownMax, dailyLossLimit, profitTarget, evalBusinessDays, dailyTarget } = mesaConstraints;
 
-  // Calibragem por perfil do aluno
-  const { dataSource, adjustmentFactor } = resolveDataSource(profile4D, indicators, validProfile);
+  // Calibragem por perfil do aluno (transparência + WR para EV)
+  const { dataSource, adjustmentFactor, assumedWR } = resolveDataSource(profile4D, indicators, profile.family);
+
+  // ============================================
+  // CÁLCULO DETERMINÍSTICO BASE (sem instrumento)
+  // ============================================
+  const roUSD = round(drawdownMax * profile.roPct, 2);
+  const winUSD = round(roUSD * profile.rr, 2);
+  const lossesToBust = roUSD > 0 ? Math.floor(drawdownMax / roUSD) : 0;
+  const evPerTrade = round((assumedWR * winUSD) - ((1 - assumedWR) * roUSD), 2);
+  const wrBelowBreakeven = assumedWR < RR2_BREAKEVEN_WR;
 
   // ============================================
   // MODO ABSTRACT — sem instrumento selecionado
@@ -203,29 +207,44 @@ export function calculateAttackPlan(templateRules, profile4D, indicators, planPr
   if (!instrumentSymbol) {
     return {
       mode: 'abstract',
-      profile: validProfile,
+      profile: profileKey,
+      profileName: profile.name,
+      profileFamily: profile.family,
+      profileRecommended: profile.recommended === true,
       dataSource,
       adjustmentFactor: round(adjustmentFactor, 4),
+      assumedWR,
+      wrBelowBreakeven,
 
-      // Constraints da mesa (sempre presentes)
+      // Constraints da mesa
       drawdownMax,
       dailyLossLimit,
       profitTarget,
       evalBusinessDays,
       dailyTarget,
+      phase: validPhase,
 
-      // Sem instrumento, valores de execução são null
+      // Plano determinístico (sem instrumento — apenas USD)
+      roPerTrade: roUSD,
+      roPct: profile.roPct,
+      rrMinimum: profile.rr,
+      winUSD,
+      lossesToBust,
+      evPerTrade,
+      maxTradesPerDay: profile.maxTradesPerDay,
+
+      // Sem instrumento, valores em pontos são null
       instrument: null,
       stopPoints: null,
       stopPerTrade: null,
-      roPerTrade: null,
-      rrMinimum: RR_MINIMUM[validProfile],
-      maxTradesPerDay: null,
+      targetPoints: null,
+      targetPerTrade: null,
+      stopNyPct: null,
       sizing: null,
 
-      // Mensagem informativa
       message: 'Selecione um instrumento para gerar o plano de execução completo.',
-
+      incompatible: false,
+      microSuggestion: null,
       constraintsViolated: [],
       generatedAt: new Date().toISOString()
     };
@@ -238,7 +257,7 @@ export function calculateAttackPlan(templateRules, profile4D, indicators, planPr
   if (!instrument) {
     return {
       mode: 'error',
-      profile: validProfile,
+      profile: profileKey,
       dataSource,
       error: `Instrumento '${instrumentSymbol}' não encontrado na tabela`,
       constraintsViolated: ['instrument_not_found'],
@@ -250,96 +269,106 @@ export function calculateAttackPlan(templateRules, profile4D, indicators, planPr
   const firm = (templateRules.firm ?? '').toLowerCase();
   const allowed = !firm || isInstrumentAllowed(instrumentSymbol, firm);
 
-  // Stop natural recomendado (max(ATR×5%, minStop))
-  const stop = getRecommendedStop(instrument);
-  const stopPoints = stop.stopPoints;
-  const stopUSD = stop.stopUSD;
+  // Stop em pontos = back-calculated do RO em USD
+  const stopPoints = round(roUSD / instrument.pointValue, 4);
+  const targetPoints = round(stopPoints * profile.rr, 4);
 
-  // RR mínimo por perfil
-  const rrMinimum = RR_MINIMUM[validProfile];
+  // Stop como % do range esperado da sessão NY
+  const nyRange = instrument.avgDailyRange * NY_RANGE_FRACTION;
+  const stopNyPct = nyRange > 0 ? round((stopPoints / nyRange) * 100, 2) : 0;
 
-  // RO por trade = stop natural + overhead (gordura para slippage/comissão)
-  const overhead = RO_OVERHEAD[validProfile];
-  const adjustedOverhead = overhead * (1 + (1 - adjustmentFactor) * 0.5); // aluno fraco = mais gordura
-  let roPerTrade = Math.ceil(stopUSD * (1 + adjustedOverhead));
+  // Stop USD efetivo (idêntico a roUSD por construção, mas explícito)
+  const stopUSD = round(stopPoints * instrument.pointValue, 2);
+  const targetUSD = round(targetPoints * instrument.pointValue, 2);
 
   // ============================================
-  // VERIFICAR FACTIBILIDADE
+  // CHECAGENS DE VIABILIDADE
   // ============================================
-  // Se RO por trade > daily loss limit, instrumento é incompatível
-  // (1 trade já estoura o dia inteiro)
+  const minViableStop = MIN_VIABLE_STOP[instrument.type] ?? 0;
+  const constraintsViolated = [];
   let incompatible = false;
   let microSuggestion = null;
+  let inviabilityReason = null;
 
-  if (roPerTrade > dailyLossLimit) {
+  // V1: Stop em pontos abaixo do mínimo viável → ruído no instrumento
+  if (stopPoints < minViableStop) {
     incompatible = true;
-    // Sugerir micro variant se disponível
-    if (!instrument.isMicro) {
-      const micro = suggestMicroAlternative(instrumentSymbol);
-      if (micro && (!firm || isInstrumentAllowed(micro.symbol, firm))) {
-        microSuggestion = micro.symbol;
-      }
+    inviabilityReason = `stop ${stopPoints}pts abaixo do mínimo viável ${minViableStop}pts para ${instrument.type}`;
+    constraintsViolated.push('stop_below_min_viable');
+  }
+
+  // V2: Stop excede 75% do range NY → vela única consome
+  if (stopNyPct > MAX_STOP_NY_PCT) {
+    incompatible = true;
+    inviabilityReason = inviabilityReason
+      ?? `stop ${stopNyPct.toFixed(1)}% do range NY excede limite ${MAX_STOP_NY_PCT}%`;
+    constraintsViolated.push('stop_exceeds_ny_range');
+  }
+
+  // V3: RO maior que daily loss → 1 trade estoura o dia
+  if (roUSD > dailyLossLimit) {
+    incompatible = true;
+    inviabilityReason = inviabilityReason
+      ?? `RO $${roUSD} excede daily loss $${dailyLossLimit}`;
+    constraintsViolated.push('ro_exceeds_daily_loss');
+  }
+
+  // Sugerir micro alternative se incompatível e instrumento é full size
+  if (incompatible && !instrument.isMicro) {
+    const micro = suggestMicroAlternative(instrumentSymbol);
+    if (micro && (!firm || isInstrumentAllowed(micro.symbol, firm))) {
+      microSuggestion = micro.symbol;
     }
   }
 
-  // Max trades por dia: cap operacional + constraint do daily loss
-  const operationalCap = MAX_TRADES_CAP[validProfile];
-  let maxTradesPerDay = incompatible
-    ? 0
-    : Math.min(
-        operationalCap,
-        Math.max(1, Math.floor(dailyLossLimit / roPerTrade))
-      );
-
-  // CONSTRAINT: roPerTrade × maxTradesPerDay ≤ dailyLossLimit
-  // (já garantido pela divisão acima — sanity check)
-  if (!incompatible && roPerTrade * maxTradesPerDay > dailyLossLimit) {
-    roPerTrade = Math.floor(dailyLossLimit / maxTradesPerDay);
+  // V4: maxTradesPerDay × RO não pode exceder daily loss → reduzir
+  let maxTradesPerDay = incompatible ? 0 : profile.maxTradesPerDay;
+  if (!incompatible && roUSD * maxTradesPerDay > dailyLossLimit) {
+    maxTradesPerDay = Math.max(1, Math.floor(dailyLossLimit / roUSD));
   }
 
-  // Sizing: 1 contrato é o default seguro
-  // (escalar para mais contratos = aumentar pointValue efetivo, não entra na Fase 1.5)
+  // V5: instrumento não permitido na mesa
+  if (!allowed) {
+    constraintsViolated.push(`instrumento '${instrumentSymbol}' não permitido na mesa '${firm}'`);
+  }
+
+  // Stop notavelmente pequeno (< 5% do range NY) — warning, não inviabiliza
+  const stopIsNoise = !incompatible && stopNyPct < MIN_STOP_NY_PCT && stopNyPct > 0;
+
+  // Restrição de sessão: stop pequeno relativo ao range NY → operar fora de NY.
+  // Threshold 12.5% (≈30 pts no NQ). NY consome stops abaixo disso por volatilidade.
+  // Não inviabiliza — restringe sessões recomendadas.
+  const nySessionViable = !incompatible && stopNyPct >= NY_MIN_VIABLE_STOP_PCT;
+  const recommendedSessions = incompatible
+    ? []
+    : (nySessionViable ? ['ny', 'london', 'asia'] : ['london', 'asia']);
+  const sessionRestricted = !incompatible && !nySessionViable;
+
+  // Sizing: 1 contrato fixo (escalar = Fase futura)
   const sizing = incompatible ? 0 : 1;
 
-  // Days to target
+  // Days to target (sanity)
   const daysToTarget = dailyTarget > 0
     ? Math.ceil(profitTarget / dailyTarget)
     : evalBusinessDays;
   const bufferDays = Math.max(0, evalBusinessDays - daysToTarget);
 
-  // ============================================
-  // VALIDAÇÃO DAS CONSTRAINTS
-  // ============================================
-  const constraintsViolated = [];
-  if (!incompatible) {
-    if (roPerTrade > dailyLossLimit) {
-      constraintsViolated.push('roPerTrade excede dailyLossLimit');
-    }
-    if (stopUSD > dailyLossLimit) {
-      constraintsViolated.push('stopPerTrade excede dailyLossLimit');
-    }
-    if (roPerTrade * maxTradesPerDay > dailyLossLimit) {
-      constraintsViolated.push('roPerTrade × maxTradesPerDay excede dailyLossLimit');
-    }
-    if (dailyTarget * evalBusinessDays < profitTarget) {
-      constraintsViolated.push('metaDiaria × diasUteis < profitTarget');
-    }
-  }
-
-  if (!allowed) {
-    constraintsViolated.push(`instrumento '${instrumentSymbol}' não permitido na mesa '${firm}'`);
-  }
-
   return {
     mode: 'execution',
-    profile: validProfile,
+    profile: profileKey,
+    profileName: profile.name,
+    profileFamily: profile.family,
+    profileRecommended: profile.recommended === true,
     dataSource,
     adjustmentFactor: round(adjustmentFactor, 4),
+    assumedWR,
+    wrBelowBreakeven,
 
     // Hard limits da mesa
     drawdownMax,
     dailyLossLimit,
     profitTarget,
+    phase: validPhase,
 
     // Instrumento
     instrument: {
@@ -348,34 +377,44 @@ export function calculateAttackPlan(templateRules, profile4D, indicators, planPr
       isMicro: instrument.isMicro,
       pointValue: instrument.pointValue,
       avgDailyRange: instrument.avgDailyRange,
-      type: instrument.type
+      type: instrument.type,
+      minViableStop
     },
 
-    // Por trade (instrument-aware)
-    stopPoints,                          // pontos no instrumento (ex: 20 pts MNQ)
-    stopPerTrade: round(stopUSD, 2),     // USD (ex: $40 MNQ, $400 NQ)
-    stopSource: stop.source,             // 'atr' ou 'min'
-    roPerTrade,                          // USD (stop + overhead, ex: $44 ou $48)
-    rrMinimum,
-    targetPerTrade: round(stopUSD * rrMinimum, 2), // USD esperado por trade ganho
+    // Por trade (back-calculated do RO)
+    roPct: profile.roPct,
+    roPerTrade: roUSD,
+    stopPoints,
+    stopPerTrade: stopUSD,
+    targetPoints,
+    targetPerTrade: targetUSD,
+    rrMinimum: profile.rr,
+    stopNyPct,
+    nyRangePoints: round(nyRange, 2),
 
-    // Diário
+    // Estatísticas e EV
+    winUSD,
+    lossesToBust,
+    evPerTrade,
     maxTradesPerDay,
-    dailyTarget,
 
-    // Total avaliação
+    // Diário / total
+    dailyTarget,
     evalBusinessDays,
     daysToTarget,
     bufferDays,
 
-    // Sizing (1 contrato fixo na Fase 1.5)
+    // Sizing
     sizing,
 
-    // Factibilidade
+    // Viabilidade
     incompatible,
+    inviabilityReason,
     microSuggestion,
-
-    // Validação
+    stopIsNoise,
+    nySessionViable,
+    sessionRestricted,
+    recommendedSessions,
     constraintsViolated,
 
     generatedAt: new Date().toISOString()

--- a/src/utils/propFirmDrawdownEngine.js
+++ b/src/utils/propFirmDrawdownEngine.js
@@ -1,0 +1,311 @@
+// ============================================
+// PROP FIRM DRAWDOWN ENGINE — Função pura
+// ============================================
+// Camada 3 do modelo semântico: a cada trade fechado, recalcula o estado
+// runtime da instância prop firm na conta — peakBalance, currentDrawdownThreshold,
+// lockLevel, isDayPaused, tradingDays, dailyPnL — e gera flags.
+//
+// Função 100% pura. CF a chama dentro de runTransaction para garantir
+// atomicidade do peakBalance em escrita concorrente (batch import).
+//
+// Suporta 4 tipos nominais (DRAWDOWN_TYPES):
+//   STATIC              — peak nunca move, threshold = accountSize - DD fixo
+//   TRAILING_INTRADAY   — peak move a cada trade ganhador
+//   TRAILING_EOD        — peak move apenas no fechamento do dia (snapshot no 1º trade do dia seguinte)
+//   TRAILING_WITH_LOCK  — tratado como INTRADAY com lock obrigatório (legacy)
+//
+// Lock é independente do tipo: qualquer trailing pode ter ou não lockAt/lockFormula.
+// Quando peakBalance atinge lockAt, threshold congela em lockLevel = accountSize
+// (a partir daí, comporta-se como STATIC).
+//
+// LIMITAÇÃO INTENCIONAL DA v1:
+//   A engine NÃO recalcula o histórico se um trade antigo for editado. Processa
+//   somente o trade atual com o estado atual. Para reconstrução completa, futura
+//   versão pode adicionar cron noturno que recomputa do zero.
+//
+// Ref: issue #52 Fase 2, sessão 09/04/2026
+
+import { DRAWDOWN_TYPES } from '../constants/propFirmDefaults';
+
+// ============================================
+// Constantes
+// ============================================
+
+// Quando distanceToDD < DD_NEAR_THRESHOLD → flag DD_NEAR
+export const DD_NEAR_THRESHOLD = 0.20;
+
+// Flags possíveis no resultado
+export const DRAWDOWN_FLAGS = {
+  DAILY_LOSS_HIT: 'DAILY_LOSS_HIT',         // dailyPnL atingiu daily loss limit
+  ACCOUNT_BUST: 'ACCOUNT_BUST',             // newBalance ≤ currentDrawdownThreshold
+  DD_NEAR: 'DD_NEAR',                       // distanceToDD < 20%
+  LOCK_ACTIVATED: 'LOCK_ACTIVATED',         // lockLevel ativado neste trade
+  EVAL_DEADLINE_NEAR: 'EVAL_DEADLINE_NEAR'  // (helper separado)
+};
+
+// ============================================
+// resolveLockAt — traduz lockAt numérico ou lockFormula textual
+// ============================================
+
+/**
+ * Resolve o valor de peakBalance que dispara o lock do trailing.
+ *
+ * @param {Object} template - propFirmTemplates doc
+ * @param {number} accountSize - tamanho da conta (do template)
+ * @returns {number|null} valor de peakBalance que dispara o lock, ou null se sem lock
+ */
+export function resolveLockAt(template, accountSize) {
+  const dd = template?.drawdown;
+  if (!dd) return null;
+
+  // 1ª prioridade: valor numérico explícito
+  if (typeof dd.lockAt === 'number') return dd.lockAt;
+
+  // 2ª prioridade: fórmula textual conhecida
+  if (dd.lockFormula === 'BALANCE + DD + 100') {
+    return accountSize + (dd.maxAmount ?? 0) + 100;
+  }
+
+  return null;
+}
+
+// ============================================
+// getPeakUpdateMode — quando o peak deve atualizar
+// ============================================
+
+/**
+ * Retorna o modo de atualização do peakBalance baseado no tipo de drawdown.
+ *
+ * @param {string} type - DRAWDOWN_TYPES
+ * @returns {'never'|'intraday'|'eod'}
+ */
+export function getPeakUpdateMode(type) {
+  if (type === DRAWDOWN_TYPES.STATIC) return 'never';
+  if (type === DRAWDOWN_TYPES.TRAILING_EOD) return 'eod';
+  // TRAILING_INTRADAY ou TRAILING_WITH_LOCK (legacy)
+  return 'intraday';
+}
+
+// ============================================
+// initializePropFirmState — estado inicial ao vincular conta a template
+// ============================================
+
+/**
+ * Cria o estado inicial do propFirm para uma nova conta vinculada a uma mesa.
+ *
+ * @param {Object} template - propFirmTemplates doc
+ * @param {number} accountSize - tamanho da conta (geralmente template.accountSize)
+ * @returns {Object} estado inicial (campos runtime, sem template/phase metadata)
+ */
+export function initializePropFirmState(template, accountSize) {
+  if (!template || !template.drawdown) {
+    throw new Error('template.drawdown é obrigatório');
+  }
+  const drawdownMax = template.drawdown.maxAmount ?? 0;
+  return {
+    peakBalance: accountSize,
+    currentDrawdownThreshold: accountSize - drawdownMax,
+    lockLevel: null,
+    isDayPaused: false,
+    tradingDays: 0,
+    dailyPnL: 0,
+    lastTradeDate: null
+  };
+}
+
+// ============================================
+// calculateDrawdownState — recalcula o estado após um trade
+// ============================================
+
+/**
+ * Função pura. Recebe o estado atual e dados do trade, retorna novo estado + flags.
+ *
+ * Esta função NÃO escreve em Firestore. A CF chama dentro de runTransaction
+ * para atomicidade do peakBalance.
+ *
+ * @param {Object} args
+ * @param {Object} args.propFirm - estado atual (account.propFirm); pode ser estado inicial
+ * @param {Object} args.template - template da mesa (propFirmTemplates doc)
+ * @param {number} args.accountSize - tamanho da conta (template.accountSize ou account.initialBalance)
+ * @param {number} args.balanceBefore - saldo da conta ANTES deste trade
+ * @param {number} args.tradeNet - P&L net do trade (positivo win, negativo loss)
+ * @param {string} args.tradeDate - data do trade no formato YYYY-MM-DD
+ * @returns {Object} novo estado + newBalance + distanceToDD + flags + transitions
+ */
+export function calculateDrawdownState({
+  propFirm,
+  template,
+  accountSize,
+  balanceBefore,
+  tradeNet,
+  tradeDate
+}) {
+  if (!template || !template.drawdown) {
+    throw new Error('template.drawdown é obrigatório');
+  }
+  if (typeof accountSize !== 'number' || accountSize <= 0) {
+    throw new Error('accountSize deve ser número positivo');
+  }
+  if (typeof balanceBefore !== 'number') {
+    throw new Error('balanceBefore deve ser número');
+  }
+  if (typeof tradeNet !== 'number') {
+    throw new Error('tradeNet deve ser número');
+  }
+  if (!tradeDate || typeof tradeDate !== 'string') {
+    throw new Error('tradeDate (YYYY-MM-DD) é obrigatório');
+  }
+
+  const drawdownType = template.drawdown.type;
+  const drawdownMax = template.drawdown.maxAmount ?? 0;
+  const dailyLossLimit = template.dailyLossLimit ?? 0;
+  const peakMode = getPeakUpdateMode(drawdownType);
+
+  // Estado atual (com defaults para conta nova)
+  let peakBalance = propFirm?.peakBalance ?? accountSize;
+  let dailyPnL = propFirm?.dailyPnL ?? 0;
+  let isDayPaused = propFirm?.isDayPaused ?? false;
+  let tradingDays = propFirm?.tradingDays ?? 0;
+  let lockLevel = propFirm?.lockLevel ?? null;
+  const previousLockLevel = lockLevel;
+  const lastTradeDate = propFirm?.lastTradeDate ?? null;
+
+  // ============================================
+  // 1. Detectar novo dia
+  // ============================================
+  const isNewDay = lastTradeDate !== tradeDate;
+
+  if (isNewDay) {
+    // EOD trailing: snapshot do peak no fechamento do dia anterior
+    // (só atualiza se o saldo de fechamento foi maior que o peak corrente
+    //  e o lock ainda não foi disparado)
+    if (peakMode === 'eod' && lockLevel === null && lastTradeDate !== null) {
+      peakBalance = Math.max(peakBalance, balanceBefore);
+    }
+
+    // Reset diário
+    dailyPnL = 0;
+    isDayPaused = false;
+    tradingDays += 1;
+  }
+
+  // ============================================
+  // 2. Aplicar trade
+  // ============================================
+  const newBalance = round(balanceBefore + tradeNet, 2);
+  dailyPnL = round(dailyPnL + tradeNet, 2);
+
+  // ============================================
+  // 3. Atualizar peak (intraday) — não atualiza após lock
+  // ============================================
+  if (peakMode === 'intraday' && lockLevel === null) {
+    peakBalance = Math.max(peakBalance, newBalance);
+  }
+
+  // ============================================
+  // 4. Verificar lock
+  // ============================================
+  const lockAt = resolveLockAt(template, accountSize);
+  if (lockAt !== null && lockLevel === null && peakBalance >= lockAt) {
+    // Lock ativado: threshold congela em accountSize (sai do drawdown trailing)
+    lockLevel = accountSize;
+  }
+
+  // ============================================
+  // 5. Calcular currentDrawdownThreshold
+  // ============================================
+  let currentDrawdownThreshold;
+  if (drawdownType === DRAWDOWN_TYPES.STATIC) {
+    currentDrawdownThreshold = accountSize - drawdownMax;
+  } else if (lockLevel !== null) {
+    currentDrawdownThreshold = lockLevel;
+  } else {
+    currentDrawdownThreshold = peakBalance - drawdownMax;
+  }
+
+  // ============================================
+  // 6. Daily loss check (soft — não bloqueia, apenas marca flag)
+  // ============================================
+  if (dailyLossLimit > 0 && dailyPnL <= -dailyLossLimit) {
+    isDayPaused = true;
+  }
+
+  // ============================================
+  // 7. Distance to DD (margem proporcional ainda disponível)
+  // ============================================
+  const distanceToDD = drawdownMax > 0
+    ? round((newBalance - currentDrawdownThreshold) / drawdownMax, 4)
+    : 1;
+
+  // ============================================
+  // 8. Flags
+  // ============================================
+  const flags = [];
+  if (isDayPaused) flags.push(DRAWDOWN_FLAGS.DAILY_LOSS_HIT);
+  if (newBalance <= currentDrawdownThreshold) flags.push(DRAWDOWN_FLAGS.ACCOUNT_BUST);
+  if (distanceToDD < DD_NEAR_THRESHOLD && distanceToDD > 0) flags.push(DRAWDOWN_FLAGS.DD_NEAR);
+  if (lockLevel !== null && previousLockLevel === null) flags.push(DRAWDOWN_FLAGS.LOCK_ACTIVATED);
+
+  return {
+    // Estado novo (escrito pela CF em account.propFirm.*)
+    peakBalance: round(peakBalance, 2),
+    currentDrawdownThreshold: round(currentDrawdownThreshold, 2),
+    lockLevel: lockLevel !== null ? round(lockLevel, 2) : null,
+    isDayPaused,
+    tradingDays,
+    dailyPnL,
+    lastTradeDate: tradeDate,
+
+    // Derivados / observabilidade
+    newBalance,
+    distanceToDD,
+    flags,
+    isNewDay
+  };
+}
+
+// ============================================
+// calculateEvalDaysRemaining — countdown de dias corridos
+// ============================================
+
+/**
+ * Calcula dias corridos restantes até o eval deadline.
+ * Apex e similares contam dias corridos, NÃO dias de trading.
+ *
+ * @param {string|Date} phaseStartDate - data de início da fase EVALUATION
+ * @param {number} evalTimeLimit - dias corridos (do template)
+ * @param {Date} [now] - data de referência (para testes); default new Date()
+ * @returns {number|null} dias restantes (0 se já expirou) ou null se inputs inválidos
+ */
+export function calculateEvalDaysRemaining(phaseStartDate, evalTimeLimit, now = new Date()) {
+  if (!phaseStartDate || typeof evalTimeLimit !== 'number' || evalTimeLimit <= 0) {
+    return null;
+  }
+  const start = phaseStartDate instanceof Date
+    ? phaseStartDate
+    : new Date(phaseStartDate);
+  if (isNaN(start.getTime())) return null;
+
+  const deadline = new Date(start);
+  deadline.setDate(deadline.getDate() + evalTimeLimit);
+
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const remaining = Math.ceil((deadline.getTime() - now.getTime()) / msPerDay);
+  return Math.max(0, remaining);
+}
+
+/**
+ * Helper para flag EVAL_DEADLINE_NEAR.
+ * Threshold padrão: 7 dias.
+ */
+export function isEvalDeadlineNear(daysRemaining, threshold = 7) {
+  if (daysRemaining === null || daysRemaining === undefined) return false;
+  return daysRemaining > 0 && daysRemaining <= threshold;
+}
+
+// --- Helpers ---
+
+function round(value, decimals) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.24.0: feat: Prop Firm Engine (#52) — Fase 1 templates/config/plano rule-based, Fase 1.5 instrumentsTable curada + 5 perfis determinísticos instrument-aware + viabilidade + restrição sessão NY, Fase 2 engine drawdown puro + CF onTrade* integrada + subcollection drawdownHistory + notificações throttled, correção crítica ATR v2 (TradingView real), DEC-057/058/059, DT-034
  * - 1.23.0: feat: Controle de Assinaturas da Mentoria — subcollection students/{id}/subscriptions, CF checkSubscriptions, trial/paid, accessTier, billingPeriodMonths, receiptUrl (issue #094, DEC-055/DEC-056)
  * - 1.22.1: fix: Aluno não consegue deletar plano — firestore.rules DEC-025 + índice composto movements (issue #089)
  * - 1.22.0: debt: Node.js 20→22 + firebase-functions SDK 4.5→5.1 nas Cloud Functions (issue #096, DT-016, DT-028)
@@ -37,10 +38,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.23.0',
-  build: '20260405',
-  display: 'v1.23.0',
-  full: '1.23.0+20260405',
+  version: '1.24.0',
+  build: '20260409',
+  display: 'v1.24.0',
+  full: '1.24.0+20260409',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Resumo

Implementa o epic **#52 — Gestão de Contas em Mesas Proprietárias (Prop Firms)** nas fases 1, 1.5 e 2. Deploy das CFs já executado e validado ao vivo na conta `gJ3zjI9OoF5PqM2puV0H` (Apex EOD 25K). Chunk CHUNK-17 (Prop Firm Engine) locked por este issue.

## Fases entregues

### Fase 1 — Templates, Configuração e Plano de Ataque rule-based
- Collection raiz `propFirmTemplates` com 21 templates pré-configurados (Apex EOD/Intraday, MFF, Lucid, Tradeify)
- `PropFirmConfigPage` (Settings → aba Prop Firms) — mentor faz seed/edit/delete
- Campo `propFirm` inline em `accounts` (templateId, firmName, phase, evalDeadline, selectedInstrument, suggestedPlan)
- Seletor PROP 2 níveis (firma → produto) no `AccountsPage`
- Auto-abertura do `PlanManagementModal` com defaults derivados do attackPlan

### Fase 1.5 — Instrument-aware + 5 perfis determinísticos
- `src/constants/instrumentsTable.js` — 23 instrumentos curados com ATR real TradingView (correção v2)
- **5 perfis determinísticos** substituindo o modelo binário conservador/agressivo:
  - CONS_A 10% DD, **CONS_B 15% DD ★ recomendado**, CONS_C 20%, AGRES_A 25%, AGRES_B 30%
  - RR fixo 1:2. Lógica invertida: mais risco = menos trades (CONS 2/dia, AGRES 1/dia)
  - Fórmula: `roUSD = drawdownMax × profile.roPct`, `stopPoints = roUSD / instrument.pointValue`
- **Viabilidade por 3 critérios** + sugestão automática de micro alternative:
  - `stop_below_min_viable` (por instrument type)
  - `stop_exceeds_ny_range` (>75% do NY range)
  - `ro_exceeds_daily_loss`
- **Restrição de sessão NY** — stops < 12.5% do range NY → `recommendedSessions: ['london', 'asia']` (DEC-058)
- `normalizeAttackProfile()` legacy compat para contas antigas
- UI: grid 5 botões com tooltip, preview grid 3 cols, modal `max-w-4xl`

### Fase 2 — Engine de Drawdown + CFs
- `src/utils/propFirmDrawdownEngine.js` — engine puro 4 tipos (STATIC, TRAILING_INTRADAY, TRAILING_EOD, TRAILING_WITH_LOCK) com lock formula `BALANCE + DD + 100`, daily loss soft, 5 flags, countdown eval deadline
- `functions/propFirmEngine.js` — cópia CommonJS para Cloud Functions (DEC-059, DT-034 registra unificação futura)
- **CF `onTradeCreated/onTradeUpdated/onTradeDeleted` estendidas** com `runTransaction` (atomicidade peakBalance)
- Helpers `recalculatePropFirmState`, `appendDrawdownHistory`, `notifyPropFirmFlag` (throttle 1×/dia/flag)
- **Subcollection `accounts/{id}/drawdownHistory`** append-only audit log
- **Schema novo** em `account.propFirm` (expansão INV-15 aprovada): `peakBalance`, `currentDrawdownThreshold`, `lockLevel`, `isDayPaused`, `tradingDays`, `dailyPnL`, `lastTradeDate`, `currentBalance`, `distanceToDD`, `flags`, `lastUpdateTradeId`
- CF bump `v1.9.0 → v1.10.0`

## Correção crítica — ATR alucinado v1 (bug resolvido)

`Temp/instruments-table-v2-atr-real.md` trouxe ATR real do TradingView. **13 valores corrigidos**: ES 55→**123**, NQ 400→**549**, YM 420→**856**, RTY 30→**70**, CL 2.5→**9.11**, GC 40→**180**, SI 0.60→**5.69**, 6B/6J/ZC/ZW/ZS/MBT.

**Bug emblemático:** MES Apex 25K CONS_B com stop 30pts era calculado como 90.9% do range NY (INVIÁVEL) por causa do ATR ES alucinado em 55. Com ATR real 123, calcula 40.65% (✅ VIÁVEL day trade). Teste de regressão adicionado.

## Validação produção

Engine deployado e validado ao vivo:

```
02:18:34 → [onTradeCreated] PropFirm recalculado: balance=25100, threshold=24000, flags=[]
02:23:18 → [onTradeCreated] PropFirm recalculado: balance=24700, threshold=24000, flags=[]
```

Documento `accounts/gJ3zjI9OoF5PqM2puV0H` com todos os campos `propFirm.*` populados corretamente (conferido no Firebase Console pelo Marcio).

## Testes

- **963 testes Vitest passando** (58 engine drawdown + 52 attackPlan calculator + 46 instrumentsTable + 807 pré-existentes)
- Zero regressão
- Build cliente limpo
- `node --check` limpo nas CFs
- Smoke test do engine CommonJS via `node -e` confirmou paridade com ESM

## Decisões arquiteturais (PROJECT.md §7)

- **DEC-053** — Escopo revisado com regras Apex Mar/2026
- **DEC-057** — 5 perfis determinísticos instrument-aware com RR fixo 1:2
- **DEC-058** — Restrição sessão NY threshold 12.5%
- **DEC-059** — Engine duplicado (Opção A pragmática + DT-034 futura)

## Dívida técnica registrada

- **DT-034** — Unificar engine prop firm via build step ou monorepo workspace
- **DT-035** — Re-medir ATR de NG/HG/6A no TradingView (não incluídos no v2)

## Limitações v1 (aceitas explicitamente)

- `onTradeUpdated` aplica delta incremental, **não reconstrói histórico do peakBalance** (trade editado antigo pode dessincronizar)
- `onTradeDeleted` aplica reversão mas **não remove snapshot do drawdownHistory** (append-only audit log — análises filtram por tradeId existente)
- Pre-read `account.get()` em todos os trades (~50ms overhead para non-PROP — monitorar)

## Pendente (fases futuras)

- **Fase 2.5** — CF `generatePropFirmApproachPlan` com Sonnet 4.6 (prompt v1.0 em `Temp/ai-approach-plan-prompt.md`)
- **Fase 3** — Dashboard card prop + gauges + alertas visuais (depende CHUNK-04 unlock #93)
- **Fase 4** — Payout tracking + qualifying days + simulador de saque

## Test plan

- [x] Suíte Vitest completa (963 testes)
- [x] Build cliente limpo
- [x] Validação `node --check` CFs
- [x] Smoke test engine CommonJS
- [x] Deploy Firestore rules (`firebase deploy --only firestore:rules`)
- [x] Deploy 3 CFs (`firebase deploy --only functions:onTradeCreated,functions:onTradeUpdated,functions:onTradeDeleted`)
- [x] Validação ao vivo na conta `gJ3zjI9OoF5PqM2puV0H` (Marcio conferiu no Firebase Console)
- [ ] Revisão final do diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)