### PR TITLE
chore: permitir aluno toggle alunoDoneIds em review CLOSED (#102)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -62,10 +62,19 @@ service cloud.firestore {
         );
         allow create: if isMentor() &&
           request.resource.data.status == 'DRAFT';
-        allow update: if isMentor() && (
-          (resource.data.status == 'DRAFT' && request.resource.data.status in ['DRAFT', 'CLOSED']) ||
-          (resource.data.status == 'CLOSED' && request.resource.data.status in ['CLOSED', 'ARCHIVED']) ||
-          (resource.data.status == 'ARCHIVED' && request.resource.data.status == 'ARCHIVED')
+        allow update: if (
+          // Mentor: transições de state machine (A4).
+          (isMentor() && (
+            (resource.data.status == 'DRAFT' && request.resource.data.status in ['DRAFT', 'CLOSED']) ||
+            (resource.data.status == 'CLOSED' && request.resource.data.status in ['CLOSED', 'ARCHIVED']) ||
+            (resource.data.status == 'ARCHIVED' && request.resource.data.status == 'ARCHIVED')
+          )) ||
+          // Stage 4.5: aluno toggla apenas alunoDoneIds em revisão CLOSED
+          // (arrayUnion/arrayRemove). Campo separado do item.done (mentor).
+          (isOwner(studentId) &&
+            resource.data.status == 'CLOSED' &&
+            request.resource.data.status == 'CLOSED' &&
+            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['alunoDoneIds']))
         );
         allow delete: if isMentor() && resource.data.status != 'ARCHIVED';
       }


### PR DESCRIPTION
## Summary

- Stage 4.5 do issue #102: aluno pode marcar takeaways como feitos (`alunoDoneIds` via `arrayUnion`/`arrayRemove`) em revisões `CLOSED`
- Regra granular: `affectedKeys().hasOnly(['alunoDoneIds'])` + `status==CLOSED` (imutável pelo aluno)
- Campo separado de `item.done` (mentor) — preserva semântica "encerrado pelo mentor" × "feito pelo aluno"

## Context

Stage 4.5 do issue #102 já foi implementado no worktree (`feat/issue-102-revisao-semanal`):
- `useWeeklyReviews.toggleAlunoDone(reviewId, itemId, markDone)`
- `<PendingTakeaways />` no dashboard do aluno agrupa pendentes por revisão

Sem esta rule, aluno recebe `permission-denied` ao marcar.

## Deploy

\`\`\`bash
firebase deploy --only firestore:rules
\`\`\`

## Test plan

- [ ] Aluno autentica
- [ ] Aluno marca takeaway em revisão `CLOSED` → sucesso
- [ ] Aluno tenta alterar outro campo (ex: `status`) em `CLOSED` → `permission-denied`
- [ ] Aluno tenta marcar em revisão `DRAFT` ou `ARCHIVED` → `permission-denied`
- [ ] Mentor continua conseguindo transições de state machine A4

Relacionado: #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)