### PR TITLE
hotfix: StudentDashboard assessmentStudentId not defined (#162) — SEV1

### DIFF
--- a/docs/dev/issues/issue-162-hotfix-assessment-student-id.md
+++ b/docs/dev/issues/issue-162-hotfix-assessment-student-id.md
@@ -1,0 +1,117 @@
+# Issue 162 — hotfix: Espelho fora do ar por implementação do issue #102
+> **Branch:** `fix/issue-162-hotfix-assessment-student-id`
+> **Worktree:** `~/projects/issue-162`
+> **Milestone:** —
+> **Aberto em:** 20/04/2026
+> **Status:** 🔴 SEV1 — plataforma fora do ar em produção
+> **Versão entregue:** v1.38.1 (reservada no main commit `db665db3`)
+> **Labels GitHub:** `epic:aluno-stability`, `module:dashboard-aluno`, `Sev1`, `type:bug`
+
+---
+
+## 1. CONTEXTO
+
+Pós-merge do PR #160 (entrega do #102 — Revisão Semanal v2, commit `30af3a18`, v1.38.0) a
+plataforma em produção renderiza tela branca no dashboard do aluno com o erro:
+
+```
+Uncaught ReferenceError: assessmentStudentId is not defined
+    at AN (index-D-IbMnHz.js:64:1720)
+```
+
+Logs consecutivos de `[useTrades] Student mode`, `[usePlans] Student mode`,
+`[useAccounts] Student mode` precedem o crash — confirma que os hooks de dados inicializam OK, o
+erro é síncrono no render do componente `StudentDashboardBody` durante mount.
+
+Causa raiz (linha 362 de `src/pages/StudentDashboard.jsx`):
+
+```jsx
+<PendingTakeaways
+  studentId={assessmentStudentId}   // ← identificador não existe no escopo
+  onNavigateToFeedback={onNavigateToFeedback}
+/>
+```
+
+O componente `<PendingTakeaways>` é novo, introduzido pelo #102 (PR #160). A prop
+`studentId` referencia a variável `assessmentStudentId` que **não está declarada** em
+`StudentDashboardBody` (linha 88+). Resíduo de refactor/rename. No mesmo arquivo, a linha
+558 (dentro de `StudentDashboard` wrapper) já define o padrão canônico para resolver o
+UID do aluno neste dashboard:
+
+```js
+const scopeStudentId = overrideStudentId || user?.uid || 'anon';
+```
+
+E os 3 hooks irmãos no mesmo `StudentDashboardBody` (linhas 96-98) passam
+`overrideStudentId` e aplicam o fallback `user?.uid` internamente
+(`useTrades(overrideStudentId)`, `useAccounts(overrideStudentId)`,
+`usePlans(overrideStudentId)`). `<PendingTakeaways>` consome `students/{studentId}/reviews`
+(linha 28 do componente) — mesma semântica: UID do aluno dono das reviews = UID do aluno
+dono das trades/accounts/plans.
+
+## 2. ACCEPTANCE CRITERIA
+
+- [ ] `src/pages/StudentDashboard.jsx:362` deixa de referenciar `assessmentStudentId`
+- [ ] Prop recebe `overrideStudentId || user?.uid` (padrão canônico do arquivo)
+- [ ] Dashboard do aluno renderiza sem crash no `npm run build` + preview local
+- [ ] Cenário mentor (`viewAs.uid`) também renderiza — `PendingTakeaways` recebe o UID do aluno
+      visualizado, não o UID do mentor logado
+- [ ] Teste smoke adicionado: `<StudentDashboard>` monta sem throw em ambos os modos
+- [ ] 1727/1727 testes seguem passando
+- [ ] DebugBadge de `StudentDashboard` mostra v1.38.1 (build date 20260420)
+
+## 3. ANÁLISE DE IMPACTO
+
+| Aspecto | Detalhe |
+|---------|---------|
+| Collections tocadas | Nenhuma (fix puramente de referência JSX) |
+| Cloud Functions afetadas | Nenhuma |
+| Hooks/listeners afetados | Nenhum novo — `PendingTakeaways` já listava `students/{studentId}/reviews` antes, a prop só voltará a receber um UID válido |
+| Side-effects (PL, compliance, emotional) | Nenhum |
+| Dados parciais/inválidos | N/A — não toca trade/plan writer |
+| INV-01..INV-18 | Nenhuma tocada — fix sintético de 1 linha |
+| Blast radius | Restaura dashboard aluno (todos os consumidores) em produção |
+| Rollback | Trivial — revert do PR |
+
+## 4. SOLUÇÃO
+
+Alterar exatamente a linha 362 de `src/pages/StudentDashboard.jsx`:
+
+```diff
+-        studentId={assessmentStudentId}
++        studentId={overrideStudentId || user?.uid}
+```
+
+Ambos (`overrideStudentId` e `user`) já estão no escopo de `StudentDashboardBody` (linhas 89-90).
+
+## 5. DELTA DE SHARED FILES
+
+Aplicados no main ANTES da criação do worktree (commit `db665db3`, branch `main`):
+
+- `src/version.js` — bump `1.38.0` → `1.38.1`, build `20260420`, changelog inline reservado
+- `docs/PROJECT.md` — header `0.22.8` → `0.22.9`, entrada 0.22.9 na tabela de histórico,
+  lock CHUNK-02 na §6.3 "Locks ativos", entrada `[1.38.1]` reservada no CHANGELOG §10
+
+Nenhum shared file é editado dentro deste worktree — apenas o próprio arquivo de controle e
+o fix em `StudentDashboard.jsx`/teste smoke.
+
+## 6. CHUNKS
+
+| Chunk | Modo | Motivo |
+|-------|------|--------|
+| CHUNK-02 | escrita | Alteração em `src/pages/StudentDashboard.jsx` (linha 362) |
+| CHUNK-16 | leitura | Confirmar contrato de `src/components/reviews/PendingTakeaways.jsx` (prop `studentId`) — não modifica |
+
+> Lock ativo registrado em PROJECT.md §6.3 (commit `db665db3` no main).
+> CHUNK-16 não precisa de lock (modo leitura).
+
+## 7. NOTAS DE INVESTIGAÇÃO
+
+- PR #157 (rules `alunoDoneIds`) **não** está envolvido no crash — a falha é síncrona no
+  render JSX, anterior a qualquer round-trip Firestore
+- O erro **não** aparece no dev local do CC anterior porque o dashboard só é hit via URL
+  roteada como aluno; o build minificado de produção (`index-D-IbMnHz.js:64:1720`) falha
+  na primeira tentativa de mount
+- Issue de QA #159 (tracker do #102) **não cobriu** o render do dashboard do aluno com
+  `PendingTakeaways` montado — gap de validação da entrega v1.38.0 (pendência a registrar no
+  encerramento, não neste arquivo)

--- a/src/__tests__/invariants/studentDashboardReferences.test.js
+++ b/src/__tests__/invariants/studentDashboardReferences.test.js
@@ -1,0 +1,34 @@
+/**
+ * studentDashboardReferences.test.js — regressão SEV1 issue #162.
+ *
+ * Em 20/04/2026 o merge do PR #160 (#102 v1.38.0) deixou uma referência à
+ * variável `assessmentStudentId` em `src/pages/StudentDashboard.jsx` sem que
+ * o identificador estivesse declarado no escopo de `StudentDashboardBody`.
+ * Resultado: `ReferenceError: assessmentStudentId is not defined` no render
+ * do dashboard do aluno em produção — plataforma fora do ar.
+ *
+ * Este teste é uma cerca anti-regressão cirúrgica: falha se o mesmo
+ * identificador reaparecer em `StudentDashboard.jsx`. Não substitui lint
+ * `no-undef`; serve de guarda explícita enquanto `npm run lint` não é
+ * obrigatório no CI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const STUDENT_DASHBOARD = path.resolve(
+  __dirname,
+  '../../pages/StudentDashboard.jsx',
+);
+
+describe('StudentDashboard.jsx — identificadores não declarados (#162)', () => {
+  it('não referencia `assessmentStudentId` (fix SEV1 v1.38.1)', () => {
+    const src = fs.readFileSync(STUDENT_DASHBOARD, 'utf8');
+    const hits = src.match(/\bassessmentStudentId\b/g) || [];
+    expect(hits).toEqual([]);
+  });
+});

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -359,7 +359,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
 
       {/* Pendências da mentoria — takeaways em aberto (Stage 4.5) */}
       <PendingTakeaways
-        studentId={assessmentStudentId}
+        studentId={overrideStudentId || user?.uid}
         onNavigateToFeedback={onNavigateToFeedback}
       />
 


### PR DESCRIPTION
## Summary
- **SEV1 hotfix** — plataforma fora do ar em produção após merge do PR #160 (#102 v1.38.0, commit `30af3a18`)
- `src/pages/StudentDashboard.jsx:362` referenciava `assessmentStudentId` (identificador não declarado no escopo de `StudentDashboardBody`) → `Uncaught ReferenceError` no render do dashboard do aluno
- Fix 1-linha: substituído por `overrideStudentId || user?.uid` (padrão canônico da linha 558 e dos hooks irmãos `useTrades`/`useAccounts`/`usePlans`)
- Teste invariante novo (`studentDashboardReferences.test.js`) trava reintrodução do identificador

## Shared files (já commitados no `main`)
- `src/version.js` → v1.38.1 (commit `db665db3`)
- `docs/PROJECT.md` → v0.22.9, lock CHUNK-02 registrado em §6.3, entrada `[1.38.1]` reservada no CHANGELOG

## Test plan
- [x] 1728/1728 testes passando (baseline 1727 + novo invariante)
- [x] `npm run build` verde (15.28s, 2913 módulos)
- [ ] Smoke manual pós-merge/deploy: abrir dashboard do aluno em prod e confirmar render sem ReferenceError
- [ ] Confirmar DebugBadge exibindo v1.38.1

## Rastreabilidade
- Issue de controle: `docs/dev/issues/issue-162-hotfix-assessment-student-id.md`
- Branch: `fix/issue-162-hotfix-assessment-student-id`
- Worktree: `~/projects/issue-162`

Closes #162