### PR TITLE
fix: mover botão Novo Plano para AccountDetailPage (#146)

### DIFF
--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,8 +1,8 @@
 # PROJECT.md — Acompanhamento 2.0
 ## Documento Mestre do Projeto · Single Source of Truth
 
-> **Versão:** 0.20.1  
-> **Última atualização:** 15/04/2026 — Abertura #102 v1.33.0 (reservada), lock CHUNK-16, Revisão Semanal Fases A-D  
+> **Versão:** 0.21.0  
+> **Última atualização:** 16/04/2026 — Abertura #146 v1.34.0 (reservada), locks CHUNK-02/03 (bypass #145), fix botão Novo Plano → AccountDetailPage  
 > **Criado:** 26/03/2026 — sessão de consolidação documental  
 > **Fontes originais:** ARCHITECTURE.md, AVOID-SESSION-FAILURES.md, VERSIONING.md, CHANGELOG.md, CHUNK-REGISTRY.md  
 > **Mantido por:** Marcio Portes (integrador único)
@@ -51,6 +51,7 @@ Este documento segue versionamento semântico:
 | 0.19.1 | 15/04/2026 | Encerramento #142 | PR #143 mergeado, lock CHUNK-10 liberado (AVAILABLE), issue doc movida para archive, worktree removido |
 | 0.20.0 | 15/04/2026 | Abertura #145 Mesa Prop v1.32.0 | Locks CHUNK-02/17, v1.32.0 reservada em version.js, Página dedicada Mesa Prop — extrair componentes prop do Dashboard (epic #144) |
 | 0.20.1 | 15/04/2026 | Abertura #102 Revisão Semanal v1.33.0 | Lock CHUNK-16, v1.33.0 reservada em version.js, Revisão Semanal Fases A-D (#106 absorvido como Fase A) |
+| 0.21.0 | 16/04/2026 | Abertura #146 fix Novo Plano v1.34.0 | Locks CHUNK-02/03 (bypass CHUNK-02 lock #145 — sessão solo autorizada), v1.34.0 reservada, mover criação de plano de DashboardHeader para AccountDetailPage |
 
 **Regra de uso:**
 - Toda sessão que modificar este documento DEVE incrementar a versão e adicionar entrada na tabela acima
@@ -632,6 +633,8 @@ Chunks são conjuntos técnicos atômicos. Uma sessão faz check-out de chunks n
 | CHUNK-02 | #145 | arch/issue-145-prop-firm-page | 15/04/2026 | Página dedicada Mesa Prop — extrair componentes prop do Dashboard |
 | CHUNK-17 | #145 | arch/issue-145-prop-firm-page | 15/04/2026 | Página dedicada Mesa Prop — PropFirmPage, adaptador contexto |
 | CHUNK-16 | #102 | feat/issue-102-revisao-semanal | 15/04/2026 | Revisão Semanal — Fases A-D (PlanLedgerExtract + reviews + SWOT IA + integração mentor/aluno) |
+| CHUNK-02 | #146 | fix/issue-146-novo-plano-account-detail | 16/04/2026 | Fix botão Novo Plano — bypass lock #145, sessão solo autorizada |
+| CHUNK-03 | #146 | fix/issue-146-novo-plano-account-detail | 16/04/2026 | Fix botão Novo Plano — mover criação de plano para AccountDetailPage |
 
 ### 6.4 Checklist de Check-Out
 

--- a/docs/dev/issues/issue-146-novo-plano-account-detail.md
+++ b/docs/dev/issues/issue-146-novo-plano-account-detail.md
@@ -1,0 +1,64 @@
+# Issue #146 — fix: Botão Novo Plano inacessível após issue-118
+
+> **Status:** Implementado — aguardando PR  
+> **Versão reservada:** v1.34.0  
+> **Branch:** `fix/issue-146-novo-plano-account-detail`  
+> **Worktree:** `~/projects/issue-146`  
+> **Chunks:** CHUNK-02 (ESCRITA, bypass lock #145), CHUNK-03 (ESCRITA)  
+
+---
+
+## 1. Contexto
+
+O issue #118 (Context Bar) tornou o botão "Novo Plano" no `DashboardHeader` inacessível. O botão só aparece com `selectedAccountId === 'all'`, mas a Context Bar força conta selecionada por padrão.
+
+## 2. Solução
+
+Mover criação de plano para `AccountDetailPage`, onde a conta já está selecionada e os planos vinculados já são exibidos. Limpar código órfão no `DashboardHeader` e `StudentDashboard`.
+
+## 3. Escopo de Alterações
+
+| Arquivo | Ação | Chunk |
+|---------|------|-------|
+| `src/pages/AccountDetailPage.jsx` | Adicionar botão "Novo Plano" + prop `onCreatePlan` | CHUNK-03 |
+| `src/pages/AccountsPage.jsx` | Passar `onCreatePlan` callback com `defaultAccountId` | CHUNK-03 |
+| `src/components/dashboard/DashboardHeader.jsx` | Remover botão "Novo Plano" e prop `onCreatePlan` | CHUNK-02 |
+| `src/pages/StudentDashboard.jsx` | Limpar state/props órfãos de criação de plano | CHUNK-02 |
+
+## 4. Análise de Impacto
+
+- **Collections tocadas:** nenhuma (apenas UI)
+- **Cloud Functions:** nenhuma afetada
+- **Side-effects:** nenhum
+- **Blast radius:** baixo — apenas reorganização de UI existente
+- **Rollback:** trivial (reverter commits)
+
+## 5. Gate Pré-Código
+
+- [x] Issue aberto no GitHub (#146)
+- [x] Arquivo de controle criado
+- [x] Worktree isolado criado
+- [x] Chunks lockados (CHUNK-02 bypass autorizado, CHUNK-03)
+- [x] Versão reservada (v1.34.0)
+- [x] Análise de impacto documentada
+- [x] Aprovação do Marcio
+
+## 6. Chunks
+
+| Chunk | Modo | Status |
+|-------|------|--------|
+| CHUNK-02 | ESCRITA | LOCKED (bypass #145 autorizado) |
+| CHUNK-03 | ESCRITA | LOCKED |
+
+## 7. Shared Files — Deltas Propostos
+
+| Arquivo | Delta |
+|---------|-------|
+| `src/version.js` | Bump para 1.34.0 (reservado no main) |
+| `docs/PROJECT.md` | CHANGELOG v1.34.0 (no merge) |
+
+## 8. Testes
+
+- Verificação visual: botão "Novo Plano" acessível na AccountDetailPage
+- Verificação visual: modal abre com conta pré-selecionada
+- Verificação visual: DashboardHeader sem botão órfão

--- a/src/components/dashboard/DashboardHeader.jsx
+++ b/src/components/dashboard/DashboardHeader.jsx
@@ -5,7 +5,7 @@
  *   Extraído do StudentDashboard para modularização.
  */
 
-import { PlusCircle, Filter, Wallet, Upload, FolderPlus } from 'lucide-react';
+import { PlusCircle, Filter, Wallet, Upload } from 'lucide-react';
 import AccountFilterBar from '../AccountFilterBar';
 import { formatCurrencyDynamic } from '../../utils/currency';
 import { isRealAccount } from '../../utils/planCalculations';
@@ -34,7 +34,6 @@ const DashboardHeader = ({
   onNewTrade,
   onCsvImport,
   onOrderImport,
-  onCreatePlan,
   accounts,
   accountTypeFilter,
   onAccountTypeChange,
@@ -87,11 +86,6 @@ const DashboardHeader = ({
       {/* Card informativo: contas incluídas na seleção — v1.15.0: multi-moeda */}
       {selectedAccountId === 'all' && filteredAccountsByType.length > 0 && (
         <div className="flex items-center gap-2 px-3 py-2 bg-slate-800/40 rounded-xl border border-slate-700/30 text-xs text-slate-400 flex-wrap">
-          {!viewAs && (
-            <button onClick={onCreatePlan} className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border border-blue-500/30 bg-blue-500/10 hover:border-blue-500/50 hover:bg-blue-500/20 text-[11px] font-bold text-blue-400 hover:text-blue-300 transition-all mr-1">
-              <FolderPlus className="w-3 h-3" /> Novo Plano
-            </button>
-          )}
           <Wallet className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" />
           <span className="text-slate-500 font-medium">
             {accountTypeFilter === 'real' ? 'Reais:' : accountTypeFilter === 'demo' ? 'Demo:' : 'Contas:'}

--- a/src/pages/AccountDetailPage.jsx
+++ b/src/pages/AccountDetailPage.jsx
@@ -1,9 +1,13 @@
 /**
  * AccountDetailPage
- * @version 7.0.0 (Plans View + Mentor Edit)
+ * @version 8.0.0 (Plans View + Create + Mentor Edit)
  * @description Extrato com cálculo reverso (Reverse Ledger) + Planos vinculados.
  * 
  * CHANGELOG:
+ * - 8.0.0: Issue #146 — Botão "Novo Plano" + criação de plano (movido do DashboardHeader)
+ *   - Seção "Planos Vinculados" sempre visível (com empty state)
+ *   - PlanManagementModal desbloqueado do gate isMentor() para criação
+ *   - Prop onCreatePlan + defaultAccountId pré-setado
  * - 7.0.0: Issue #43 — Seção "Planos Vinculados" com indicadores estratégicos
  *   - Mentor vê e edita planos do aluno
  *   - Indicadores: PL, RO, Stop Período, Stop Ciclo, Meta
@@ -48,7 +52,7 @@ const translateType = (type) => {
   return map[type] || type;
 };
 
-const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubmitting = false }) => {
+const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, onCreatePlan, planSubmitting = false }) => {
   const { movements, loading, addDeposit, addWithdrawal } = useMovements(account?.id);
   const { user, isMentor } = useAuth();
   
@@ -190,14 +194,17 @@ const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubm
     return amount >= 0 ? <TrendingUp className="w-4 h-4 text-emerald-400" /> : <TrendingDown className="w-4 h-4 text-red-400" />;
   };
 
-  // Handler: Mentor salva edição do plano com audit trail
-  const handleMentorSavePlan = async (planData) => {
-    if (!editingPlan || !onUpdatePlan) return;
-    
-    const auditInfo = buildAuditInfo(user?.email, editingPlan, planData);
-
+  // Handler: salva plano (criação ou edição mentor com audit trail)
+  const handleSavePlan = async (planData) => {
     try {
-      await onUpdatePlan(editingPlan.id, planData, auditInfo);
+      if (editingPlan) {
+        if (!onUpdatePlan) return;
+        const auditInfo = buildAuditInfo(user?.email, editingPlan, planData);
+        await onUpdatePlan(editingPlan.id, planData, auditInfo);
+      } else {
+        if (!onCreatePlan) return;
+        await onCreatePlan(planData);
+      }
       setShowPlanModal(false);
       setEditingPlan(null);
     } catch (err) {
@@ -228,13 +235,23 @@ const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubm
         </div>
       </div>
 
-      {/* === PLANOS VINCULADOS (Issue #43) === */}
-      {accountPlans.length > 0 && (
-        <div className="mb-8">
-          <h2 className="text-lg font-bold text-white flex items-center gap-2 mb-4">
+      {/* === PLANOS VINCULADOS (Issue #43 + #146) === */}
+      <div className="mb-8">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-white flex items-center gap-2">
             <Target className="w-5 h-5 text-blue-400" /> Planos Vinculados
-            <span className="text-sm font-normal text-slate-500">({accountPlans.length})</span>
+            {accountPlans.length > 0 && <span className="text-sm font-normal text-slate-500">({accountPlans.length})</span>}
           </h2>
+          {onCreatePlan && (
+            <button
+              onClick={() => { setEditingPlan(null); setShowPlanModal(true); }}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-blue-500/30 bg-blue-500/10 hover:border-blue-500/50 hover:bg-blue-500/20 text-xs font-bold text-blue-400 hover:text-blue-300 transition-all"
+            >
+              <Plus className="w-3.5 h-3.5" /> Novo Plano
+            </button>
+          )}
+        </div>
+        {accountPlans.length > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
             {accountPlans.map(plan => {
               const plInitial = plan.pl || 0;
@@ -296,8 +313,13 @@ const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubm
               );
             })}
           </div>
-        </div>
-      )}
+        ) : (
+          <div className="glass-card p-8 text-center">
+            <Target className="w-10 h-10 text-slate-600 mx-auto mb-3" />
+            <p className="text-slate-500 text-sm">Nenhum plano vinculado a esta conta.</p>
+          </div>
+        )}
+      </div>
 
       {/* EXTRATO CARD */}
       <div className="glass-card">
@@ -466,16 +488,15 @@ const AccountDetailPage = ({ account, onBack, plans = [], onUpdatePlan, planSubm
           </div>
         </div>
       )}
-      {/* MODAL PLANO (Mentor Edit) */}
-      {isMentor() && (
-        <PlanManagementModal
-          isOpen={showPlanModal}
-          onClose={() => { setShowPlanModal(false); setEditingPlan(null); }}
-          onSubmit={handleMentorSavePlan}
-          editingPlan={editingPlan}
-          isSubmitting={planSubmitting}
-        />
-      )}
+      {/* MODAL PLANO (Criação + Mentor Edit) — issue #146 */}
+      <PlanManagementModal
+        isOpen={showPlanModal}
+        onClose={() => { setShowPlanModal(false); setEditingPlan(null); }}
+        onSubmit={handleSavePlan}
+        editingPlan={editingPlan}
+        defaultAccountId={account?.id}
+        isSubmitting={planSubmitting}
+      />
       <DebugBadge component="AccountDetailPage" />
     </div>
   );

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -549,7 +549,7 @@ const AccountsPage = () => {
 
   if (selectedAccount) {
     const mergedAccount = { ...selectedAccount, currentBalance: balancesByAccountId[selectedAccount.id] ?? selectedAccount.currentBalance ?? 0 };
-    return <AccountDetailPage account={mergedAccount} onBack={() => setSelectedAccount(null)} plans={plans} onUpdatePlan={handleMentorUpdatePlan} planSubmitting={planSubmitting} />;
+    return <AccountDetailPage account={mergedAccount} onBack={() => setSelectedAccount(null)} plans={plans} onUpdatePlan={handleMentorUpdatePlan} onCreatePlan={addPlan} planSubmitting={planSubmitting} />;
   }
 
   return (

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -363,7 +363,6 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, returnToPla
         onNewTrade={() => { setEditingTrade(null); setShowAddModal(true); }}
         onCsvImport={() => setShowCsvWizard(true)}
         onOrderImport={() => setShowOrderImport(true)}
-        onCreatePlan={() => { setEditingPlan(null); setShowPlanModal(true); }}
         accounts={accounts}
         accountTypeFilter={accountTypeFilter}
         onAccountTypeChange={setAccountTypeFilter}
@@ -509,7 +508,6 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, returnToPla
         onOpenLedger={setLedgerPlan}
         onEditPlan={(plan) => { setEditingPlan(plan); setShowPlanModal(true); }}
         onDeletePlan={handleDeletePlan}
-        onCreatePlan={() => { setEditingPlan(null); setShowPlanModal(true); }}
         onAuditPlan={handleAuditPlan}
       />
 

--- a/src/version.js
+++ b/src/version.js
@@ -52,10 +52,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.31.0',
-  build: '20260415',
-  display: 'v1.31.0',
-  full: '1.31.0+20260415',
+  version: '1.34.0',
+  build: '20260416',
+  display: 'v1.34.0',
+  full: '1.34.0+20260416',
 };
 export default VERSION;
 export { VERSION };

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.34.0: fix: Botão Novo Plano inacessível (#146) — mover criação de plano de DashboardHeader para AccountDetailPage, limpar state órfão no StudentDashboard. [RESERVADO]
  * - 1.33.0: feat: Revisão Semanal (#102) — PlanLedgerExtract fundação + collection reviews + CF createWeeklyReview + CF generateWeeklySwot + WeeklyReviewModal + integração mentor/aluno. [RESERVADO]
  * - 1.32.0: arch: Pagina dedicada Mesa Prop (#145) — extrair PropAccountCard/AlertsBanner/PayoutTracker/AiApproachPlanSection do StudentDashboard para PropFirmPage, novo item condicional no Sidebar, ContextBar governa pagina, fix sparkline DD threshold, plano phase-aware (PA/SIM_FUNDED/LIVE). [RESERVADO]
  * - 1.31.0: feat: Order Import Tradovate Orders (#142) — parser parseTradovateOrders + FORMAT_REGISTRY extensivel em orderParsers.js + auto-detect ProfitChart vs Tradovate por header signature + remove gatekeep hardcoded em OrderImportPage.jsx + deteccao multi-delimitador (; e ,). Shape canonico identico entre parsers — downstream (normalize/validate/reconstruct/correlate) inalterado. Mapas EN inline (STATUS/SIDE/TYPE com trim de leading space), datas US (MM/DD/YYYY HH:MM:SS) via parseDateTime, numeros US (Papa quote-aware lida com thousands). 19 testes novos (2 Fase A + 17 Fase B), fixtures reais april/feb 2026 conta Apex. Validado em browser.


### PR DESCRIPTION
## Summary

- Botão "Novo Plano" movido de `DashboardHeader` para `AccountDetailPage`, onde a conta já está selecionada e os planos vinculados são exibidos
- Seção "Planos Vinculados" agora sempre visível (com empty state quando sem planos)
- `PlanManagementModal` desbloqueado do gate `isMentor()` para permitir criação por alunos
- Limpeza de props órfãs em `DashboardHeader` e `StudentDashboard`

**Regressão corrigida:** issue #118 (Context Bar) tornou o botão inacessível — só aparecia com `selectedAccountId === 'all'`, mas a Context Bar força conta selecionada por padrão.

## Arquivos alterados

| Arquivo | Alteração |
|---------|-----------|
| `AccountDetailPage.jsx` | +botão "Novo Plano", +prop `onCreatePlan`, +empty state, modal desbloqueado |
| `AccountsPage.jsx` | Passa `onCreatePlan={addPlan}` ao AccountDetailPage |
| `DashboardHeader.jsx` | Remove botão e prop `onCreatePlan` |
| `StudentDashboard.jsx` | Remove `onCreatePlan` de DashboardHeader e PlanCardGrid |

## Test plan

- [x] Build limpo (zero erros)
- [x] 1456 testes passando, zero regressão
- [ ] Validar no browser: Contas → conta → botão "Novo Plano" visível e funcional
- [ ] Validar no browser: modal abre com conta pré-selecionada
- [ ] Validar no browser: Dashboard "Todas as contas" sem botão "Novo Plano" órfão

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)