### PR TITLE
fix(#191): aderência recente no gate compliance-100 (Metódico→Profissional)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ Version source of truth: `src/version.js`.
 
 ---
 
+## [1.44.1] - 24/04/2026
+
+**Issue:** #191 (fix: aderência recente no gate compliance-100 do stage Profissional)
+
+#### Corrigido
+
+- **Gate `compliance-100` (Metódico → Profissional) agora avalia a janela recente correta.** Antes, `complianceRate100` era apenas alias de `complianceRate` (linha ~126 de `functions/maturity/preComputeShapes.js`) — o gate reusava o cálculo da janela total do histórico em vez da aderência recente que o nome promete. Resultado: traders com violações antigas mas excelentes recentes podiam ser reprovados; traders com histórico bom mas violações recentes podiam ser aprovados.
+
+#### Adicionado
+
+- **`computeCycleBasedComplianceRate({trades, plans, now, minTrades=20})`** — helper puro novo em `functions/maturity/computeCycleBasedComplianceRate.js` (CommonJS) com mirror espelhado em `src/utils/maturityEngine/computeCycleBasedComplianceRate.js` (ESM). Aplica a regra:
+  - **Janela** = união dos ranges `[cycleStart, cycleEnd]` do ciclo que contém `now` em cada plano (derivação por `adjustmentCycle`: Mensal/Trimestral/Semestral/Anual).
+  - **Mínimo 20 trades CLOSED.** Se `< 20`, retrocede simultaneamente 1 ciclo em CADA plano e recoleta. Repete até atingir o mínimo ou esgotar.
+  - **Esgotamento** = iteração que não acrescenta nenhum trade novo. Cap mecânico defensivo `MAX_LOOKBACK_CYCLES = 36`.
+  - **Insuficiente** (`< 20` mesmo após esgotar) → `null`. Em `evaluateGates`, `null` cai em `met: null`, `reason: 'METRIC_UNAVAILABLE'` → gate fica pendente: **não promove** (`gatesMet < gatesTotal` bloqueia `proposeStageTransition`) e **não rebaixa** (`detectRegressionSignal` não consome este campo, DEC-020 preservada).
+  - **Fórmula**: `(trades_sem_flag / total) * 100` sobre a janela final. Aceita `trade.date` em `YYYY-MM-DD`, `DD/MM/YYYY` ou `Date`. Dedup por `trade.id` em planos com ciclos sobrepostos.
+- `preComputeShapes({trades, plans, now})` agora aceita `now` (default: `new Date()`) e propaga para o novo helper. `recomputeMaturity.js` repassa o `now` que já calcula.
+
+#### Testes
+
+- 17 testes em `src/__tests__/utils/maturityEngine/computeCycleBasedComplianceRate.test.js` cobrindo cenários A-E da memória de cálculo aprovada + invariantes (vazios, dates inválidos, formato BR/ISO/Date, redFlags array vs hasRedFlags, dedup por id, plano Trimestral, `minTrades` customizável, default `adjustmentCycle`, retrocesso multi-ciclo).
+- 3 testes de paridade ESM↔CommonJS em `src/__tests__/functions/maturity/computeCycleBasedComplianceRate.test.js`.
+- Suite total: **2421 testes (144 arquivos), 100% verde**.
+
+#### Decisões
+
+- DEC-AUTO-191-01 — Janela = união de ciclos ativos por plano + fallback retroativo simultâneo.
+- DEC-AUTO-191-02 — Estado insuficiente = `null` (mapeia para `METRIC_UNAVAILABLE` no gate, semanticamente correto: pendente, não promove e não rebaixa).
+
+---
+
 ## [1.44.0] - 24/04/2026
 
 **Issue:** #119 (feat: Motor de progressão Maturidade 4D × 5 stages — modo autônomo)

--- a/docs/dev/issues/issue-191-compliance-ciclo.md
+++ b/docs/dev/issues/issue-191-compliance-ciclo.md
@@ -1,0 +1,115 @@
+# Issue #191 — fix: aderência recente (últimos N trades) no gate compliance-100 do stage Profissional
+
+## Autorização (OBRIGATÓRIA)
+
+- [x] Mockup dispensado — issue simples sem UI nova; anuência explícita do Marcio em 24/04/2026
+- [x] Memória de cálculo apresentada e aprovada em 24/04/2026
+- [x] Marcio autorizou — 24/04/2026 (capturado em sessão #815a1e1a; decisões 1–6 batidas no chat)
+- [x] Gate Pré-Código liberado
+
+## Context
+
+O gate `compliance-100` (`>= 100`) governa a transição Metódico → Profissional (3→4) no motor de maturidade #119. Hoje, `complianceRate100` é apenas alias de `complianceRate` (linha ~126 de `functions/maturity/preComputeShapes.js`) — ou seja, o mesmo cálculo da janela padrão é reusado. Consequência: o gate aprova/reprova com base no histórico inteiro do trader, não na **aderência recente** que o nome promete. Furo é semântico (fórmula filtra a janela errada); dados existem.
+
+## Spec
+
+Ver issue body no GitHub: #191.
+
+## Memória de Cálculo
+
+### Inputs
+
+- `trades` — coleção raiz `trades`. Filtros upstream: `studentId == aluno`, `status == 'CLOSED'`. Campos consumidos: `date` (string ISO `YYYY-MM-DD` ou BR `DD/MM/YYYY`), `hasRedFlags` (bool) e/ou `redFlags` (array).
+- `plans` — coleção raiz `plans`. Filtros upstream: `studentId == aluno`. Campos consumidos: `id`, `adjustmentCycle` (`'Mensal'|'Trimestral'|'Semestral'|'Anual'` — default `'Mensal'`).
+- `now` — `Date` (referência temporal para detectar ciclo ativo).
+- Compliance por trade já avaliado pela camada CHUNK-05 e gravado em `hasRedFlags`/`redFlags`. Esta função apenas consome.
+
+### Janela (decisões 1-3 aprovadas)
+
+1. **Ciclo ativo de cada plano** = ciclo do `adjustmentCycle` que contém `now`. Construído via `getCycleStartDate`/`getCycleEndDate` (mesma derivação por datas usada em `cycleResolver.detectActiveCycle` e `planStateMachine`).
+2. **Janela inicial** = união dos ranges `[cycleStart, cycleEnd]` de todos os planos do aluno.
+3. **Trades qualificados** = trades CLOSED cujo `date` cai em algum range da união.
+4. **Mínimo: 20 trades fechados** na janela.
+5. **Fallback (volume baixo)**: se `< 20` trades, retroceder UM ciclo (mesmo `adjustmentCycle`) em CADA plano simultaneamente, recalcular união, recoletar trades. Repetir até atingir 20 ou esgotar histórico.
+6. **Esgotamento**: iteração de retrocesso que não acrescenta nenhum trade novo (todos os planos sem trades naquele ciclo histórico). Cap mecânico defensivo: `MAX_LOOKBACK_CYCLES = 36`.
+7. **Trader sem ciclo ativo**: se nenhum plano tem trades no ciclo que contém `now` (todos os planos só têm histórico passado), o passo 5 cobre — o primeiro retrocesso já pega o último ciclo encerrado.
+
+### Estado "insuficiente" (decisão 4)
+
+- Janela `< 20` mesmo após esgotar histórico → retornar `null`.
+- Em `evaluateGates`, `complianceRate100 === null` cai em `met: null`, `reason: 'METRIC_UNAVAILABLE'` (vide `evaluateGates.js`):
+  - **Não promove**: gate fica pendente, `gatesMet < gatesTotal` → `proposeStageTransition` não emite UP.
+  - **Não rebaixa**: `detectRegressionSignal` não consome este campo (verificado).
+  - DEC-020 preservada (stage não regride abaixo de baseline).
+
+### Fórmula
+
+Sobre os trades da janela final:
+
+```
+withFlags = trades.filter(t => t.hasRedFlags || (t.redFlags?.length > 0)).length
+compliant = trades.length - withFlags
+rate = (compliant / trades.length) * 100      // 0–100
+```
+
+Idêntica ao `calcComplianceRate` atual; o que muda é exclusivamente a **janela** sobre a qual se calcula.
+
+### Threshold (decisão 5)
+
+`>= 100` (gate compliance-100). Inalterado.
+
+### Casos limites
+
+- `trades` vazio → `null`.
+- `plans` vazio → `null` (sem ciclo definível).
+- Plano sem `adjustmentCycle` → default `'Mensal'`.
+- Trade com `date` inválido → ignorado silenciosamente.
+- Múltiplos planos com ciclos sobrepostos → união (trade contado uma vez por id).
+- Plano arquivado/encerrado: tratado como qualquer outro plano (ciclo derivado das datas, não do status).
+
+### Exemplo numérico (cenário B da memória aprovada)
+
+Trader com 1 plano `Mensal`, `now = 2026-04-24`. Ciclo ativo: `2026-04-01..2026-04-30`. Trades CLOSED em abril: 12 (3 com `hasRedFlags`).
+
+- Janela inicial: 12 trades. `< 20` → retroceder.
+- Ciclo anterior: `2026-03-01..2026-03-31`. Trades em março: 18 (1 com flag).
+- União: 30 trades, 4 com flag.
+- `compliant = 26`; `rate = 26/30 * 100 = 86.67`.
+- Gate `>= 100`: **não promove** (86.67 < 100). Estado: avaliado, abaixo do alvo.
+
+### Cenários de teste (A–E)
+
+- **A — Janela inicial suficiente, 100% aderente**: 1 plano `Mensal`, ciclo ativo com 25 trades, 0 com flag → `rate = 100` (gate met).
+- **B — Janela inicial < 20, fallback completa**: como exemplo numérico acima → `rate = 86.67` (gate não met).
+- **C — Histórico esgotado < 20**: 1 plano `Mensal`, total 8 trades em todo o histórico → `null` (gate pendente).
+- **D — Múltiplos planos, ciclo ativo cobre 20**: 2 planos `Mensal`, união do ciclo atual = 22 trades, 1 com flag → `rate = 95.45`.
+- **E — Trader sem trades no ciclo atual, último ciclo encerrado cobre**: 1 plano `Mensal`, ciclo atual vazio, ciclo anterior 24 trades, 0 flags → `rate = 100`.
+
+## Phases
+
+- F1 — Helper puro `computeCycleBasedComplianceRate` em `functions/maturity/` (CommonJS) e mirror em `src/utils/maturityEngine/` (ESM)
+- F2 — Wire em `preComputeShapes.js` (functions): substituir alias linha 126 + receber `now`
+- F3 — Repassar `now` em `recomputeMaturity.js`
+- F4 — Testes unitários A–E em ambos os mirrors + smoke de `evaluateGates` consumindo `null`
+- F5 — Bump 1.44.0 → 1.44.1 + entrada `CHANGELOG.md`
+
+## Sessions
+
+_(preenchido durante execução — 1 linha por task)_
+
+## Shared Deltas
+
+- `src/version.js` — bump 1.44.0 → 1.44.1
+- `docs/registry/versions.md` — marcar 1.44.1 consumida (no encerramento §4.3)
+- `docs/registry/chunks.md` — liberar CHUNK-09 (no encerramento §4.3)
+- `CHANGELOG.md` — nova entrada `[1.44.1] - 24/04/2026`
+- `docs/PROJECT.md` — bump versão (no encerramento §4.3)
+
+## Decisions
+
+- DEC-AUTO-191-01 — Janela = união de ciclos ativos por plano + fallback retroativo simultâneo
+- DEC-AUTO-191-02 — Estado insuficiente = `null` (mapeia para `METRIC_UNAVAILABLE` no gate)
+
+## Chunks
+
+- CHUNK-09 (escrita) — alteração do motor de maturidade (preComputeShapes + helper novo)

--- a/functions/maturity/computeCycleBasedComplianceRate.js
+++ b/functions/maturity/computeCycleBasedComplianceRate.js
@@ -1,0 +1,195 @@
+// ============================================
+// MATURITY ENGINE — computeCycleBasedComplianceRate (issue #191)
+// ============================================
+//
+// Aderência (compliance) avaliada sobre a janela de ciclos ativos do trader,
+// união de todos os planos. Substitui o alias antigo `complianceRate100 =
+// complianceRate` que reusava a janela total do histórico.
+//
+// Decisões aprovadas (DEC-AUTO-191-01 / -02):
+//   - Janela = união dos ciclos que contêm `now` em cada plano.
+//   - Mínimo 20 trades CLOSED. Se < 20, retroceder simultaneamente 1 ciclo em
+//     CADA plano e reunir; repetir até atingir 20 ou esgotar histórico.
+//   - Esgotamento = iteração que não acrescenta nenhum trade novo. Cap defensivo
+//     `MAX_LOOKBACK_CYCLES = 36`.
+//   - `< 20` mesmo após esgotar → retorna `null` (mapeia para METRIC_UNAVAILABLE
+//     no evaluateGates: gate fica pendente — não promove e não rebaixa).
+//
+// Mirror: src/utils/maturityEngine/computeCycleBasedComplianceRate.js (ESM).
+
+const MAX_LOOKBACK_CYCLES = 36;
+const DEFAULT_MIN_TRADES = 20;
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+function parseTradeDate(value) {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return value;
+  }
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const iso = ISO_DATE_RE.exec(value);
+  if (iso) {
+    const d = new Date(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3]));
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  const br = BR_DATE_RE.exec(value);
+  if (br) {
+    const d = new Date(Number(br[3]), Number(br[2]) - 1, Number(br[1]));
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  const fallback = new Date(value);
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
+}
+
+function getCycleStart(adjustmentCycle, date) {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  switch (adjustmentCycle) {
+    case 'Trimestral':
+      return new Date(y, Math.floor(m / 3) * 3, 1, 0, 0, 0, 0);
+    case 'Semestral':
+    case 'Semanal':
+      return new Date(y, m < 6 ? 0 : 6, 1, 0, 0, 0, 0);
+    case 'Anual':
+      return new Date(y, 0, 1, 0, 0, 0, 0);
+    case 'Mensal':
+    default:
+      return new Date(y, m, 1, 0, 0, 0, 0);
+  }
+}
+
+function getCycleEnd(adjustmentCycle, date) {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  switch (adjustmentCycle) {
+    case 'Trimestral': {
+      const qEndMonth = Math.floor(m / 3) * 3 + 2;
+      return new Date(y, qEndMonth + 1, 0, 23, 59, 59, 999);
+    }
+    case 'Semestral':
+    case 'Semanal':
+      return new Date(y, m < 6 ? 5 : 11, m < 6 ? 30 : 31, 23, 59, 59, 999);
+    case 'Anual':
+      return new Date(y, 11, 31, 23, 59, 59, 999);
+    case 'Mensal':
+    default:
+      return new Date(y, m + 1, 0, 23, 59, 59, 999);
+  }
+}
+
+function previousCycleRefDate(cycleStart) {
+  // Um milissegundo antes do início é último instante do ciclo anterior.
+  return new Date(cycleStart.getTime() - 1);
+}
+
+function isInRange(date, start, end) {
+  const t = date.getTime();
+  return t >= start.getTime() && t <= end.getTime();
+}
+
+function rangesContain(ranges, date) {
+  for (const r of ranges) {
+    if (isInRange(date, r.start, r.end)) return true;
+  }
+  return false;
+}
+
+function complianceFromTrades(trades) {
+  if (trades.length === 0) return null;
+  const withFlags = trades.filter(
+    (t) => t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0),
+  ).length;
+  const compliant = trades.length - withFlags;
+  return (compliant / trades.length) * 100;
+}
+
+/**
+ * Calcula a aderência (compliance) sobre a janela de ciclos ativos do trader.
+ *
+ * @param {{
+ *   trades: Array<{ id?: string, date: string|Date, hasRedFlags?: boolean, redFlags?: Array<unknown> }>,
+ *   plans: Array<{ id?: string, adjustmentCycle?: 'Mensal'|'Trimestral'|'Semestral'|'Anual' }>,
+ *   now: Date|string|number,
+ *   minTrades?: number,
+ * }} input
+ * @returns {number|null} 0-100 ou null quando histórico < minTrades.
+ */
+function computeCycleBasedComplianceRate({ trades, plans, now, minTrades = DEFAULT_MIN_TRADES } = {}) {
+  const safeTrades = Array.isArray(trades) ? trades : [];
+  const safePlans = Array.isArray(plans) ? plans : [];
+  if (safeTrades.length === 0 || safePlans.length === 0) return null;
+
+  const ref = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(ref.getTime())) return null;
+
+  // Pré-parse trade dates uma vez.
+  const parsedTrades = safeTrades
+    .map((t) => ({ trade: t, date: parseTradeDate(t.date) }))
+    .filter((p) => p.date !== null);
+  if (parsedTrades.length === 0) return null;
+
+  // Estado de retrocesso por plano: refDate começa em `now` (ciclo ativo).
+  const planStates = safePlans.map((p) => ({
+    adjustmentCycle: p.adjustmentCycle || 'Mensal',
+    refDate: ref,
+  }));
+
+  const ranges = [];
+  const seenIds = new Set();
+  const collected = [];
+  let prevSize = 0;
+
+  for (let iter = 0; iter <= MAX_LOOKBACK_CYCLES; iter += 1) {
+    // Adiciona o ciclo corrente de cada plano à união.
+    for (const state of planStates) {
+      const start = getCycleStart(state.adjustmentCycle, state.refDate);
+      const end = getCycleEnd(state.adjustmentCycle, state.refDate);
+      ranges.push({ start, end });
+    }
+
+    // Recoleta TODOS os trades dentro da nova união (ranges acumulados).
+    collected.length = 0;
+    seenIds.clear();
+    for (const p of parsedTrades) {
+      if (!rangesContain(ranges, p.date)) continue;
+      const key = p.trade.id != null ? String(p.trade.id) : `__idx_${collected.length}`;
+      if (seenIds.has(key)) continue;
+      seenIds.add(key);
+      collected.push(p.trade);
+    }
+
+    if (collected.length >= minTrades) {
+      return complianceFromTrades(collected);
+    }
+
+    // Esgotamento: iteração não acrescentou trade nenhum.
+    if (iter > 0 && collected.length === prevSize) {
+      return null;
+    }
+    prevSize = collected.length;
+
+    // Retrocede UM ciclo em cada plano para a próxima iteração.
+    for (const state of planStates) {
+      const currentStart = getCycleStart(state.adjustmentCycle, state.refDate);
+      state.refDate = previousCycleRefDate(currentStart);
+    }
+  }
+
+  // Cap atingido sem reunir minTrades → insuficiente.
+  return collected.length >= minTrades ? complianceFromTrades(collected) : null;
+}
+
+module.exports = {
+  computeCycleBasedComplianceRate,
+  // Exports auxiliares só para testes (não estáveis publicamente).
+  __internals: {
+    parseTradeDate,
+    getCycleStart,
+    getCycleEnd,
+    previousCycleRefDate,
+    MAX_LOOKBACK_CYCLES,
+    DEFAULT_MIN_TRADES,
+  },
+};

--- a/functions/maturity/preComputeShapes.js
+++ b/functions/maturity/preComputeShapes.js
@@ -19,7 +19,13 @@
 //   emotionalAnalysis (CHUNK-06 emotionalAnalysisV2.calculatePeriodScore) — neutro 50
 //   evLeakage         (depende de plans com pl/riskPerOperation/rrTarget) — null
 //   advancedMetricsPresent — false (depende de MFE/MAE tracking)
-//   complianceRate100 — null (variante de calculateComplianceRate sobre últimos 100)
+//
+// Issue #191: complianceRate100 agora usa janela de ciclos ativos do trader
+// (computeCycleBasedComplianceRate). Quando a janela é insuficiente (<20 trades
+// mesmo após esgotar histórico), retorna null → evaluateGates marca o gate
+// compliance-100 como METRIC_UNAVAILABLE (pendente, não promove e não rebaixa).
+
+const { computeCycleBasedComplianceRate } = require('./computeCycleBasedComplianceRate');
 
 function isNum(v) {
   return typeof v === 'number' && Number.isFinite(v);
@@ -107,11 +113,11 @@ function calcComplianceRate(trades) {
   return (compliant / trades.length) * 100;
 }
 
-function preComputeShapes({ trades, plans }) {
-  void plans;
+function preComputeShapes({ trades, plans, now } = {}) {
   const safeTrades = Array.isArray(trades) ? trades : [];
   const safePlans = Array.isArray(plans) ? plans : [];
   const initialBalance = safePlans[0]?.initialBalance ?? 0;
+  const refNow = now instanceof Date ? now : (now ? new Date(now) : new Date());
 
   const stats = calcStats(safeTrades);
   const payoff = calcPayoff(stats);
@@ -123,7 +129,11 @@ function preComputeShapes({ trades, plans }) {
   const emotionalAnalysis = { periodScore: 50, tiltCount: 0, revengeCount: 0 };
   const evLeakage = null;
   const advancedMetricsPresent = false;
-  const complianceRate100 = complianceRate;
+  const complianceRate100 = computeCycleBasedComplianceRate({
+    trades: safeTrades,
+    plans: safePlans,
+    now: refNow,
+  });
 
   return {
     stats,
@@ -145,4 +155,5 @@ module.exports = {
   calcMaxDrawdown,
   calcConsistencyCV,
   calcComplianceRate,
+  computeCycleBasedComplianceRate,
 };

--- a/functions/maturity/recomputeMaturity.js
+++ b/functions/maturity/recomputeMaturity.js
@@ -194,9 +194,9 @@ async function recomputeForStudent(db, studentId, { lastTradeId = null, admin: a
       .get();
     const plans = plansSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
 
-    const preComputed = preComputeShapes({ trades, plans });
-
     const now = new Date();
+    const preComputed = preComputeShapes({ trades, plans, now });
+
     const payloads = buildMaturityPayloads({
       trades,
       plans,

--- a/src/__tests__/functions/maturity/computeCycleBasedComplianceRate.test.js
+++ b/src/__tests__/functions/maturity/computeCycleBasedComplianceRate.test.js
@@ -1,0 +1,47 @@
+/**
+ * Issue #191 — paridade do mirror CommonJS (functions/) com o ESM (src/).
+ *
+ * Não duplica todos os cenários — só smoke A/B/C para confirmar que a cópia
+ * espelhada se comporta igual.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeCycleBasedComplianceRate as commonjsImpl } from '../../../../functions/maturity/computeCycleBasedComplianceRate';
+import { computeCycleBasedComplianceRate as esmImpl } from '../../../utils/maturityEngine/computeCycleBasedComplianceRate.js';
+
+const NOW = new Date(2026, 3, 24, 15, 0, 0);
+const PLAN = { id: 'p1', adjustmentCycle: 'Mensal' };
+
+function trades(count, prefix, date, flagsForFirstN = 0) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    date,
+    hasRedFlags: i < flagsForFirstN,
+  }));
+}
+
+describe('computeCycleBasedComplianceRate — paridade ESM ↔ CommonJS', () => {
+  it('A — ambos retornam 100 com 25 trades 0 flags', () => {
+    const input = { trades: trades(25, 'a', '2026-04-15', 0), plans: [PLAN], now: NOW };
+    expect(commonjsImpl(input)).toBe(esmImpl(input));
+  });
+
+  it('B — ambos retornam 86.67 com fallback de ciclo', () => {
+    const input = {
+      trades: [...trades(12, 'apr', '2026-04-10', 3), ...trades(18, 'mar', '2026-03-15', 1)],
+      plans: [PLAN],
+      now: NOW,
+    };
+    expect(commonjsImpl(input)).toBeCloseTo(esmImpl(input), 10);
+  });
+
+  it('C — ambos retornam null com histórico esgotado < 20', () => {
+    const input = {
+      trades: trades(8, 'few', '2026-04-15', 0),
+      plans: [PLAN],
+      now: NOW,
+    };
+    expect(commonjsImpl(input)).toBeNull();
+    expect(esmImpl(input)).toBeNull();
+  });
+});

--- a/src/__tests__/utils/maturityEngine/computeCycleBasedComplianceRate.test.js
+++ b/src/__tests__/utils/maturityEngine/computeCycleBasedComplianceRate.test.js
@@ -1,0 +1,222 @@
+/**
+ * Issue #191 — computeCycleBasedComplianceRate (ESM mirror)
+ *
+ * Cenários A-E da memória de cálculo aprovada + casos limites.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeCycleBasedComplianceRate } from '../../../utils/maturityEngine/computeCycleBasedComplianceRate.js';
+
+const NOW = new Date(2026, 3, 24, 15, 0, 0); // 2026-04-24 15:00 local
+const PLAN_M = { id: 'p1', adjustmentCycle: 'Mensal' };
+const PLAN_M2 = { id: 'p2', adjustmentCycle: 'Mensal' };
+const PLAN_T = { id: 'pT', adjustmentCycle: 'Trimestral' };
+
+function makeTrades(count, prefix, date, flagsForFirstN = 0) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    date,
+    hasRedFlags: i < flagsForFirstN,
+  }));
+}
+
+describe('computeCycleBasedComplianceRate — cenários da memória', () => {
+  it('A — janela inicial suficiente, 100% aderente → 100', () => {
+    const trades = makeTrades(25, 'a', '2026-04-15', 0);
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+
+  it('B — janela inicial < 20, fallback completa um ciclo → 86.67', () => {
+    const apr = makeTrades(12, 'apr', '2026-04-10', 3); // 12 trades, 3 flags
+    const mar = makeTrades(18, 'mar', '2026-03-15', 1); // 18 trades, 1 flag
+    const rate = computeCycleBasedComplianceRate({
+      trades: [...apr, ...mar],
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    // União 30 trades, 4 flags → 26/30 * 100 = 86.6666...
+    expect(rate).toBeCloseTo((26 / 30) * 100, 6);
+  });
+
+  it('C — histórico esgotado < 20 → null', () => {
+    const trades = [
+      ...makeTrades(3, 'apr', '2026-04-15', 0),
+      ...makeTrades(2, 'mar', '2026-03-15', 0),
+      ...makeTrades(3, 'feb', '2026-02-15', 0),
+    ];
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBeNull();
+  });
+
+  it('D — múltiplos planos, ciclo ativo cobre 20 → 95.45', () => {
+    // Ciclo Mensal de p1 = abril, ciclo de p2 também abril (mesmo adjustmentCycle).
+    // União de ranges com mesmo intervalo dedup por trade.id.
+    const trades = makeTrades(22, 'mix', '2026-04-12', 1); // 22 trades, 1 flag
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M, PLAN_M2],
+      now: NOW,
+    });
+    expect(rate).toBeCloseTo((21 / 22) * 100, 6);
+  });
+
+  it('E — trader sem trades no ciclo atual, último encerrado cobre → 100', () => {
+    const trades = makeTrades(24, 'mar', '2026-03-15', 0); // só março, 0 flags
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+});
+
+describe('computeCycleBasedComplianceRate — invariantes', () => {
+  it('retorna null quando trades é vazio', () => {
+    expect(computeCycleBasedComplianceRate({ trades: [], plans: [PLAN_M], now: NOW })).toBeNull();
+  });
+
+  it('retorna null quando plans é vazio', () => {
+    const trades = makeTrades(25, 'x', '2026-04-15', 0);
+    expect(computeCycleBasedComplianceRate({ trades, plans: [], now: NOW })).toBeNull();
+  });
+
+  it('retorna null quando now é inválido', () => {
+    const trades = makeTrades(25, 'x', '2026-04-15', 0);
+    expect(
+      computeCycleBasedComplianceRate({ trades, plans: [PLAN_M], now: new Date('not-a-date') }),
+    ).toBeNull();
+  });
+
+  it('ignora trades com date inválido sem quebrar', () => {
+    const trades = [
+      ...makeTrades(20, 'ok', '2026-04-10', 0),
+      { id: 'bad-1', date: 'lixo' },
+      { id: 'bad-2', date: null },
+      { id: 'bad-3', date: undefined },
+    ];
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBe(100); // 20 ok, 0 flags
+  });
+
+  it('aceita trade.date em formato BR (DD/MM/YYYY)', () => {
+    const trades = Array.from({ length: 20 }, (_, i) => ({
+      id: `br-${i}`,
+      date: '15/04/2026',
+      hasRedFlags: false,
+    }));
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+
+  it('aceita trade.date como Date', () => {
+    const trades = Array.from({ length: 20 }, (_, i) => ({
+      id: `dt-${i}`,
+      date: new Date(2026, 3, 15, 10),
+      hasRedFlags: false,
+    }));
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+
+  it('redFlags array é equivalente a hasRedFlags=true', () => {
+    const trades = [
+      ...Array.from({ length: 19 }, (_, i) => ({
+        id: `ok-${i}`,
+        date: '2026-04-15',
+      })),
+      { id: 'rf', date: '2026-04-15', redFlags: ['x'] },
+    ];
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBeCloseTo((19 / 20) * 100, 6);
+  });
+
+  it('trades duplicados por id são contados uma vez (planos sobrepostos)', () => {
+    const shared = makeTrades(22, 'shared', '2026-04-12', 0);
+    const rate = computeCycleBasedComplianceRate({
+      trades: shared,
+      plans: [PLAN_M, PLAN_M2, { id: 'p3', adjustmentCycle: 'Mensal' }],
+      now: NOW,
+    });
+    expect(rate).toBe(100); // 22 trades únicos, não 66
+  });
+
+  it('plano Trimestral agrupa janela em quarter', () => {
+    // Q2 2026 = abril+maio+junho. Ciclo ativo do plano Trimestral cobre Q2.
+    // 25 trades em maio, 0 flags.
+    const trades = Array.from({ length: 25 }, (_, i) => ({
+      id: `q-${i}`,
+      date: '2026-05-10',
+      hasRedFlags: false,
+    }));
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_T],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+
+  it('respeita parâmetro minTrades customizado', () => {
+    const trades = makeTrades(5, 'few', '2026-04-15', 1);
+    // minTrades=4 deve aceitar e calcular
+    expect(
+      computeCycleBasedComplianceRate({ trades, plans: [PLAN_M], now: NOW, minTrades: 4 }),
+    ).toBeCloseTo((4 / 5) * 100, 6);
+    // minTrades=10 deve recusar
+    expect(
+      computeCycleBasedComplianceRate({ trades, plans: [PLAN_M], now: NOW, minTrades: 10 }),
+    ).toBeNull();
+  });
+
+  it('plano sem adjustmentCycle defaults para Mensal', () => {
+    const trades = makeTrades(20, 'd', '2026-04-15', 0);
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [{ id: 'no-cfg' }],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+
+  it('histórico longo: retrocede múltiplos ciclos até atingir mínimo', () => {
+    // 5 trades por mês, em abril/março/fevereiro/janeiro = 20 trades, 0 flags
+    const trades = [
+      ...makeTrades(5, 'apr', '2026-04-10', 0),
+      ...makeTrades(5, 'mar', '2026-03-10', 0),
+      ...makeTrades(5, 'feb', '2026-02-10', 0),
+      ...makeTrades(5, 'jan', '2026-01-10', 0),
+    ];
+    const rate = computeCycleBasedComplianceRate({
+      trades,
+      plans: [PLAN_M],
+      now: NOW,
+    });
+    expect(rate).toBe(100);
+  });
+});

--- a/src/utils/maturityEngine/computeCycleBasedComplianceRate.js
+++ b/src/utils/maturityEngine/computeCycleBasedComplianceRate.js
@@ -1,0 +1,174 @@
+/**
+ * src/utils/maturityEngine/computeCycleBasedComplianceRate.js
+ *
+ * Mirror ESM de functions/maturity/computeCycleBasedComplianceRate.js (issue #191).
+ * Comportamento idêntico — manter sincronizado.
+ *
+ * Aderência avaliada sobre a janela de ciclos ativos do trader, união de todos
+ * os planos. Mínimo 20 trades CLOSED; fallback retroativo simultâneo até atingir
+ * o mínimo ou esgotar histórico. Estado insuficiente → null (METRIC_UNAVAILABLE
+ * no evaluateGates: gate pendente, não promove e não rebaixa).
+ */
+
+const MAX_LOOKBACK_CYCLES = 36;
+const DEFAULT_MIN_TRADES = 20;
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+function parseTradeDate(value) {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null;
+    return value;
+  }
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const iso = ISO_DATE_RE.exec(value);
+  if (iso) {
+    const d = new Date(Number(iso[1]), Number(iso[2]) - 1, Number(iso[3]));
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  const br = BR_DATE_RE.exec(value);
+  if (br) {
+    const d = new Date(Number(br[3]), Number(br[2]) - 1, Number(br[1]));
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  const fallback = new Date(value);
+  return Number.isNaN(fallback.getTime()) ? null : fallback;
+}
+
+function getCycleStart(adjustmentCycle, date) {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  switch (adjustmentCycle) {
+    case 'Trimestral':
+      return new Date(y, Math.floor(m / 3) * 3, 1, 0, 0, 0, 0);
+    case 'Semestral':
+    case 'Semanal':
+      return new Date(y, m < 6 ? 0 : 6, 1, 0, 0, 0, 0);
+    case 'Anual':
+      return new Date(y, 0, 1, 0, 0, 0, 0);
+    case 'Mensal':
+    default:
+      return new Date(y, m, 1, 0, 0, 0, 0);
+  }
+}
+
+function getCycleEnd(adjustmentCycle, date) {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  switch (adjustmentCycle) {
+    case 'Trimestral': {
+      const qEndMonth = Math.floor(m / 3) * 3 + 2;
+      return new Date(y, qEndMonth + 1, 0, 23, 59, 59, 999);
+    }
+    case 'Semestral':
+    case 'Semanal':
+      return new Date(y, m < 6 ? 5 : 11, m < 6 ? 30 : 31, 23, 59, 59, 999);
+    case 'Anual':
+      return new Date(y, 11, 31, 23, 59, 59, 999);
+    case 'Mensal':
+    default:
+      return new Date(y, m + 1, 0, 23, 59, 59, 999);
+  }
+}
+
+function previousCycleRefDate(cycleStart) {
+  return new Date(cycleStart.getTime() - 1);
+}
+
+function isInRange(date, start, end) {
+  const t = date.getTime();
+  return t >= start.getTime() && t <= end.getTime();
+}
+
+function rangesContain(ranges, date) {
+  for (const r of ranges) {
+    if (isInRange(date, r.start, r.end)) return true;
+  }
+  return false;
+}
+
+function complianceFromTrades(trades) {
+  if (trades.length === 0) return null;
+  const withFlags = trades.filter(
+    (t) => t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0),
+  ).length;
+  const compliant = trades.length - withFlags;
+  return (compliant / trades.length) * 100;
+}
+
+/**
+ * @param {{
+ *   trades: Array<{ id?: string, date: string|Date, hasRedFlags?: boolean, redFlags?: Array<unknown> }>,
+ *   plans: Array<{ id?: string, adjustmentCycle?: 'Mensal'|'Trimestral'|'Semestral'|'Anual' }>,
+ *   now: Date|string|number,
+ *   minTrades?: number,
+ * }} input
+ * @returns {number|null}
+ */
+export function computeCycleBasedComplianceRate({ trades, plans, now, minTrades = DEFAULT_MIN_TRADES } = {}) {
+  const safeTrades = Array.isArray(trades) ? trades : [];
+  const safePlans = Array.isArray(plans) ? plans : [];
+  if (safeTrades.length === 0 || safePlans.length === 0) return null;
+
+  const ref = now instanceof Date ? now : new Date(now);
+  if (Number.isNaN(ref.getTime())) return null;
+
+  const parsedTrades = safeTrades
+    .map((t) => ({ trade: t, date: parseTradeDate(t.date) }))
+    .filter((p) => p.date !== null);
+  if (parsedTrades.length === 0) return null;
+
+  const planStates = safePlans.map((p) => ({
+    adjustmentCycle: p.adjustmentCycle || 'Mensal',
+    refDate: ref,
+  }));
+
+  const ranges = [];
+  const seenIds = new Set();
+  const collected = [];
+  let prevSize = 0;
+
+  for (let iter = 0; iter <= MAX_LOOKBACK_CYCLES; iter += 1) {
+    for (const state of planStates) {
+      const start = getCycleStart(state.adjustmentCycle, state.refDate);
+      const end = getCycleEnd(state.adjustmentCycle, state.refDate);
+      ranges.push({ start, end });
+    }
+
+    collected.length = 0;
+    seenIds.clear();
+    for (const p of parsedTrades) {
+      if (!rangesContain(ranges, p.date)) continue;
+      const key = p.trade.id != null ? String(p.trade.id) : `__idx_${collected.length}`;
+      if (seenIds.has(key)) continue;
+      seenIds.add(key);
+      collected.push(p.trade);
+    }
+
+    if (collected.length >= minTrades) {
+      return complianceFromTrades(collected);
+    }
+
+    if (iter > 0 && collected.length === prevSize) {
+      return null;
+    }
+    prevSize = collected.length;
+
+    for (const state of planStates) {
+      const currentStart = getCycleStart(state.adjustmentCycle, state.refDate);
+      state.refDate = previousCycleRefDate(currentStart);
+    }
+  }
+
+  return collected.length >= minTrades ? complianceFromTrades(collected) : null;
+}
+
+export const __internals = {
+  parseTradeDate,
+  getCycleStart,
+  getCycleEnd,
+  previousCycleRefDate,
+  MAX_LOOKBACK_CYCLES,
+  DEFAULT_MIN_TRADES,
+};

--- a/src/version.js
+++ b/src/version.js
@@ -6,6 +6,21 @@
  * - 1.45.0: feat: FeedbackPage mentor edit+lock+recalc + MentorDashboard currency multi-moeda +
  *   PlanSummaryCard + StudentDashboard cards respeitam ContextBar sem exceção (issue #188, Sev1) —
  *   [RESERVADA — entrada definitiva no encerramento.]
+ * - 1.44.1: fix: Aderência recente (últimos N trades) no gate compliance-100 do stage
+ *   Profissional (issue #191). Antes: `complianceRate100 = complianceRate` (alias do
+ *   cálculo da janela total — semanticamente errado). Agora: novo helper puro
+ *   `computeCycleBasedComplianceRate({trades, plans, now, minTrades=20})` aplica a
+ *   janela = união dos ciclos ativos do trader (todos os planos pelo `adjustmentCycle`
+ *   Mensal/Trimestral/Semestral/Anual). Mínimo 20 trades fechados; se não atinge,
+ *   retrocede simultaneamente 1 ciclo em cada plano até bater 20 ou esgotar histórico
+ *   (cap defensivo `MAX_LOOKBACK_CYCLES=36` ou iteração que não acrescenta nada).
+ *   Insuficiente (`<20` mesmo após esgotar) → retorna `null` → `evaluateGates` marca o
+ *   gate como `METRIC_UNAVAILABLE` (pendente, não promove e não rebaixa — DEC-020
+ *   preservada). Mirror espelhado em `functions/maturity/` (CommonJS) e
+ *   `src/utils/maturityEngine/` (ESM); `preComputeShapes.js` agora aceita `now` e
+ *   `recomputeMaturity.js` repassa. 20 testes novos cobrindo cenários A-E + invariantes
+ *   (datas BR/ISO/Date, dedup por id em planos sobrepostos, defaults, trimestral,
+ *   minTrades customizável). DEC-AUTO-191-01/-02. Suite: 2421/2421 passando.
  * - 1.43.1: fix: Plano criado por mentor não é visível pelo aluno (issue #183, Sev1) —
  *   `usePlans.addPlan` hardcodava `studentId: user.uid` mesmo quando o criador era
  *   o mentor atuando em nome do aluno. Plano ficava gravado com UID do mentor e o
@@ -157,10 +172,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.44.0',
+  version: '1.44.1',
   build: '20260424',
-  display: 'v1.44.0',
-  full: '1.44.0+20260424',
+  display: 'v1.44.1',
+  full: '1.44.1+20260424',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
Closes #191

## Problema

`complianceRate100` (gate da transição Metódico → Profissional) era apenas alias de `complianceRate` em `functions/maturity/preComputeShapes.js:126` — ou seja, o cálculo da janela total do histórico era reusado. Resultado: traders com violações antigas mas excelentes recentes podiam ser reprovados; traders com bom histórico mas violações recentes podiam ser aprovados. Furo de **semântica**, não de coleta.

## Solução

Novo helper puro `computeCycleBasedComplianceRate({ trades, plans, now, minTrades=20 })` em `functions/maturity/` (CommonJS) com mirror espelhado em `src/utils/maturityEngine/` (ESM). Aplica:

- **Janela** = união dos ranges `[cycleStart, cycleEnd]` do ciclo que contém `now` em **cada plano** (derivação por `adjustmentCycle`: Mensal / Trimestral / Semestral / Anual).
- **Mínimo 20 trades CLOSED.** Se `< 20`, retrocede simultaneamente 1 ciclo em CADA plano e recoleta. Repete até atingir o mínimo ou esgotar histórico.
- **Esgotamento** = iteração que não acrescenta nenhum trade novo. Cap defensivo `MAX_LOOKBACK_CYCLES = 36`.
- **Insuficiente** (`< 20` mesmo após esgotar) → `null` → `evaluateGates` marca o gate como `METRIC_UNAVAILABLE` (pendente — **não promove e não rebaixa**, DEC-020 preservada).
- **Fórmula**: `(trades_sem_flag / total) * 100` sobre a janela final (idêntica ao `calcComplianceRate` atual; o que muda é exclusivamente a janela).

`preComputeShapes({trades, plans, now})` agora aceita `now` (default `new Date()`) e propaga para o novo helper. `recomputeMaturity.js` repassa o `now` que já calcula.

## Decisões aprovadas (capturadas em sessão de 24/04/2026)

1. Janela = ciclos ativos do trader, união de planos (maturidade é do trader, não de plano específico).
2. Mínimo 20 trades; estende para ciclo(s) anterior(es) se não bate.
3. Trader sem ciclo ativo → primeiro retrocesso já cobre o último encerrado.
4. Janela < 20 mesmo após esgotar → estado "insuficiente", retorna `null` (mapeia para `METRIC_UNAVAILABLE` no gate).
5. Threshold do gate continua **`>= 100`** (definição existente).
6. Mockup dispensado (issue simples sem UI).

## Decisions

- DEC-AUTO-191-01 — Janela = união de ciclos ativos por plano + fallback retroativo simultâneo.
- DEC-AUTO-191-02 — Estado insuficiente = `null` (METRIC_UNAVAILABLE no gate).

## Test plan

- [x] 17 testes ESM cobrindo cenários A-E da memória + invariantes (`src/__tests__/utils/maturityEngine/computeCycleBasedComplianceRate.test.js`)
- [x] 3 testes de paridade ESM ↔ CommonJS (`src/__tests__/functions/maturity/computeCycleBasedComplianceRate.test.js`)
- [x] Suite total: **2421 / 2421 verde** (144 arquivos)
- [x] `evaluateGates`/`evaluateMaturity`/`buildMaturityPayloads` continuam aceitando `complianceRate100` injetado (testes existentes não regridem)

## Files

- `functions/maturity/computeCycleBasedComplianceRate.js` — novo (CommonJS)
- `src/utils/maturityEngine/computeCycleBasedComplianceRate.js` — mirror ESM
- `functions/maturity/preComputeShapes.js` — aceita `now`, consome novo helper (substitui alias linha 126)
- `functions/maturity/recomputeMaturity.js` — repassa `now`
- `src/__tests__/utils/maturityEngine/computeCycleBasedComplianceRate.test.js` — 17 testes
- `src/__tests__/functions/maturity/computeCycleBasedComplianceRate.test.js` — 3 testes de paridade
- `docs/dev/issues/issue-191-compliance-ciclo.md` — doc de controle (briefing + memória + decisions)
- `src/version.js` + `CHANGELOG.md` — bump 1.44.0 → 1.44.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)