### PR TITLE
feat: SetupAnalysis V2 — KPIs operacionais por setup (#170)

### DIFF
--- a/docs/dev/issues/issue-170-setup-analysis-v2.md
+++ b/docs/dev/issues/issue-170-setup-analysis-v2.md
@@ -1,0 +1,125 @@
+# Issue #170 — SetupAnalysis V2: KPIs operacionais por setup
+
+**Baseado na versão PROJECT.md:** 0.28.0  
+**Branch:** `feature/issue-170-setup-analysis-v2`  
+**Worktree:** `~/projects/issue-170`  
+**Versão reservada:** v1.42.0  
+**Milestone:** v1.2.0 — Mentor Cockpit  
+**Modo:** Autônomo (degradado — scripts `cc-notify-email.py` / `cc-validate-task.py` ausentes; notificação manual)
+
+---
+
+## 1. Escopo (vindo do issue GitHub)
+
+Substituir `SetupAnalysis.jsx` atual (barra proporcional + WR) por ferramenta de diagnóstico operacional que responda **"meu setup X está entregando o que promete?"**.
+
+### E1 · Card de setup com 4 KPIs operacionais + sparkline
+- Header: nome · N trades · PL total · WR
+- Grid 2×2:
+  - **Financial · EV por trade** = `totalPL / n`
+  - **Financial · Payoff** = `avgWin / |avgLoss|` (fallback `—` quando insuficiente)
+  - **Operational · ΔT W vs L** = `(tempoW − tempoL) / tempoL × 100%` — semáforo `>+20%` 🟢 / `-10%..+20%` 🟡 / `<-10%` 🔴 + tempos W/L em sub-linha
+  - **Impact · Contribuição ao EV total** = `(n × EV_setup) / Σ(n × EV)` em %
+- **Aderência RR** (sub-linha condicional): mostrar `X/N dentro da banda` com % e cor somente se `setups.targetRR` existir; omitida quando ausente (não fabrica dado)
+- **Sparkline 6m**: PL acumulado do setup nos últimos 6 meses; reusa padrão da Matriz 4D (`EmotionAnalysis`)
+- **Insight 1-linha**: reusa `buildInsight` (ofensor shift>40%, best performer payoff≥1.5, aderência RR<50%, fallback positivo)
+
+### E2 · Ordenação e agrupamento por impacto
+- Cards ordenados por `|contribEV|` desc
+- Setups com `n < 3` agrupados em accordion "Esporádicos (N)" colapsado no rodapé
+- Accordion expandido por default quando nenhum setup atinge `n ≥ 3`
+
+### E3 · Util `analyzeBySetupV2` + testes
+- Novo `src/utils/setupAnalysisV2.js` retornando por setup: `{ setup, n, totalPL, wr, ev, payoff, durationWin, durationLoss, deltaT, contribEV, adherenceRR, sparkline6m }`
+- Aceita opcional `setupsMeta` (array de docs `setups` com `targetRR`); ausente → `adherenceRR = null`
+- Zero campo Firestore novo
+- 15-20 testes cobrindo cálculos puros + edges (n=1, só wins, só losses, sem `targetRR`, multi-moeda ignorada)
+
+### E4 · Integração sem breaking change
+- Substitui `SetupAnalysis.jsx` mantendo prop `trades` + nova prop opcional `setupsMeta`
+- Consumo em `StudentDashboard` e `MentorDashboard` (ambos já importam)
+- `DebugBadge component="SetupAnalysis"` mantido (INV-04)
+
+## 2. Fora do Escopo
+- Shift emocional por setup (join com `emotionMatrix4D`) → fase 2
+- Aderência à checklist do setup (exige schema novo em `setups`) → fase 2
+- Heatmap setup × emoção → fase 2
+- Filtro drill-down por setup no resto do dashboard → decidir depois
+
+## 3. Análise de Impacto
+
+| Aspecto | Detalhe |
+|---------|---------|
+| Collections tocadas | **Leitura:** `trades`, `setups` (opcional). **Escrita:** zero |
+| Cloud Functions | Nenhuma |
+| Hooks/listeners | `useSetups` passa a ser consumido no `SetupAnalysis` via prop drilling |
+| Side-effects (PL/compliance/emotional) | Zero |
+| Blast radius | Baixo — componente isolado, API externa preservada |
+| Rollback | `git revert` limpo |
+
+### 3.1 Chunks necessários
+
+| Chunk | Modo | Motivo |
+|-------|------|--------|
+| CHUNK-02 | escrita | `SetupAnalysis.jsx`, consumo em `StudentDashboard.jsx` |
+| CHUNK-04 | leitura | `useTrades` para série 6m e cálculos |
+| CHUNK-16 | leitura | `MentorDashboard` consumo (só passa `setupsMeta`) |
+
+### 3.2 INV checklist
+- ✅ INV-01/02 (zero escrita em `trades`/`plans`)
+- ✅ INV-04 DebugBadge mantido
+- ✅ INV-05 testes antes de UI (util + render)
+- ✅ INV-10/15 zero estrutura Firestore nova
+- ✅ INV-17 declarado (seção 3.3)
+- ✅ INV-18 spec aprovada via issue body
+
+### 3.3 Gate INV-17 — Arquitetura de Informação
+
+| Nível | Domínio | Duplicação | Budget |
+|-------|---------|------------|--------|
+| seção (componente substituído) | Dashboard do Aluno | Nenhuma — evolui `SetupAnalysis` existente. Sparkline é o mesmo pattern da Matriz 4D (padrão unificado, não duplicação) | Net-zero (substitui) |
+
+## 4. Ordem de implementação
+
+1. **E3a** — Testes de `analyzeBySetupV2` (falhando)
+2. **E3b** — Util `analyzeBySetupV2` (testes passam)
+3. **E1a** — Testes render `SetupAnalysis` V2 (falhando)
+4. **E1b** — UI `SetupAnalysis` V2 + extrair Sparkline reutilizável
+5. **E2** — Ordenação + accordion esporádicos
+6. **E4** — Wire `StudentDashboard` + `MentorDashboard` passando `setupsMeta` via `useSetups`
+7. **Validação browser** — setup com muitos trades, esporádico, sem `targetRR`, perdedor com shift alto, multi-setup
+
+## 5. Deltas de shared files (a aplicar no main no encerramento)
+
+- `src/version.js` — promover 1.42.0 de RESERVADA para definitiva (remover tag `[RESERVADA — entrada definitiva no encerramento.]`)
+- `docs/PROJECT.md` — entrada 0.29.0 Encerramento #170, liberar lock CHUNK-02, arquivar issue doc
+
+**Nenhum outro shared file tocado.** `StudentDashboard.jsx` e `MentorDashboard.jsx` pertencem a CHUNK-02/16 e são editados dentro do worktree (não são shared files do Protocolo §4.1 — são arquivos do chunk com lock).
+
+## 6. Log da sessão
+
+### 22/04/2026 — Fase 3 §4.0 (Abertura no main)
+- ✅ Bump PROJECT.md 0.27.0 → 0.28.0 + entrada de histórico
+- ✅ Lock CHUNK-02 registrado em §6.3 para branch `feature/issue-170-setup-analysis-v2`
+- ✅ v1.42.0 reservada em `src/version.js` (entrada CHANGELOG tagged [RESERVADA])
+- ✅ Commit `3b69ea4b` no main: `docs: abertura #170 — lock CHUNK-02 + v1.42.0 reservada (SetupAnalysis V2)`
+- ✅ Worktree criado em `~/projects/issue-170`
+- ✅ Arquivo de controle criado (este)
+
+### Próximo: E3a (testes analyzeBySetupV2 falhando)
+
+## 7. CLAIMS por task (INV-27 universal)
+
+Cada task entregue deve fornecer bloco CLAIMS estruturado para validação:
+
+```
+CLAIMS:
+- commit: <sha>
+- tests: <n passing>/<total>
+- files_changed: [<path>, ...]
+- invariants: [INV-04, INV-05, ...]
+```
+
+## 8. Origem
+
+Spin-off do review #164. Durante validação browser, Marcio observou que o componente atual "só mostra agrupamento por setup" e pediu análise que vá além disso. Um setup é hipótese operacional (RR esperado, frequência ideal, tempo médio, contexto) — análise atual não responde se o setup entrega o que promete.

--- a/docs/dev/issues/issue-170-setup-analysis-v2.md
+++ b/docs/dev/issues/issue-170-setup-analysis-v2.md
@@ -104,9 +104,76 @@ Substituir `SetupAnalysis.jsx` atual (barra proporcional + WR) por ferramenta de
 - ✅ v1.42.0 reservada em `src/version.js` (entrada CHANGELOG tagged [RESERVADA])
 - ✅ Commit `3b69ea4b` no main: `docs: abertura #170 — lock CHUNK-02 + v1.42.0 reservada (SetupAnalysis V2)`
 - ✅ Worktree criado em `~/projects/issue-170`
-- ✅ Arquivo de controle criado (este)
+- ✅ Arquivo de controle criado
 
-### Próximo: E3a (testes analyzeBySetupV2 falhando)
+### 22/04/2026 — Implementação (modo autônomo)
+
+**E3 · util `analyzeBySetupV2`** — commit `2bd11e82`
+- `src/utils/setupAnalysisV2.js` (245 linhas)
+- `src/__tests__/utils/setupAnalysisV2.test.js` (23 testes, 7 describes)
+- Cobre: defensivo (null/undefined/array vazio/tipo inválido), agrupamento por setup com trim e fallback "Sem Setup", KPIs básicos (n/totalPL/wr/ev/payoff null quando falta wins ou losses), ΔT com derivação de entryTime/exitTime quando duration ausente, contribEV com denominador Σ|totalPL| preservando sinal, ordenação |contribEV| desc, flag `isSporadic` (n<3), aderência RR condicional (null sem setupsMeta, null sem targetRR, banda [target×0.8, target×1.2]), sparkline 6m (6 buckets mensais determinísticos via `today`, ignora trades fora da janela, 6 zeros para setup sem trades), edges (n=1, multi-moeda não particiona, result null/undefined vira 0).
+
+**E1 + E2 · UI SetupAnalysis V2** — commit `52919bc7`
+- `src/components/SetupAnalysis.jsx` (reescrito: 434 linhas, +349 vs V1)
+- `src/__tests__/components/SetupAnalysisV2.test.jsx` (17 testes)
+- Header com nome · N trades · PL total · WR
+- Grid 2×2: Financial (EV + Payoff), Operational (ΔT com semáforo ±20%/±10% + tempos W/L brutos), Impact (ContribEV com sinal), Maturidade (Sparkline 6m + ícone Trend)
+- Aderência RR condicional: linha só renderiza quando `setupsMeta[x].targetRR` existe. Cor: ≥70% verde, ≥40% âmbar, <40% vermelho
+- Ordenação por `|contribEV|` desc; setups com n<3 em accordion "Esporádicos (N)" colapsado (expandido por default quando nenhum setup atinge n≥3)
+- Insight 1-linha: ofensor contribEV<-20% → best performer payoff≥1.5 → aderência RR<50% → fallback positivo
+- Sparkline local com mesmo visual do EmotionAnalysis (não extraído — duplicação intencional dentro do escopo do componente)
+- DebugBadge `component="SetupAnalysis"` preservado (INV-04)
+
+**E4 · Wire nos dashboards** — commit `e5239727`
+- `StudentDashboard.jsx`: passa `setupsMeta={setups}` via `useSetups()` já presente (mudança de 1 linha)
+- `MentorDashboard.jsx`: **não alterado** — `useSetups` não é consumido na página e os setups globais + pessoais mistos não têm filtro por `selectedStudent.uid`. Aderência RR fica omitida (condicional). Wire mentor-side proposto para fast-follow ou issue dedicada.
+
+### Gate Pré-Entrega (INV-09 §4.2)
+
+- ✅ `src/version.js` reservada para v1.42.0 (definitiva no encerramento)
+- ✅ CHANGELOG de v1.42.0 escrito em version.js (tagged [RESERVADA])
+- ✅ Testes para toda lógica nova: 23 util + 17 render = **40 novos testes**
+- ✅ DebugBadge mantido em `SetupAnalysis` com `component="SetupAnalysis"`
+- ✅ `npm test -- --run`: **1880/1880 passing** (baseline 1840 + 40)
+- ✅ `npx eslint` nos arquivos tocados: zero errors, warnings pré-existentes não regressivos
+- ✅ `npm run build`: verde em 14.74s
+- ⏸️ **Validação browser pendente** (modo autônomo degradado — sem Marcio online). Cenários da spec a validar no merge:
+  - Setup com muitos trades
+  - Setup esporádico (accordion colapsado)
+  - Setup sem `targetRR` (linha Aderência omitida)
+  - Setup perdedor com shift alto (insight ofensor)
+  - Multi-setup com diferentes impactos (ordenação por |contribEV|)
+
+### CLAIMS (INV-27)
+
+```
+commit: e5239727 (tip)
+chain: dcc8c59f → 2bd11e82 → 52919bc7 → e5239727
+tests: 1880/1880 (baseline 1840 +40 novos)
+files_added:
+  - src/utils/setupAnalysisV2.js (245 linhas)
+  - src/__tests__/utils/setupAnalysisV2.test.js (304 linhas, 23 testes)
+  - src/__tests__/components/SetupAnalysisV2.test.jsx (180 linhas, 17 testes)
+  - docs/dev/issues/issue-170-setup-analysis-v2.md
+files_modified:
+  - src/components/SetupAnalysis.jsx (reescrito: 349 linhas adicionadas)
+  - src/pages/StudentDashboard.jsx (prop setupsMeta)
+invariants:
+  - INV-01/02: ✅ zero escrita em trades/plans
+  - INV-04: ✅ DebugBadge component="SetupAnalysis"
+  - INV-05: ✅ testes antes da UI (util E3 → UI E1/E2)
+  - INV-10/15: ✅ zero estrutura Firestore nova
+  - INV-17: ✅ declarado em §3.3
+  - INV-18: ✅ spec aprovada via issue body (não há ambiguidade residual)
+out_of_scope_untouched:
+  - shift emocional por setup (fase 2)
+  - aderência à checklist do setup (fase 2)
+  - heatmap setup × emoção (fase 2)
+  - filtro drill-down por setup no dashboard
+  - wire MentorDashboard (setups não filtrados por aluno — fast-follow/issue nova)
+```
+
+### Próximo: PR + review do Marcio
 
 ## 7. CLAIMS por task (INV-27 universal)
 

--- a/src/__tests__/components/SetupAnalysisV2.test.jsx
+++ b/src/__tests__/components/SetupAnalysisV2.test.jsx
@@ -1,0 +1,180 @@
+/**
+ * SetupAnalysisV2.test.jsx — render tests for SetupAnalysis V2 (issue #170)
+ *
+ * Cobre E1 (cards com 4 KPIs + sparkline + aderência condicional),
+ * E2 (ordenação por |contribEV| + accordion esporádicos) e E4 (DebugBadge, API).
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import SetupAnalysis from '../../components/SetupAnalysis';
+
+const mk = (overrides = {}) => ({
+  setup: 'A',
+  result: 100,
+  duration: 10,
+  entryTime: '2026-04-15T10:00:00',
+  exitTime: '2026-04-15T10:10:00',
+  date: '2026-04-15',
+  ...overrides,
+});
+
+describe('SetupAnalysis V2 — estados vazios', () => {
+  it('renderiza mensagem quando trades = []', () => {
+    render(<SetupAnalysis trades={[]} />);
+    expect(screen.getByText(/nenhum trade registrado/i)).toBeInTheDocument();
+  });
+
+  it('renderiza mensagem quando trades = null', () => {
+    render(<SetupAnalysis trades={null} />);
+    expect(screen.getByText(/nenhum trade registrado/i)).toBeInTheDocument();
+  });
+});
+
+describe('SetupAnalysis V2 — E1 card com 4 KPIs + header', () => {
+  const trades = [
+    mk({ setup: 'Breakout', result: 200, duration: 20 }),
+    mk({ setup: 'Breakout', result: 100, duration: 20 }),
+    mk({ setup: 'Breakout', result: -50, duration: 10 }),
+  ];
+
+  it('header mostra nome, N trades, PL total e WR', () => {
+    render(<SetupAnalysis trades={trades} />);
+    const card = screen.getByTestId('setup-card-Breakout');
+    expect(card).toHaveTextContent('Breakout');
+    expect(card).toHaveTextContent(/3\s*trades?/i);
+    expect(card).toHaveTextContent(/67/); // WR = 2/3 ≈ 66.67% ou 67%
+  });
+
+  it('renderiza quadrante EV por trade', () => {
+    render(<SetupAnalysis trades={trades} />);
+    const card = screen.getByTestId('setup-card-Breakout');
+    expect(card).toHaveTextContent(/EV/i);
+  });
+
+  it('renderiza quadrante Payoff', () => {
+    render(<SetupAnalysis trades={trades} />);
+    const card = screen.getByTestId('setup-card-Breakout');
+    expect(card).toHaveTextContent(/Payoff/i);
+  });
+
+  it('renderiza quadrante ΔT W vs L', () => {
+    render(<SetupAnalysis trades={trades} />);
+    const card = screen.getByTestId('setup-card-Breakout');
+    expect(card).toHaveTextContent(/ΔT/);
+  });
+
+  it('renderiza quadrante Contribuição ao EV total', () => {
+    render(<SetupAnalysis trades={trades} />);
+    const card = screen.getByTestId('setup-card-Breakout');
+    expect(card).toHaveTextContent(/Contrib|Impact/i);
+  });
+
+  it('renderiza sparkline 6m (SVG testId)', () => {
+    render(<SetupAnalysis trades={trades} />);
+    expect(screen.getByTestId('setup-sparkline-Breakout')).toBeInTheDocument();
+  });
+
+  it('exibe "—" em Payoff quando só há wins', () => {
+    const onlyWins = [
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: 50 }),
+      mk({ setup: 'A', result: 30 }),
+    ];
+    render(<SetupAnalysis trades={onlyWins} />);
+    const card = screen.getByTestId('setup-card-A');
+    expect(card).toHaveTextContent('—');
+  });
+});
+
+describe('SetupAnalysis V2 — E1 Aderência RR condicional', () => {
+  const trades = [
+    mk({ setup: 'A', result: 100, rr: 2.0 }),
+    mk({ setup: 'A', result: 100, rr: 2.1 }),
+    mk({ setup: 'A', result: -50, rr: 1.5 }),
+  ];
+
+  it('não mostra linha Aderência RR quando setupsMeta ausente', () => {
+    render(<SetupAnalysis trades={trades} />);
+    expect(screen.queryByText(/Aderência RR/i)).not.toBeInTheDocument();
+  });
+
+  it('não mostra quando setup existe em setupsMeta mas sem targetRR', () => {
+    render(<SetupAnalysis trades={trades} setupsMeta={[{ name: 'A' }]} />);
+    expect(screen.queryByText(/Aderência RR/i)).not.toBeInTheDocument();
+  });
+
+  it('mostra X/N + percentual quando targetRR existe', () => {
+    render(
+      <SetupAnalysis
+        trades={trades}
+        setupsMeta={[{ name: 'A', targetRR: 2.0 }]}
+      />,
+    );
+    expect(screen.getByText(/Aderência RR/i)).toBeInTheDocument();
+    // 2 dentro da banda (rr=2.0, rr=2.1), 1 fora (rr=1.5 < 1.6)
+    const card = screen.getByTestId('setup-card-A');
+    expect(card).toHaveTextContent(/2\/3/);
+  });
+});
+
+describe('SetupAnalysis V2 — E2 ordenação + accordion esporádicos', () => {
+  const trades = [
+    // Setup A: n=3, maior impacto negativo
+    mk({ setup: 'A', result: -500 }),
+    mk({ setup: 'A', result: -500 }),
+    mk({ setup: 'A', result: -500 }),
+    // Setup B: n=3, impacto positivo menor
+    mk({ setup: 'B', result: 100 }),
+    mk({ setup: 'B', result: 100 }),
+    mk({ setup: 'B', result: 100 }),
+    // Setup C: n=2, esporádico
+    mk({ setup: 'C', result: 50 }),
+    mk({ setup: 'C', result: 50 }),
+  ];
+
+  it('cards não-esporádicos vêm ordenados por |contribEV| desc', () => {
+    render(<SetupAnalysis trades={trades} />);
+    const cards = screen.getAllByTestId(/^setup-card-/);
+    // A (|-1500|) > B (|+300|) — C é esporádico, vai no accordion
+    const names = cards.map((c) => c.getAttribute('data-testid'));
+    expect(names.indexOf('setup-card-A')).toBeLessThan(names.indexOf('setup-card-B'));
+  });
+
+  it('setups com n<3 aparecem em accordion "Esporádicos (N)" colapsado', () => {
+    render(<SetupAnalysis trades={trades} />);
+    // accordion presente com label
+    expect(screen.getByText(/Esporádicos\s*\(1\)/i)).toBeInTheDocument();
+    // Card C não visível por default (colapsado)
+    expect(screen.queryByTestId('setup-card-C')).not.toBeInTheDocument();
+  });
+
+  it('expandir accordion revela cards esporádicos', () => {
+    render(<SetupAnalysis trades={trades} />);
+    fireEvent.click(screen.getByText(/Esporádicos\s*\(1\)/i));
+    expect(screen.getByTestId('setup-card-C')).toBeInTheDocument();
+  });
+
+  it('accordion expandido por default quando nenhum setup atinge n≥3', () => {
+    const tradesEsporadicos = [
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'B', result: 50 }),
+    ];
+    render(<SetupAnalysis trades={tradesEsporadicos} />);
+    // Todos esporádicos → accordion expandido
+    expect(screen.getByTestId('setup-card-A')).toBeInTheDocument();
+    expect(screen.getByTestId('setup-card-B')).toBeInTheDocument();
+  });
+});
+
+describe('SetupAnalysis V2 — DebugBadge (INV-04)', () => {
+  it('renderiza DebugBadge com component="SetupAnalysis"', () => {
+    const trades = [mk({ setup: 'A' })];
+    const { container } = render(<SetupAnalysis trades={trades} />);
+    // DebugBadge usa data-testid ou text com version — aceitamos a presença do version string
+    const text = container.textContent || '';
+    expect(text).toMatch(/v1\.\d+\.\d+/);
+  });
+});

--- a/src/__tests__/utils/setupAnalysisV2.test.js
+++ b/src/__tests__/utils/setupAnalysisV2.test.js
@@ -1,0 +1,304 @@
+/**
+ * setupAnalysisV2.test.js — issue #170
+ *
+ * Testa util puro `analyzeBySetupV2(trades, { setupsMeta, today })`.
+ * Retorno por setup: { setup, n, totalPL, wr, ev, payoff, durationWin, durationLoss,
+ *   deltaT, contribEV, adherenceRR, sparkline6m }
+ *
+ * Notas:
+ * - Util é PURO: recebe `today` (Date) opcional para determinismo da janela 6m.
+ *   Se ausente, usa `new Date()`.
+ * - Multi-moeda: valores são somados dentro do mesmo setup independente de currency,
+ *   conforme spec (multi-moeda "ignorada por setup" = não particiona, não converte).
+ * - Trades sem setup recebem chave "Sem Setup".
+ */
+import { describe, it, expect } from 'vitest';
+import { analyzeBySetupV2 } from '../../utils/setupAnalysisV2';
+
+// Helper: builda trade determinístico mínimo
+const mk = (overrides = {}) => ({
+  setup: 'A',
+  result: 100,
+  duration: 10,
+  entryTime: '2026-04-15T10:00:00',
+  exitTime: '2026-04-15T10:10:00',
+  date: '2026-04-15',
+  ...overrides,
+});
+
+describe('analyzeBySetupV2 — defensivo / entrada vazia', () => {
+  it('retorna [] quando trades é null/undefined', () => {
+    expect(analyzeBySetupV2(null)).toEqual([]);
+    expect(analyzeBySetupV2(undefined)).toEqual([]);
+  });
+
+  it('retorna [] quando trades é array vazio', () => {
+    expect(analyzeBySetupV2([])).toEqual([]);
+  });
+
+  it('retorna [] quando trades não é array', () => {
+    expect(analyzeBySetupV2({})).toEqual([]);
+    expect(analyzeBySetupV2('trade')).toEqual([]);
+  });
+});
+
+describe('analyzeBySetupV2 — agrupamento e KPIs básicos', () => {
+  it('agrupa trades por setup (trim), trades sem setup viram "Sem Setup"', () => {
+    const trades = [
+      mk({ setup: ' Breakout ', result: 100 }),
+      mk({ setup: 'Breakout', result: 200 }),
+      mk({ setup: '', result: -50 }),
+      mk({ setup: undefined, result: -30 }),
+    ];
+    const out = analyzeBySetupV2(trades);
+    const breakout = out.find(s => s.setup === 'Breakout');
+    const semSetup = out.find(s => s.setup === 'Sem Setup');
+    expect(breakout.n).toBe(2);
+    expect(breakout.totalPL).toBe(300);
+    expect(semSetup.n).toBe(2);
+    expect(semSetup.totalPL).toBe(-80);
+  });
+
+  it('calcula n, totalPL, wr, ev corretamente', () => {
+    const trades = [
+      mk({ setup: 'A', result: 300 }),
+      mk({ setup: 'A', result: 200 }),
+      mk({ setup: 'A', result: -100 }),
+      mk({ setup: 'A', result: 0 }),
+    ];
+    const [a] = analyzeBySetupV2(trades);
+    expect(a.setup).toBe('A');
+    expect(a.n).toBe(4);
+    expect(a.totalPL).toBe(400);
+    expect(a.wr).toBeCloseTo(50, 4); // 2 wins / 4 = 50%
+    expect(a.ev).toBe(100); // 400/4
+  });
+
+  it('payoff = avgWin / |avgLoss|', () => {
+    const trades = [
+      mk({ setup: 'A', result: 200 }),
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: -50 }),
+    ];
+    const [a] = analyzeBySetupV2(trades);
+    // avgWin=150, avgLoss=-50 → payoff=3
+    expect(a.payoff).toBe(3);
+  });
+
+  it('payoff = null quando não há wins ou não há losses', () => {
+    const onlyWins = [
+      mk({ setup: 'W', result: 100 }),
+      mk({ setup: 'W', result: 50 }),
+    ];
+    const onlyLosses = [
+      mk({ setup: 'L', result: -100 }),
+      mk({ setup: 'L', result: -50 }),
+    ];
+    expect(analyzeBySetupV2(onlyWins)[0].payoff).toBeNull();
+    expect(analyzeBySetupV2(onlyLosses)[0].payoff).toBeNull();
+  });
+});
+
+describe('analyzeBySetupV2 — ΔT W vs L (duração)', () => {
+  it('calcula deltaT = (durationWin - durationLoss) / durationLoss', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100, duration: 15 }),
+      mk({ setup: 'A', result: 50, duration: 25 }), // wins: média 20
+      mk({ setup: 'A', result: -50, duration: 5 }),
+      mk({ setup: 'A', result: -100, duration: 5 }), // losses: média 5
+    ];
+    const [a] = analyzeBySetupV2(trades);
+    expect(a.durationWin).toBe(20);
+    expect(a.durationLoss).toBe(5);
+    // (20 - 5) / 5 = 3 → 300%
+    expect(a.deltaT).toBe(300);
+  });
+
+  it('deltaT = null quando falta wins ou losses', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100, duration: 10 }),
+      mk({ setup: 'A', result: 50, duration: 10 }),
+    ];
+    expect(analyzeBySetupV2(trades)[0].deltaT).toBeNull();
+  });
+
+  it('derivá duration de entryTime/exitTime quando duration está ausente', () => {
+    const trades = [
+      mk({
+        setup: 'A',
+        result: 100,
+        duration: undefined,
+        entryTime: '2026-04-15T10:00:00',
+        exitTime: '2026-04-15T10:30:00',
+      }),
+      mk({ setup: 'A', result: -50, duration: 10 }),
+    ];
+    const [a] = analyzeBySetupV2(trades);
+    expect(a.durationWin).toBe(30);
+  });
+});
+
+describe('analyzeBySetupV2 — Contribuição ao EV total (contribEV)', () => {
+  it('contribEV = (n × EV_setup) / Σ(n × EV) expressa em %', () => {
+    const trades = [
+      // Setup A: n=2, totalPL=+200, EV=100 → n×EV = 200
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: 100 }),
+      // Setup B: n=3, totalPL=-300, EV=-100 → n×EV = -300
+      mk({ setup: 'B', result: -100 }),
+      mk({ setup: 'B', result: -100 }),
+      mk({ setup: 'B', result: -100 }),
+    ];
+    const out = analyzeBySetupV2(trades);
+    const a = out.find(s => s.setup === 'A');
+    const b = out.find(s => s.setup === 'B');
+    // Σ|n×EV| = 200 + 300 = 500 (denominador usa soma dos totalPL em módulo)
+    // contribEV_A = +200/500 = +40%, contribEV_B = -300/500 = -60%
+    expect(a.contribEV).toBeCloseTo(40, 4);
+    expect(b.contribEV).toBeCloseTo(-60, 4);
+  });
+
+  it('contribEV = 0 quando todos setups têm PL zero', () => {
+    const trades = [
+      mk({ setup: 'A', result: 0 }),
+      mk({ setup: 'B', result: 0 }),
+    ];
+    const out = analyzeBySetupV2(trades);
+    expect(out.every(s => s.contribEV === 0)).toBe(true);
+  });
+});
+
+describe('analyzeBySetupV2 — Ordenação e esporádicos', () => {
+  it('cards ordenados por |contribEV| desc (impacto absoluto)', () => {
+    const trades = [
+      // B é o maior impacto negativo, A é impacto positivo menor
+      mk({ setup: 'A', result: 50 }),
+      mk({ setup: 'A', result: 50 }),
+      mk({ setup: 'A', result: 50 }),
+      mk({ setup: 'B', result: -300 }),
+      mk({ setup: 'B', result: -300 }),
+      mk({ setup: 'B', result: -300 }),
+    ];
+    const out = analyzeBySetupV2(trades);
+    expect(out[0].setup).toBe('B'); // maior |contribEV|
+    expect(out[1].setup).toBe('A');
+  });
+
+  it('retorna todos os setups; flag isSporadic = n < 3 para permitir grouping no componente', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: 100 }), // n=3
+      mk({ setup: 'B', result: 100 }),
+      mk({ setup: 'B', result: 100 }), // n=2 → esporádico
+    ];
+    const out = analyzeBySetupV2(trades);
+    const a = out.find(s => s.setup === 'A');
+    const b = out.find(s => s.setup === 'B');
+    expect(a.isSporadic).toBe(false);
+    expect(b.isSporadic).toBe(true);
+  });
+});
+
+describe('analyzeBySetupV2 — Aderência RR (condicional via setupsMeta)', () => {
+  it('adherenceRR = null quando setupsMeta ausente', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100, rr: 2.0 }),
+      mk({ setup: 'A', result: 100, rr: 2.2 }),
+    ];
+    expect(analyzeBySetupV2(trades)[0].adherenceRR).toBeNull();
+  });
+
+  it('adherenceRR = null quando setupsMeta existe mas setup não tem targetRR', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100, rr: 2.0 }),
+    ];
+    const setupsMeta = [{ name: 'A' /* targetRR ausente */ }];
+    expect(analyzeBySetupV2(trades, { setupsMeta })[0].adherenceRR).toBeNull();
+  });
+
+  it('adherenceRR conta trades com rr dentro da banda [target*0.8, target*1.2]', () => {
+    const trades = [
+      mk({ setup: 'A', rr: 2.0 }), // dentro (target=2, banda 1.6-2.4)
+      mk({ setup: 'A', rr: 2.3 }), // dentro
+      mk({ setup: 'A', rr: 1.0 }), // fora
+      mk({ setup: 'A', rr: 2.5 }), // fora
+      mk({ setup: 'A', rr: undefined }), // rr ausente → fora
+    ];
+    const setupsMeta = [{ name: 'A', targetRR: 2.0 }];
+    const [a] = analyzeBySetupV2(trades, { setupsMeta });
+    expect(a.adherenceRR).toEqual({
+      inBand: 2,
+      total: 5,
+      pct: 40, // 2/5 = 40%
+      targetRR: 2.0,
+    });
+  });
+});
+
+describe('analyzeBySetupV2 — Sparkline 6m', () => {
+  it('sparkline6m retorna array ordenado de PL acumulado mensal', () => {
+    const today = new Date('2026-04-22');
+    const trades = [
+      // Setup A com trades em meses diferentes
+      mk({ setup: 'A', result: 100, date: '2026-04-10' }),
+      mk({ setup: 'A', result: 50, date: '2026-03-15' }),
+      mk({ setup: 'A', result: -30, date: '2026-02-01' }),
+    ];
+    const [a] = analyzeBySetupV2(trades, { today });
+    // Sparkline 6m: 6 buckets (mais antigo → mais recente), PL acumulado
+    expect(a.sparkline6m).toHaveLength(6);
+    expect(a.sparkline6m[a.sparkline6m.length - 1]).toBe(120); // -30 + 50 + 100
+  });
+
+  it('ignora trades fora da janela 6m', () => {
+    const today = new Date('2026-04-22');
+    const trades = [
+      mk({ setup: 'A', result: 1000, date: '2025-09-01' }), // >6 meses
+      mk({ setup: 'A', result: 100, date: '2026-04-10' }),
+    ];
+    const [a] = analyzeBySetupV2(trades, { today });
+    expect(a.sparkline6m[a.sparkline6m.length - 1]).toBe(100); // ignora 2025-09
+  });
+
+  it('retorna 6 zeros quando setup não tem trades na janela', () => {
+    const today = new Date('2026-04-22');
+    const trades = [
+      mk({ setup: 'A', result: 100, date: '2020-01-01' }),
+    ];
+    const [a] = analyzeBySetupV2(trades, { today });
+    expect(a.sparkline6m).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe('analyzeBySetupV2 — edges', () => {
+  it('n=1 retorna KPIs coerentes (deltaT null, payoff null se só win ou só loss)', () => {
+    const trades = [mk({ setup: 'S', result: 100 })];
+    const [s] = analyzeBySetupV2(trades);
+    expect(s.n).toBe(1);
+    expect(s.ev).toBe(100);
+    expect(s.payoff).toBeNull();
+    expect(s.deltaT).toBeNull();
+  });
+
+  it('soma trades de moedas diferentes sem particionar (multi-moeda ignorada por setup)', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100, currency: 'BRL' }),
+      mk({ setup: 'A', result: 20, currency: 'USD' }),
+    ];
+    const [a] = analyzeBySetupV2(trades);
+    expect(a.n).toBe(2);
+    expect(a.totalPL).toBe(120); // soma crua, sem conversão
+  });
+
+  it('trades com result null/undefined contam como 0 no PL mas entram no n', () => {
+    const trades = [
+      mk({ setup: 'A', result: 100 }),
+      mk({ setup: 'A', result: null }),
+      mk({ setup: 'A', result: undefined }),
+    ];
+    const [a] = analyzeBySetupV2(trades);
+    expect(a.n).toBe(3);
+    expect(a.totalPL).toBe(100);
+  });
+});

--- a/src/components/SetupAnalysis.jsx
+++ b/src/components/SetupAnalysis.jsx
@@ -1,15 +1,300 @@
-import { useMemo } from 'react';
-import { BarChart3 } from 'lucide-react';
-import { analyzeBySetup, formatCurrency, formatPercent } from '../utils/calculations';
+/**
+ * SetupAnalysis V2 — issue #170
+ *
+ * Substitui a versão anterior (barra proporcional + WR) por card de
+ * diagnóstico operacional com 4 KPIs por setup:
+ *   - Financial · EV por trade
+ *   - Financial · Payoff (avgWin / |avgLoss|)
+ *   - Operational · ΔT W vs L (semáforo ±20%/±10%)
+ *   - Impact · Contribuição ao EV total (%)
+ *
+ * Sparkline 6m (PL acumulado) + Aderência RR condicional (quando setupsMeta
+ * traz targetRR) + Insight 1-linha no rodapé.
+ *
+ * Ordenação por |contribEV| desc. Setups com n<3 vão para accordion
+ * "Esporádicos (N)" colapsado (expandido quando nenhum setup tem n≥3).
+ *
+ * API preservada: prop `trades`. Nova prop opcional `setupsMeta`.
+ */
 
-const SetupAnalysis = ({ trades }) => {
-  const setupData = useMemo(() => {
-    return analyzeBySetup(trades);
-  }, [trades]);
+import React, { useMemo, useState } from 'react';
+import { BarChart3, TrendingUp, TrendingDown, ChevronRight, ChevronDown } from 'lucide-react';
+import { formatCurrency } from '../utils/calculations';
+import { analyzeBySetupV2 } from '../utils/setupAnalysisV2';
+import DebugBadge from './DebugBadge';
 
-  if (setupData.length === 0) {
+const fmtSignedCurrency = (v) => (v >= 0 ? `+${formatCurrency(v)}` : formatCurrency(v));
+const fmtPct = (v, digits = 0) => `${v.toFixed(digits)}%`;
+const fmtSignedPct = (v, digits = 0) => `${v >= 0 ? '+' : ''}${v.toFixed(digits)}%`;
+
+// Semáforo ΔT (spec #170): >+20% verde / -10%..+20% âmbar / <-10% vermelho
+const deltaTColor = (deltaT) => {
+  if (deltaT === null) return 'text-slate-500';
+  if (deltaT > 20) return 'text-emerald-400';
+  if (deltaT >= -10) return 'text-amber-400';
+  return 'text-red-400';
+};
+
+// Sparkline local (mesmo visual do EmotionAnalysis). Recebe values: number[].
+const Sparkline = ({ values, positive, testId }) => {
+  if (!values || values.length === 0) return null;
+  const width = 60;
+  const height = 24;
+  const padding = 2;
+
+  if (values.length === 1) {
+    const cx = width / 2;
+    const cy = height / 2;
     return (
-      <div className="glass-card p-6">
+      <svg
+        data-testid={testId}
+        viewBox={`0 0 ${width} ${height}`}
+        width={width}
+        height={height}
+        className="overflow-visible"
+      >
+        <polyline
+          fill="none"
+          stroke={positive ? '#34d399' : '#f87171'}
+          strokeWidth="1.5"
+          points={`${cx - 4},${cy} ${cx + 4},${cy}`}
+        />
+      </svg>
+    );
+  }
+
+  const min = Math.min(...values, 0);
+  const max = Math.max(...values, 0);
+  const range = max - min || 1;
+  const points = values
+    .map((v, i) => {
+      const x = padding + (i / (values.length - 1)) * (width - 2 * padding);
+      const y = height - padding - ((v - min) / range) * (height - 2 * padding);
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+  const zeroY = height - padding - ((0 - min) / range) * (height - 2 * padding);
+
+  return (
+    <svg
+      data-testid={testId}
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      className="overflow-visible"
+    >
+      <line
+        x1={padding}
+        x2={width - padding}
+        y1={zeroY}
+        y2={zeroY}
+        stroke="#334155"
+        strokeWidth="0.5"
+        strokeDasharray="2 2"
+      />
+      <polyline
+        fill="none"
+        stroke={positive ? '#34d399' : '#f87171'}
+        strokeWidth="1.5"
+        points={points}
+      />
+    </svg>
+  );
+};
+
+const Quadrant = ({ label, sublabel, children }) => (
+  <div className="flex-1 min-w-0">
+    <p className="text-[9px] uppercase tracking-wider text-slate-500 font-semibold leading-tight">
+      {label}
+    </p>
+    {sublabel && (
+      <p className="text-[9px] text-slate-600 mb-1 leading-tight">{sublabel}</p>
+    )}
+    {!sublabel && <div className="mb-1" />}
+    <div className="space-y-0.5 text-xs">{children}</div>
+  </div>
+);
+
+const KPI = ({ label, value, valueClassName = 'text-slate-200' }) => (
+  <div className="flex items-baseline justify-between gap-2">
+    <span className="text-[10px] text-slate-500">{label}</span>
+    <span className={`font-mono font-semibold ${valueClassName}`}>{value}</span>
+  </div>
+);
+
+// Insight 1-linha: ofensor com contribEV<-20%, best performer payoff ≥ 1.5,
+// aderência RR baixa, fallback positivo.
+const buildInsight = (cards) => {
+  if (!cards || cards.length === 0) return null;
+
+  const worstOffender = cards.find((c) => c.contribEV < -20 && c.n >= 3);
+  if (worstOffender) {
+    return (
+      <>
+        <span className="text-red-400 font-bold">{worstOffender.setup}</span> é seu maior
+        ofensor ({fmtSignedPct(worstOffender.contribEV)} do EV total) — revisar critério de
+        entrada antes de seguir operando.
+      </>
+    );
+  }
+
+  const best = cards.find(
+    (c) => c.totalPL > 0 && c.payoff !== null && c.payoff >= 1.5 && c.n >= 3,
+  );
+  if (best) {
+    return (
+      <>
+        Seu setup mais consistente é{' '}
+        <span className="text-emerald-400 font-bold">{best.setup}</span>, payoff{' '}
+        {best.payoff.toFixed(1)}x — sustentado por gestão de saída.
+      </>
+    );
+  }
+
+  const lowAdherence = cards.find(
+    (c) => c.adherenceRR && c.adherenceRR.pct < 50 && c.n >= 3,
+  );
+  if (lowAdherence) {
+    return (
+      <>
+        <span className="text-amber-400 font-bold">{lowAdherence.setup}</span> está entregando
+        RR fora da banda em{' '}
+        {(100 - lowAdherence.adherenceRR.pct).toFixed(0)}% dos trades — o setup não está sendo
+        executado como idealizado.
+      </>
+    );
+  }
+
+  const positive = cards.find((c) => c.totalPL > 0);
+  if (positive) {
+    return (
+      <>
+        <span className="text-emerald-400 font-bold">{positive.setup}</span> puxa seu EV
+        agregado ({fmtSignedPct(positive.contribEV)}).
+      </>
+    );
+  }
+
+  return null;
+};
+
+const SetupCard = ({ card }) => {
+  const profitable = card.totalPL >= 0;
+  const borderClass = profitable ? 'border-emerald-500/20' : 'border-red-500/20';
+  const bgClass = profitable ? 'bg-emerald-500/5' : 'bg-red-500/5';
+  const totalColor = profitable ? 'text-emerald-400' : 'text-red-400';
+
+  return (
+    <div
+      data-testid={`setup-card-${card.setup}`}
+      className={`relative p-3 rounded-xl border ${borderClass} ${bgClass} transition-all`}
+    >
+      <div className="flex justify-between items-center mb-3">
+        <div className="flex items-center gap-2">
+          <span className="font-bold text-slate-200 text-sm">{card.setup}</span>
+          <span className="text-[10px] text-slate-500 bg-slate-900/50 px-2 py-0.5 rounded-full border border-slate-700/50">
+            {card.n} {card.n === 1 ? 'trade' : 'trades'}
+          </span>
+        </div>
+        <div className="flex items-baseline gap-2">
+          <span className={`font-mono font-bold text-sm ${totalColor}`}>
+            {fmtSignedCurrency(card.totalPL)}
+          </span>
+          <span className="text-[10px] text-slate-500">{fmtPct(card.wr, 0)}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
+        <Quadrant label="Financial" sublabel="EV por trade">
+          <KPI
+            label="EV"
+            value={fmtSignedCurrency(card.ev)}
+            valueClassName={card.ev >= 0 ? 'text-emerald-400' : 'text-red-400'}
+          />
+          <KPI
+            label="Payoff"
+            value={card.payoff === null ? '—' : `${card.payoff.toFixed(1)}x`}
+          />
+        </Quadrant>
+
+        <Quadrant label="Operational" sublabel="ΔT W vs L">
+          <KPI
+            label="ΔT"
+            value={card.deltaT === null ? '—' : fmtSignedPct(card.deltaT, 0)}
+            valueClassName={deltaTColor(card.deltaT)}
+          />
+          {card.durationWin !== null && card.durationLoss !== null && (
+            <div className="text-[10px] text-slate-500 leading-tight">
+              W {card.durationWin.toFixed(0)}min · L {card.durationLoss.toFixed(0)}min
+            </div>
+          )}
+        </Quadrant>
+
+        <Quadrant label="Impact" sublabel="Contribuição ao EV">
+          <KPI
+            label="Contrib"
+            value={fmtSignedPct(card.contribEV, 0)}
+            valueClassName={card.contribEV >= 0 ? 'text-emerald-400' : 'text-red-400'}
+          />
+        </Quadrant>
+
+        <Quadrant label="Maturidade" sublabel="PL 6m">
+          <div className="flex items-center gap-2">
+            <Sparkline
+              values={card.sparkline6m}
+              positive={profitable}
+              testId={`setup-sparkline-${card.setup}`}
+            />
+            {profitable ? (
+              <TrendingUp className="w-3 h-3 text-emerald-400 opacity-60" />
+            ) : (
+              <TrendingDown className="w-3 h-3 text-red-400 opacity-60" />
+            )}
+          </div>
+        </Quadrant>
+      </div>
+
+      {card.adherenceRR && (
+        <div className="mt-2 pt-2 border-t border-slate-700/40 flex items-center justify-between">
+          <span className="text-[10px] uppercase tracking-wider text-slate-500 font-semibold">
+            Aderência RR
+          </span>
+          <span
+            className={`text-xs font-mono font-semibold ${
+              card.adherenceRR.pct >= 70
+                ? 'text-emerald-400'
+                : card.adherenceRR.pct >= 40
+                ? 'text-amber-400'
+                : 'text-red-400'
+            }`}
+          >
+            {card.adherenceRR.inBand}/{card.adherenceRR.total} ({fmtPct(card.adherenceRR.pct, 0)})
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const SetupAnalysis = ({ trades, setupsMeta }) => {
+  const cards = useMemo(
+    () => analyzeBySetupV2(trades, { setupsMeta }),
+    [trades, setupsMeta],
+  );
+
+  const { regulars, sporadics } = useMemo(() => {
+    const reg = cards.filter((c) => !c.isSporadic);
+    const spo = cards.filter((c) => c.isSporadic);
+    return { regulars: reg, sporadics: spo };
+  }, [cards]);
+
+  const [expanded, setExpanded] = useState(regulars.length === 0 && sporadics.length > 0);
+
+  const insight = useMemo(() => buildInsight(cards), [cards]);
+
+  if (!trades || trades.length === 0 || cards.length === 0) {
+    return (
+      <div className="glass-card p-6 relative">
         <div className="flex items-center gap-3 mb-4">
           <BarChart3 className="w-5 h-5 text-purple-400" />
           <h3 className="text-lg font-semibold text-white">Análise por Setup</h3>
@@ -17,93 +302,72 @@ const SetupAnalysis = ({ trades }) => {
         <p className="text-slate-500 text-center py-8">
           Nenhum trade registrado ainda
         </p>
+        <DebugBadge component="SetupAnalysis" embedded />
       </div>
     );
   }
 
-  const maxTrades = Math.max(...setupData.map(s => s.total));
-
   return (
-    <div className="glass-card p-6">
-      <div className="flex items-center gap-3 mb-6">
-        <BarChart3 className="w-5 h-5 text-purple-400" />
-        <h3 className="text-lg font-semibold text-white">Análise por Setup</h3>
-      </div>
-
-      <div className="space-y-4">
-        {setupData.map((setup, index) => (
-          <div 
-            key={setup.setup} 
-            className="group"
-            style={{ animationDelay: `${index * 50}ms` }}
+    <div className="glass-card p-6 h-full flex flex-col min-h-[350px] relative">
+      <div className="flex items-center justify-between mb-6 flex-none">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-purple-500/10 rounded-lg">
+            <BarChart3 className="w-5 h-5 text-purple-400" />
+          </div>
+          <div
+            title="Cada setup é uma hipótese operacional — tem RR esperado, frequência ideal e tempo médio. Esta análise responde: o setup está entregando o que promete? EV, Payoff, ΔT W/L (semáforo ±20%/±10%) e Contribuição ao EV total, ordenados por impacto absoluto."
           >
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-3">
-                <span className="text-sm font-medium text-white">{setup.setup}</span>
-                <span className="text-xs text-slate-500">
-                  {setup.total} trade{setup.total > 1 ? 's' : ''}
-                </span>
-              </div>
-              <div className="flex items-center gap-4">
-                <span className={`text-sm font-semibold ${setup.totalPL >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
-                  {formatCurrency(setup.totalPL)}
-                </span>
-                <span className={`text-sm font-medium px-2 py-0.5 rounded-full ${
-                  setup.winRate >= 50 ? 'bg-emerald-500/20 text-emerald-400' : 'bg-red-500/20 text-red-400'
-                }`}>
-                  {formatPercent(setup.winRate)}
-                </span>
-              </div>
-            </div>
-
-            {/* Progress bar */}
-            <div className="relative h-3 bg-slate-800/50 rounded-full overflow-hidden">
-              {/* Total bar (width baseado na quantidade de trades) */}
-              <div 
-                className="absolute top-0 left-0 h-full bg-slate-700/50 rounded-full transition-all duration-500"
-                style={{ width: `${(setup.total / maxTrades) * 100}%` }}
-              />
-              {/* Win rate bar */}
-              <div 
-                className={`absolute top-0 left-0 h-full rounded-full transition-all duration-700 ${
-                  setup.winRate >= 50 
-                    ? 'bg-gradient-to-r from-emerald-500 to-teal-500' 
-                    : 'bg-gradient-to-r from-red-500 to-orange-500'
-                }`}
-                style={{ width: `${(setup.total / maxTrades) * (setup.winRate / 100) * 100}%` }}
-              />
-            </div>
-
-            {/* Stats breakdown */}
-            <div className="flex items-center gap-4 mt-1">
-              <span className="text-xs text-emerald-400/70">
-                {setup.wins}W
-              </span>
-              <span className="text-xs text-red-400/70">
-                {setup.losses}L
-              </span>
-            </div>
+            <h3 className="text-lg font-bold text-white leading-tight">Análise por Setup</h3>
+            <p className="text-xs text-slate-500">
+              Financial · Operational · Impact · Maturidade por setup
+            </p>
           </div>
-        ))}
-      </div>
-
-      {/* Summary */}
-      <div className="mt-6 pt-4 border-t border-slate-800/50">
-        <div className="flex items-center justify-between text-sm">
-          <span className="text-slate-400">Melhor Setup:</span>
-          <span className="font-semibold text-emerald-400">
-            {setupData[0]?.setup} ({formatCurrency(setupData[0]?.totalPL)})
-          </span>
         </div>
-        {setupData.length > 1 && (
-          <div className="flex items-center justify-between text-sm mt-2">
-            <span className="text-slate-400">Setup a Melhorar:</span>
-            <span className="font-semibold text-red-400">
-              {setupData.filter(s => s.totalPL < 0)[0]?.setup || 'Nenhum'}
-            </span>
-          </div>
-        )}
       </div>
+
+      {regulars.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 content-start">
+          {regulars.map((c) => (
+            <SetupCard key={c.setup} card={c} />
+          ))}
+        </div>
+      )}
+
+      {sporadics.length > 0 && (
+        <div className={regulars.length > 0 ? 'mt-4' : ''}>
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="flex items-center gap-2 text-xs text-slate-400 hover:text-slate-200 font-semibold uppercase tracking-wider"
+          >
+            {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            Esporádicos ({sporadics.length})
+            <span className="text-[10px] text-slate-600 normal-case tracking-normal">
+              setups com menos de 3 trades
+            </span>
+          </button>
+          {expanded && (
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 content-start">
+              {sporadics.map((c) => (
+                <SetupCard key={c.setup} card={c} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {insight && (
+        <div className="mt-4 pt-4 border-t border-slate-700/40 flex-none">
+          <p className="text-xs text-slate-400 leading-relaxed">
+            <span className="text-slate-500 font-semibold uppercase tracking-wider mr-2">
+              Insight
+            </span>
+            {insight}
+          </p>
+        </div>
+      )}
+
+      <DebugBadge component="SetupAnalysis" embedded />
     </div>
   );
 };

--- a/src/components/SetupAnalysis.jsx
+++ b/src/components/SetupAnalysis.jsx
@@ -187,25 +187,28 @@ const SetupCard = ({ card }) => {
   return (
     <div
       data-testid={`setup-card-${card.setup}`}
-      className={`relative p-3 rounded-xl border ${borderClass} ${bgClass} transition-all`}
+      className={`relative p-3 rounded-xl border ${borderClass} ${bgClass} transition-all overflow-hidden`}
     >
-      <div className="flex justify-between items-center mb-3">
-        <div className="flex items-center gap-2">
-          <span className="font-bold text-slate-200 text-sm">{card.setup}</span>
-          <span className="text-[10px] text-slate-500 bg-slate-900/50 px-2 py-0.5 rounded-full border border-slate-700/50">
+      {/* Header em 2 linhas para não estourar em cards estreitos */}
+      <div className="mb-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-bold text-slate-200 text-sm truncate" title={card.setup}>
+            {card.setup}
+          </span>
+          <span className="shrink-0 text-[10px] text-slate-500 bg-slate-900/50 px-2 py-0.5 rounded-full border border-slate-700/50 whitespace-nowrap">
             {card.n} {card.n === 1 ? 'trade' : 'trades'}
           </span>
         </div>
-        <div className="flex items-baseline gap-2">
-          <span className={`font-mono font-bold text-sm ${totalColor}`}>
+        <div className="flex items-baseline gap-2 mt-1">
+          <span className={`font-mono font-bold text-sm whitespace-nowrap ${totalColor}`}>
             {fmtSignedCurrency(card.totalPL)}
           </span>
-          <span className="text-[10px] text-slate-500">{fmtPct(card.wr, 0)}</span>
+          <span className="text-[10px] text-slate-500 whitespace-nowrap">WR {fmtPct(card.wr, 0)}</span>
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-x-3 gap-y-2">
-        <Quadrant label="Financial" sublabel="EV por trade">
+        <Quadrant label="Financial" sublabel="por trade">
           <KPI
             label="EV"
             value={fmtSignedCurrency(card.ev)}
@@ -217,20 +220,20 @@ const SetupCard = ({ card }) => {
           />
         </Quadrant>
 
-        <Quadrant label="Operational" sublabel="ΔT W vs L">
+        <Quadrant label="Operational" sublabel="W vs L">
           <KPI
             label="ΔT"
             value={card.deltaT === null ? '—' : fmtSignedPct(card.deltaT, 0)}
             valueClassName={deltaTColor(card.deltaT)}
           />
           {card.durationWin !== null && card.durationLoss !== null && (
-            <div className="text-[10px] text-slate-500 leading-tight">
-              W {card.durationWin.toFixed(0)}min · L {card.durationLoss.toFixed(0)}min
+            <div className="text-[10px] text-slate-500 leading-tight truncate">
+              W {card.durationWin.toFixed(0)}m · L {card.durationLoss.toFixed(0)}m
             </div>
           )}
         </Quadrant>
 
-        <Quadrant label="Impact" sublabel="Contribuição ao EV">
+        <Quadrant label="Impact" sublabel="ao EV total">
           <KPI
             label="Contrib"
             value={fmtSignedPct(card.contribEV, 0)}
@@ -246,9 +249,9 @@ const SetupCard = ({ card }) => {
               testId={`setup-sparkline-${card.setup}`}
             />
             {profitable ? (
-              <TrendingUp className="w-3 h-3 text-emerald-400 opacity-60" />
+              <TrendingUp className="w-3 h-3 shrink-0 text-emerald-400 opacity-60" />
             ) : (
-              <TrendingDown className="w-3 h-3 text-red-400 opacity-60" />
+              <TrendingDown className="w-3 h-3 shrink-0 text-red-400 opacity-60" />
             )}
           </div>
         </Quadrant>

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -498,7 +498,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
           /* TODO(#164): onNavigateToReview — aguardando rota aluno para Revisão Semanal
              (hoje 'weekly-review' é restrita a mentor em App.jsx). */
         />
-        <SetupAnalysis trades={filteredTrades} />
+        <SetupAnalysis trades={filteredTrades} setupsMeta={setups} />
       </div>
       <div className="mb-6"><EmotionAnalysis trades={filteredTrades} globalWR={stats?.winRate} /></div>
 

--- a/src/utils/setupAnalysisV2.js
+++ b/src/utils/setupAnalysisV2.js
@@ -1,0 +1,245 @@
+/**
+ * setupAnalysisV2.js — issue #170
+ *
+ * Util puro que agrupa trades por `setup` e calcula KPIs operacionais para o
+ * componente `SetupAnalysis` V2 (Dashboard do Aluno + Mentor Dashboard).
+ *
+ * Por setup retorna:
+ *   { setup, n, totalPL, wr, ev, payoff, durationWin, durationLoss, deltaT,
+ *     contribEV, adherenceRR, sparkline6m, isSporadic, trades }
+ *
+ * Regras:
+ * - Multi-moeda é ignorada por setup (soma crua, sem conversão — spec issue #170).
+ * - ΔT e Payoff retornam `null` quando faltam wins OU losses.
+ * - Aderência RR é condicional: só calcula quando `setupsMeta[x].targetRR` existe.
+ * - Sparkline 6m: 6 buckets mensais (mais antigo → mais recente), PL acumulado.
+ * - Ordenação final: |contribEV| desc.
+ */
+
+/**
+ * Calcula duração em minutos entre dois ISO timestamps.
+ * @param {string} entryISO
+ * @param {string} exitISO
+ * @returns {number} minutos ou 0
+ */
+const durationFromTimes = (entryISO, exitISO) => {
+  if (!entryISO || !exitISO) return 0;
+  try {
+    const start = new Date(entryISO);
+    const end = new Date(exitISO);
+    const ms = end - start;
+    if (!Number.isFinite(ms) || ms < 0) return 0;
+    return Math.floor(ms / 60000);
+  } catch {
+    return 0;
+  }
+};
+
+/**
+ * Retorna a duração de um trade em minutos, priorizando o campo `duration`
+ * (persistido) e caindo para entryTime/exitTime quando ausente.
+ */
+const tradeDuration = (trade) => {
+  if (typeof trade.duration === 'number' && Number.isFinite(trade.duration)) {
+    return trade.duration;
+  }
+  return durationFromTimes(trade.entryTime, trade.exitTime);
+};
+
+/**
+ * Chave `YYYY-MM` do mês do trade. Prefere `date` (campo canônico, sem fuso),
+ * cai para `entryTime`, depois `exitTime`.
+ */
+const monthKey = (trade) => {
+  const raw = trade.date || trade.entryTime || trade.exitTime;
+  if (!raw) return null;
+  try {
+    const s = String(raw);
+    if (s.length >= 7) return s.slice(0, 7); // 'YYYY-MM'
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Gera os 6 buckets mensais terminando no mês de `today` (incluso), do mais
+ * antigo ao mais recente.
+ * @param {Date} today
+ * @returns {string[]} ['YYYY-MM', ...]
+ */
+const buildMonthBuckets = (today) => {
+  const year = today.getFullYear();
+  const month = today.getMonth(); // 0-11
+  const out = [];
+  for (let i = 5; i >= 0; i -= 1) {
+    const d = new Date(year, month - i, 1);
+    const yy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    out.push(`${yy}-${mm}`);
+  }
+  return out;
+};
+
+/**
+ * Constrói sparkline 6m para um grupo de trades: PL acumulado ao final de cada
+ * um dos 6 meses (do mais antigo ao mais recente).
+ */
+const buildSparkline6m = (trades, today) => {
+  const buckets = buildMonthBuckets(today);
+  const byMonth = new Map(buckets.map((k) => [k, 0]));
+  trades.forEach((t) => {
+    const mk = monthKey(t);
+    if (mk && byMonth.has(mk)) {
+      byMonth.set(mk, byMonth.get(mk) + (Number(t.result) || 0));
+    }
+  });
+  let acc = 0;
+  return buckets.map((k) => {
+    acc += byMonth.get(k);
+    return acc;
+  });
+};
+
+/**
+ * Calcula aderência RR: trades com `rr` dentro da banda [target*0.8, target*1.2].
+ * Retorna null quando `targetRR` não existe.
+ */
+const calcAdherenceRR = (trades, targetRR) => {
+  if (!Number.isFinite(targetRR) || targetRR <= 0) return null;
+  const lo = targetRR * 0.8;
+  const hi = targetRR * 1.2;
+  let inBand = 0;
+  trades.forEach((t) => {
+    const rr = Number(t.rr);
+    if (Number.isFinite(rr) && rr >= lo && rr <= hi) inBand += 1;
+  });
+  return {
+    inBand,
+    total: trades.length,
+    pct: trades.length > 0 ? (inBand / trades.length) * 100 : 0,
+    targetRR,
+  };
+};
+
+/**
+ * Normaliza `setupsMeta` em um Map por nome (case-insensitive + trim).
+ */
+const buildSetupsMetaIndex = (setupsMeta) => {
+  const idx = new Map();
+  if (!Array.isArray(setupsMeta)) return idx;
+  setupsMeta.forEach((s) => {
+    if (!s) return;
+    const name = (s.name || '').trim();
+    if (!name) return;
+    idx.set(name.toLowerCase(), s);
+  });
+  return idx;
+};
+
+/**
+ * @param {Array} trades
+ * @param {Object} options
+ * @param {Array} [options.setupsMeta] docs de `setups` com `{ name, targetRR? }`
+ * @param {Date} [options.today] referência para janela 6m (default: new Date())
+ * @returns {Array}
+ */
+export const analyzeBySetupV2 = (trades, options = {}) => {
+  if (!trades || !Array.isArray(trades) || trades.length === 0) return [];
+
+  const { setupsMeta, today = new Date() } = options;
+  const metaIdx = buildSetupsMetaIndex(setupsMeta);
+
+  // 1. Agrupamento por setup (trim, vazio → "Sem Setup")
+  const groups = new Map();
+  trades.forEach((trade) => {
+    const rawKey = typeof trade.setup === 'string' ? trade.setup.trim() : '';
+    const key = rawKey || 'Sem Setup';
+    if (!groups.has(key)) {
+      groups.set(key, { setup: key, trades: [] });
+    }
+    groups.get(key).trades.push(trade);
+  });
+
+  // 2. Cálculos por setup
+  const rows = [];
+  for (const [, group] of groups) {
+    const gTrades = group.trades;
+    const n = gTrades.length;
+    const totalPL = gTrades.reduce((acc, t) => acc + (Number(t.result) || 0), 0);
+
+    const wins = gTrades.filter((t) => (Number(t.result) || 0) > 0);
+    const losses = gTrades.filter((t) => (Number(t.result) || 0) < 0);
+
+    const wr = n > 0 ? (wins.length / n) * 100 : 0;
+    const ev = n > 0 ? totalPL / n : 0;
+
+    // Payoff: null se não há wins OU não há losses
+    let payoff = null;
+    if (wins.length > 0 && losses.length > 0) {
+      const avgWin = wins.reduce((a, t) => a + Number(t.result), 0) / wins.length;
+      const avgLoss = losses.reduce((a, t) => a + Number(t.result), 0) / losses.length;
+      payoff = Math.abs(avgLoss) > 0 ? avgWin / Math.abs(avgLoss) : null;
+    }
+
+    // Durations
+    const winDurations = wins.map(tradeDuration).filter((d) => d > 0);
+    const lossDurations = losses.map(tradeDuration).filter((d) => d > 0);
+    const durationWin = winDurations.length > 0
+      ? winDurations.reduce((a, d) => a + d, 0) / winDurations.length
+      : null;
+    const durationLoss = lossDurations.length > 0
+      ? lossDurations.reduce((a, d) => a + d, 0) / lossDurations.length
+      : null;
+
+    // ΔT = (durationWin - durationLoss) / durationLoss × 100 — null se falta algum
+    let deltaT = null;
+    if (
+      durationWin !== null &&
+      durationLoss !== null &&
+      durationLoss > 0
+    ) {
+      deltaT = ((durationWin - durationLoss) / durationLoss) * 100;
+    }
+
+    // Aderência RR (condicional)
+    const meta = metaIdx.get(group.setup.toLowerCase());
+    const adherenceRR = meta
+      ? calcAdherenceRR(gTrades, Number(meta.targetRR))
+      : null;
+
+    // Sparkline 6m
+    const sparkline6m = buildSparkline6m(gTrades, today);
+
+    rows.push({
+      setup: group.setup,
+      n,
+      totalPL,
+      wr,
+      ev,
+      payoff,
+      durationWin,
+      durationLoss,
+      deltaT,
+      contribEV: 0, // preenchido após total
+      adherenceRR,
+      sparkline6m,
+      isSporadic: n < 3,
+      trades: gTrades,
+    });
+  }
+
+  // 3. Contribuição ao EV total (% com sinal)
+  // Denominador: Σ |n × EV| = Σ |totalPL|. Mantém sinal do setup no numerador.
+  const totalAbs = rows.reduce((a, r) => a + Math.abs(r.totalPL), 0);
+  rows.forEach((r) => {
+    r.contribEV = totalAbs > 0 ? (r.totalPL / totalAbs) * 100 : 0;
+  });
+
+  // 4. Ordenação por |contribEV| desc
+  rows.sort((a, b) => Math.abs(b.contribEV) - Math.abs(a.contribEV));
+
+  return rows;
+};
+
+export default analyzeBySetupV2;


### PR DESCRIPTION
## Summary

Substitui `SetupAnalysis.jsx` (barra proporcional + WR) por card de diagnóstico operacional que responde **"meu setup X está entregando o que promete?"**:

- **4 KPIs em grid 2×2**: EV por trade · Payoff (avgWin/|avgLoss|) · ΔT W vs L com semáforo ±20%/±10% + tempos brutos · Contribuição ao EV total (%)
- **Aderência RR condicional** — X/N dentro da banda [target×0.8, target×1.2] quando `setups.targetRR` existe; linha omitida quando ausente (não fabrica dado)
- **Sparkline 6m** — PL acumulado mensal, mesmo visual da Matriz 4D
- **Insight 1-linha** — ofensor com contribEV<-20% → best performer payoff≥1.5 → aderência RR<50% → fallback positivo
- **Ordenação por `|contribEV|` desc** — impacto absoluto primeiro
- **Accordion "Esporádicos (N)"** — setups com n<3 colapsados no rodapé (expandido por default quando nenhum setup atinge n≥3)

Util puro novo `src/utils/setupAnalysisV2.js` (245 linhas) com 23 testes antes da UI. API externa preservada (prop `trades`) + nova prop opcional `setupsMeta`. Zero campo Firestore novo.

## Entregas

| # | Commit | Descrição |
|---|--------|-----------|
| E3 | `2bd11e82` | util `analyzeBySetupV2` + 23 testes (defensivo / agrupamento / KPIs / ΔT / contribEV / ordenação / adherenceRR / sparkline 6m / edges) |
| E1+E2 | `52919bc7` | UI SetupAnalysis V2 (4 KPIs grid 2×2 + Sparkline + accordion esporádicos) + 17 testes render |
| E4 | `e5239727` | wire `setupsMeta={setups}` em `StudentDashboard` via `useSetups` já presente |
| docs | `6b87fcd2` | log + CLAIMS consolidado |

**MentorDashboard não alterado** — `useSetups` não está consumido lá e setups globais/pessoais mistos não têm filtro por `selectedStudent.uid`. Aderência RR fica omitida (condicional). Wire mentor-side → fast-follow ou issue separada.

## Abertura (já no main via `3b69ea4b`)

- PROJECT.md v0.27.0 → v0.28.0 (entrada histórico)
- Lock CHUNK-02 (escrita) registrado em §6.3
- v1.42.0 reservada em `src/version.js` (entrada CHANGELOG tagged `[RESERVADA]`)

## Qualidade

- **1880/1880 testes** (baseline 1840 + 40 novos)
- ESLint: zero errors nos arquivos tocados (2 warnings pré-existentes em `StudentDashboard.jsx` não regressivos)
- Build: verde em 14.74s

## Impacto

| Aspecto | Detalhe |
|---------|---------|
| Collections Firestore | Leitura: `trades`, `setups` (opcional). Escrita: zero |
| Cloud Functions | Nenhuma |
| Hooks | `useSetups` passa a ser consumido no `SetupAnalysis` via prop drilling |
| Side-effects (PL/compliance/emotional) | Zero |
| Blast radius | Baixo — componente isolado, API externa preservada |
| Rollback | `git revert` limpo |

## INVs respeitadas

- INV-01/02 zero escrita em `trades`/`plans`
- INV-04 DebugBadge `component="SetupAnalysis"` preservado
- INV-05 testes antes da UI (util E3 → UI E1/E2)
- INV-10/15 zero estrutura Firestore nova
- INV-17 declarado (seção 3.3 do control file)
- INV-18 spec aprovada via issue body

## Fora do escopo (fase 2)

- Shift emocional por setup (join com `emotionMatrix4D`)
- Aderência à checklist do setup (exige schema novo em `setups`)
- Heatmap setup × emoção
- Filtro drill-down por setup no dashboard

## Test plan

- [ ] **Validação browser** — 5 cenários da spec:
  - Setup com muitos trades (n≥3)
  - Setup esporádico (n<3, accordion colapsado)
  - Setup sem `targetRR` cadastrado (linha Aderência omitida)
  - Setup perdedor com contribEV < -20% (insight ofensor)
  - Multi-setup com diferentes impactos (ordenação por |contribEV|)
- [ ] Confirmar DebugBadge `SetupAnalysis` com `v1.42.0`
- [ ] Confirmar que MentorDashboard ainda renderiza (sem setupsMeta, Aderência RR omitida)
- [ ] Sanity: rodar `npm test -- --run` localmente

Após merge eu executo §4.3: promover v1.42.0 (remover `[RESERVADA]`) + liberar lock CHUNK-02 + arquivar issue doc + `git worktree remove`.

Closes #170