### PR TITLE
fix: botão Finalizar travado na conclusão do aprofundamento (Sev1 #166)

### DIFF
--- a/docs/dev/issues/issue-166-sessao-travada-finalizar.md
+++ b/docs/dev/issues/issue-166-sessao-travada-finalizar.md
@@ -1,0 +1,67 @@
+# fix: 166 — Sessão Travada no Botão Finalizar
+
+> **Branch:** `fix/issue-166-sessao-travada-finalizar`
+> **Versão reservada:** v1.40.0
+> **Milestone:** v1.1.0 — Espelho Self-Service
+> **Prioridade:** Sev1
+> **Chunks:** CHUNK-09 (escrita)
+> **PROJECT.md base:** v0.23.5
+
+---
+
+## 1. ESCOPO
+
+Botão "Finalizar" na tela de conclusão do aprofundamento (`ProbingQuestionsFlow.jsx`) está travado — não responde ao clique ou trava sem feedback visual.
+
+**Tela afetada:**
+```
+Aprofundamento concluído
+Suas respostas serão analisadas e apresentadas ao seu mentor para a entrevista de validação.
+[Finalizar]
+```
+
+**Causa provável (a confirmar no discovery):**
+- `completeAllProbing()` é async sem loading state nem error handling — se a operação falhar ou demorar, o botão não dá feedback
+- Sem `disabled` durante execução — cliques múltiplos possíveis
+- Sem `try/catch` — falha silenciosa trava o fluxo
+
+---
+
+## 2. ACCEPTANCE CRITERIA
+
+- [ ] Botão "Finalizar" responde ao clique com loading state visível
+- [ ] Cliques múltiplos durante execução são ignorados (disabled enquanto processa)
+- [ ] Erro em `completeAllProbing()` é capturado e exibe mensagem ao usuário (não trava silenciosamente)
+- [ ] Fluxo completo testado: clique → loading → success → `onComplete()` chamado
+- [ ] Teste cobrindo o comportamento do botão (loading, disabled, error)
+
+---
+
+## 3. ANÁLISE DE IMPACTO
+
+- Collections tocadas: `students/{id}/assessment/` (escrita via `completeAllProbing`)
+- CFs afetadas: nenhuma prevista (operação local via hook)
+- Hooks: `useProbing` (`completeAllProbing`)
+- Side-effects: nenhum além da atualização de status no Firestore
+- Blast radius: BAIXO — UI only, componente isolado
+
+---
+
+## 4. SHARED FILES (delta — aplicar no main via PR)
+
+| Arquivo | Delta |
+|---------|-------|
+| `src/version.js` | Aplicar v1.40.0 (já reservada) + entrada CHANGELOG |
+| `docs/PROJECT.md` | CHANGELOG [1.40.0] + encerramento |
+
+---
+
+## 5. LOG DE EXECUÇÃO
+
+**Coordenador:** sessão a registrar (abrir de `~/projects/issue-166`)
+**Worker:** headless via tmux `cc-166` + mailbox `.cc-mailbox/`
+
+| # | Task | Status | Commit | Report |
+|---|------|--------|--------|--------|
+| 01 | Discovery — mapear fluxo completo do botão + causa raiz + propor fix | pendente | — | — |
+| 02 | Implementação — fix loading state + disabled + error handling + testes | pendente | — | — |

--- a/src/__tests__/utils/completeAllProbing.test.js
+++ b/src/__tests__/utils/completeAllProbing.test.js
@@ -1,0 +1,1 @@
+// Replaced by completeAllProbing.test.jsx

--- a/src/__tests__/utils/completeAllProbing.test.js
+++ b/src/__tests__/utils/completeAllProbing.test.js
@@ -1,1 +1,0 @@
-// Replaced by completeAllProbing.test.jsx

--- a/src/__tests__/utils/completeAllProbing.test.jsx
+++ b/src/__tests__/utils/completeAllProbing.test.jsx
@@ -5,7 +5,8 @@
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
 import ProbingQuestionsFlow from '../../components/Onboarding/ProbingQuestionsFlow.jsx';
 
 function makeProbing(overrides = {}) {
@@ -23,6 +24,11 @@ function makeProbing(overrides = {}) {
 }
 
 describe('ProbingQuestionsFlow — botão Finalizar', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
   it('chama onComplete após completeAllProbing resolver', async () => {
     const onComplete = vi.fn();
     const probing = makeProbing();

--- a/src/__tests__/utils/completeAllProbing.test.jsx
+++ b/src/__tests__/utils/completeAllProbing.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for ProbingQuestionsFlow finalizar button — issue #166
+ * Covers: success, error, loading state, and double-click guard.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import ProbingQuestionsFlow from '../../components/Onboarding/ProbingQuestionsFlow.jsx';
+
+function makeProbing(overrides = {}) {
+  return {
+    currentProbingQuestion: null,
+    currentProbingIndex: 3,
+    totalProbingQuestions: 3,
+    isProbingComplete: true,
+    analyzing: false,
+    error: null,
+    answerProbingQuestion: vi.fn(),
+    completeAllProbing: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('ProbingQuestionsFlow — botão Finalizar', () => {
+  it('chama onComplete após completeAllProbing resolver', async () => {
+    const onComplete = vi.fn();
+    const probing = makeProbing();
+
+    render(<ProbingQuestionsFlow probing={probing} onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /finalizar/i }));
+
+    await waitFor(() => {
+      expect(probing.completeAllProbing).toHaveBeenCalledTimes(1);
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('NÃO chama onComplete quando completeAllProbing rejeita; exibe mensagem de erro', async () => {
+    const onComplete = vi.fn();
+    const probing = makeProbing({
+      completeAllProbing: vi.fn().mockRejectedValue(new Error('network fail')),
+    });
+
+    render(<ProbingQuestionsFlow probing={probing} onComplete={onComplete} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /finalizar/i }));
+
+    await waitFor(() => {
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(screen.getByText('Erro ao finalizar. Tente novamente.')).toBeInTheDocument();
+    });
+  });
+
+  it('desabilita botão e exibe spinner durante execução', async () => {
+    let resolve;
+    const deferred = new Promise((r) => { resolve = r; });
+    const probing = makeProbing({ completeAllProbing: vi.fn(() => deferred) });
+
+    render(<ProbingQuestionsFlow probing={probing} onComplete={vi.fn()} />);
+
+    const btn = screen.getByRole('button', { name: /finalizar/i });
+
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => {
+      expect(btn).toBeDisabled();
+      expect(screen.getByText('Finalizando...')).toBeInTheDocument();
+    });
+
+    await act(async () => { resolve(); });
+  });
+
+  it('segundo clique durante execução não dispara nova chamada', async () => {
+    let resolve;
+    const deferred = new Promise((r) => { resolve = r; });
+    const completeAllProbing = vi.fn(() => deferred);
+    const probing = makeProbing({ completeAllProbing });
+
+    render(<ProbingQuestionsFlow probing={probing} onComplete={vi.fn()} />);
+
+    const btn = screen.getByRole('button', { name: /finalizar/i });
+
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => expect(btn).toBeDisabled());
+
+    fireEvent.click(btn);
+
+    await act(async () => { resolve(); });
+
+    expect(completeAllProbing).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Onboarding/ProbingQuestionsFlow.jsx
+++ b/src/components/Onboarding/ProbingQuestionsFlow.jsx
@@ -7,7 +7,7 @@
  * @version 1.0.0 — CHUNK-09 Fase A
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import QuestionOpen from './QuestionOpen.jsx';
 import DebugBadge from '../DebugBadge.jsx';
 
@@ -25,6 +25,9 @@ export default function ProbingQuestionsFlow({
     answerProbingQuestion,
     completeAllProbing,
   } = probing;
+
+  const [completing, setCompleting] = useState(false);
+  const [completeError, setCompleteError] = useState(null);
 
   // All probing done
   if (isProbingComplete) {
@@ -46,15 +49,31 @@ export default function ProbingQuestionsFlow({
 
         <button
           onClick={async () => {
-            await completeAllProbing();
-            if (onComplete) onComplete();
+            setCompleting(true);
+            setCompleteError(null);
+            try {
+              await completeAllProbing();
+              if (onComplete) onComplete();
+            } catch (err) {
+              setCompleteError('Erro ao finalizar. Tente novamente.');
+            } finally {
+              setCompleting(false);
+            }
           }}
-          className="px-8 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl text-sm font-medium transition-all"
+          disabled={completing}
+          className="px-8 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl text-sm font-medium transition-all flex items-center gap-2 mx-auto"
         >
-          Finalizar
+          {completing && <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+          {completing ? 'Finalizando...' : 'Finalizar'}
         </button>
 
-        <DebugBadge />
+        {completeError && (
+          <div className="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-400">
+            {completeError}
+          </div>
+        )}
+
+        <DebugBadge component="ProbingQuestionsFlow" />
       </div>
     );
   }

--- a/src/components/Onboarding/ProbingQuestionsFlow.jsx
+++ b/src/components/Onboarding/ProbingQuestionsFlow.jsx
@@ -29,6 +29,19 @@ export default function ProbingQuestionsFlow({
   const [completing, setCompleting] = useState(false);
   const [completeError, setCompleteError] = useState(null);
 
+  const handleFinalize = async () => {
+    setCompleting(true);
+    setCompleteError(null);
+    try {
+      await completeAllProbing();
+      if (onComplete) onComplete();
+    } catch (err) {
+      setCompleteError('Erro ao finalizar. Tente novamente.');
+    } finally {
+      setCompleting(false);
+    }
+  };
+
   // All probing done
   if (isProbingComplete) {
     return (
@@ -43,28 +56,23 @@ export default function ProbingQuestionsFlow({
           Aprofundamento concluído
         </h2>
         <p className="text-gray-400 text-sm mb-8">
-          Suas respostas serão analisadas e apresentadas ao seu mentor 
+          Suas respostas serão analisadas e apresentadas ao seu mentor
           para a entrevista de validação.
         </p>
 
         <button
-          onClick={async () => {
-            setCompleting(true);
-            setCompleteError(null);
-            try {
-              await completeAllProbing();
-              if (onComplete) onComplete();
-            } catch (err) {
-              setCompleteError('Erro ao finalizar. Tente novamente.');
-            } finally {
-              setCompleting(false);
-            }
-          }}
+          onClick={handleFinalize}
           disabled={completing}
           className="px-8 py-3 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl text-sm font-medium transition-all flex items-center gap-2 mx-auto"
         >
-          {completing && <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
-          {completing ? 'Finalizando...' : 'Finalizar'}
+          {completing ? (
+            <>
+              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              Finalizando...
+            </>
+          ) : (
+            'Finalizar'
+          )}
         </button>
 
         {completeError && (

--- a/src/hooks/useAssessment.js
+++ b/src/hooks/useAssessment.js
@@ -230,7 +230,7 @@ export function useAssessment(studentId) {
       completedAt: serverTimestamp(),
       summary,
     });
-    await updateOnboardingStatus('probing_complete');
+    await updateOnboardingStatus('probing_complete', 'probing');
   }, [studentId, updateOnboardingStatus]);
 
   /**

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,9 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.40.0: fix: Botão "Finalizar" travado na conclusão do aprofundamento (issue #166, Sev1) —
+ *   loading state + disabled + try/catch no onClick de ProbingQuestionsFlow; fromStatus='probing'
+ *   explícito em completeProbing (elimina stale closure); DebugBadge component= corrigido (INV-04).
  * - 1.38.1: hotfix: `assessmentStudentId is not defined` em StudentDashboard.jsx:362 (#162) — SEV1.
  *   Prop `studentId` de `<PendingTakeaways>` referenciava identificador inexistente no escopo de
  *   `StudentDashboardBody`, quebrando render do dashboard do aluno em produção (ReferenceError


### PR DESCRIPTION
## Summary

- `ProbingQuestionsFlow.jsx`: botão "Finalizar" refatorado com `handleFinalize` (try/catch/finally), `disabled` durante execução, spinner + texto dinâmico, mensagem de erro ao usuário
- `useAssessment.js`: `completeProbing` passa `fromStatus='probing'` explicitamente para eliminar stale closure (mesmo padrão DEC-026)
- `DebugBadge component="ProbingQuestionsFlow"` corrigido (INV-04)
- Arquivo placeholder vazio `completeAllProbing.test.js` removido

## Testes

- 4 testes novos: sucesso, erro, loading state, múltiplos cliques
- 1732/1732 passando, zero regressão

## Closes

Closes #166