### PR TITLE
docs(protocols): regra de uma via — sem pushback após trigger autônomo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,10 @@ CHUNK-01 Auth · CHUNK-02 Student · CHUNK-03 Plans · CHUNK-04 Trade Ledger · 
 ## Modo Autônomo vs Interativo
 
 **Default:** interativo (pair programming assíncrono).
-**Trigger autônomo (opt-in):** Marcio diz literalmente **"atacar #NNN em modo autônomo"**. Qualquer outro fraseamento → interativo. Na dúvida, perguntar.
+**Trigger autônomo (opt-in):** Marcio diz literalmente **"atacar #NNN em modo autônomo"** (ou variante explícita "em modo autônomo"). Qualquer outro fraseamento → interativo.
+
+**Regra de uma via — sem pushback após o trigger:** Se o trigger autônomo foi dito, a IA executa §13.8 Fase 1 imediatamente. NÃO pergunta "tem certeza", NÃO sugere interativo como alternativa, NÃO condiciona a uma "pré-avaliação" do issue, NÃO lista riscos pra induzir reconsideração. Único impedimento aceitável é técnico (script faltando, env quebrado, repo em estado incompatível); neste caso reporta o impedimento concreto e PARA — não converte para interativo. Os critérios "quando usar autônomo/interativo" em §13.2 são guia para Marcio antes do trigger, não checklist da IA depois dele.
+
 Spec completa: [`docs/protocols/autonomous.md`](docs/protocols/autonomous.md).
 
 INV-27 + CLAIMS + validator aplicam-se aos DOIS modos quando há delegação sem supervisão ativa.
@@ -94,6 +97,14 @@ INV-27 + CLAIMS + validator aplicam-se aos DOIS modos quando há delegação sem
 ---
 
 ## Regra de ativação automática
+
+**Roteamento por trigger:**
+- Marcio diz **"atacar #NNN em modo autônomo"** (ou variante explícita) → executa imediatamente [`docs/protocols/autonomous.md`](docs/protocols/autonomous.md) §13.8 Fase 1 (que reusa os passos 1-9 abaixo nos seus próprios passos 3-6).
+- Qualquer outra menção a issue / feature / fix / debt / arquitetura → iniciar imediatamente o protocolo §4.0 abaixo.
+
+A regra de uma via (CLAUDE.md "Modo Autônomo vs Interativo") vale para os dois caminhos: trigger presente → autônomo, sem perguntar; trigger ausente → interativo, sem perguntar. A IA não tenta "validar" o trigger ou sugerir o caminho contrário.
+
+---
 
 Ao mencionar issue / feature / fix / debt / arquitetura, iniciar imediatamente o protocolo §4.0:
 

--- a/docs/protocols/autonomous.md
+++ b/docs/protocols/autonomous.md
@@ -17,9 +17,22 @@ Executar issues do projeto em modo autônomo: Marcio dispara "atacar #NNN em mod
 **O modo autônomo é opt-in explícito.** O modo **padrão do projeto continua sendo o modo interativo** (§4.0 — pair programming assíncrono com coder, bundle formal INV-19 descartado em v0.22.2).
 
 **Triggers:**
-- Marcio diz "atacar #NNN em modo autônomo" (ou variante "em modo autônomo") → Fase 1 desta seção
+- Marcio diz "atacar #NNN em modo autônomo" (ou variante "em modo autônomo") → Fase 1 desta seção, **execução imediata**
 - Qualquer outro fraseamento → modo interativo (§4.0)
-- Na dúvida, a sessão PERGUNTA. Autônomo nunca é assumido.
+- Trigger ausente → interativo. Trigger presente → autônomo. Não há terceira via "na dúvida".
+
+**Regra de uma via — sem pushback após o trigger.** Quando o trigger explícito foi dito, a IA NÃO pode:
+- (a) Sugerir interativo como alternativa
+- (b) Perguntar "tem certeza", "confirma?", "prefere mesmo?"
+- (c) Condicionar a uma "pré-avaliação" do issue (escopo, ambiguidade, complexidade)
+- (d) Listar riscos do autônomo pra induzir reconsideração
+- (e) Consultar os critérios abaixo para "validar" se autônomo é apropriado — esses critérios são guia para **Marcio** antes do trigger, não checklist da **IA** depois dele
+
+Único impedimento aceitável para não executar Fase 1: **impossibilidade técnica concreta** (script `cc-spawn-coord.sh`/`cc-dispatch-task.sh` ausente, `~/cc-mailbox/.env` sem `EMAIL_PASSWORD`, repo em estado de merge conflict, lock CHUNK indisponível). Neste caso a IA reporta o impedimento específico e **para — não converte para interativo**. Marcio decide se desbloqueia ou cancela.
+
+---
+
+**Guia de uso (para Marcio antes do trigger — não consultar pela IA após):**
 
 **Quando usar AUTÔNOMO:**
 - Issue bem desambiguado (spec claro, decisões estruturais já fechadas)
@@ -33,13 +46,15 @@ Executar issues do projeto em modo autônomo: Marcio dispara "atacar #NNN em mod
 - Feature pequena (1 commit, <30min)
 - Marcio disponível para pair em tempo real
 
-**Regra prática:** se a conversa precisa de deliberação livre entre Marcio e CC, é interativo. Se pode ser reduzida a "tasks pré-especificadas + gates humanos pontuais", é autônomo.
+**Heurística para Marcio:** se a conversa precisa de deliberação livre entre Marcio e CC, é interativo. Se pode ser reduzida a "tasks pré-especificadas + gates humanos pontuais", é autônomo. Após decidir e digitar o trigger, a IA executa — não re-deriva a decisão.
 
 ### 13.3 O Que É Universal (Aplica aos Dois Modos)
 
 INV-27 + bloco CLAIMS + `cc-validate-task.py` **não são exclusivos do modo autônomo**. Aplicam-se sempre que CC executa tasks sem supervisão humana ativa — inclui delegações durante modo interativo ("vai implementando isso enquanto eu faço outra coisa"). No interativo, o CC roda `cc-validate-task.py` contra o próprio commit antes de relatar "pronto"; se fail → para e sinaliza.
 
 Seção `§3.2 Decisões Autônomas` no control file do issue também é universal: registra qualquer decisão tomada pelo CC sem consulta explícita ao Marcio, independentemente do modo.
+
+**Esses controles compartilhados NÃO diluem a diferença entre os modos.** Validator + CLAIMS + DEC-AUTO existem nos dois lados como rede de segurança contra alucinação, mas o autônomo entrega coisas que o interativo não entrega: paralelismo coord/worker, gate humano por email, ausência sustentável do Marcio, custo zero quando idle. Não usar "o interativo já roda validator" como argumento para preferir interativo após o trigger autônomo (§13.2 regra de uma via).
 
 ### 13.4 Atores
 
@@ -98,7 +113,9 @@ Seção `§3.2 Decisões Autônomas` no control file do issue também é univers
                                      # READ-ONLY depois. Consumido pelo listener antes de `claude --resume`.
                                      # Mesma disciplina READ-ONLY da INV-26 (amendment v0.26.0).
                                      # Divergência main vs worktree → --resume falha silenciosa
-                                     # (JSONL em project-scope errado). Bug observado na rodada #164.
+                                     # (JSONL em project-scope errado). Bug observado na rodada #164,
+                                     # MITIGADO desde #176 v0.35.0: cc-spawn-coord.sh + cc-worktree-start.sh
+                                     # impõem cwd correto. Não justifica preferir interativo (§13.2).
 ```
 
 ### 13.8 Fluxo das 6 Fases
@@ -108,14 +125,14 @@ Seção `§3.2 Decisões Autônomas` no control file do issue também é univers
 | # | Ator | Ação |
 |---|------|------|
 | 1 | Marcio → CC-Interface | "Atacar issue #NNN em modo autônomo" |
-| 2 | CC-Interface | Confirma protocolo, ativa INV-27, avisa que RC só ativa depois |
+| 2 | CC-Interface | **Inicia execução §13.8 Fase 1 imediatamente** (sem perguntar "tem certeza" — §13.2 regra de uma via). Ativa INV-27, avisa que RC só ativa depois (informativo, não-bloqueante) |
 | 3 | CC-Interface | §4.0 NO MAIN: verifica versão PROJECT.md (INV-14), `gh issue view NNN`, valida chunks §6.3 |
 | 4 | CC-Interface | NO MAIN: registra locks + reserva próximo minor em `version.js` |
 | 5 | CC-Interface | Commit no main: `docs: registrar locks + reservar vX.Y.Z para issue-NNN` |
 | 6 | CC-Interface | `git worktree add ~/projects/issue-NNN -b tipo/issue-NNN-descricao` |
 | 7 | CC-Interface | `cd worktree`, cria `docs/dev/issues/issue-NNN-*.md`, preenche §1-3, §6 |
 | 8a | CC-Interface | Cria `.cc-mailbox/{inbox,outbox,coord-inbox,locks,notify-scratch,log}/` |
-| 8b | CC-Interface | **Pré-condição dura: cwd = `~/projects/issue-NNN`** (herdado do passo 7). Executar do main repo invalida o session_id — JSONL fica em project-scope `-acompanhamento-2-0`, listener do worktree invocando `--resume` falha silenciosa por project-scope mismatch. Comando: `claude --permission-mode auto --output-format json -p "<contexto>; confirme ready e morra"` → captura `coord_session_id` do JSON. Bug observado na rodada #164 (v0.26.0). |
+| 8b | CC-Interface | **Pré-condição dura: cwd = `~/projects/issue-NNN`** (herdado do passo 7). Executar do main repo invalida o session_id — JSONL fica em project-scope `-acompanhamento-2-0`, listener do worktree invocando `--resume` falha silenciosa por project-scope mismatch. Comando recomendado: `cc-spawn-coord.sh NNN <worktree> <control_file>` (#176 v0.35.0) — wrapper que impõe cwd, renderiza template, captura `COORD_SESSION_ID`. Equivalente manual: `claude --permission-mode auto --output-format json -p "<contexto>; confirme ready e morra"` → captura `coord_session_id` do JSON. Bug observado na rodada #164 está MITIGADO desde v0.35.0 — não é justificativa pra preferir interativo (§13.2 regra de uma via). |
 | 8c | CC-Interface | `cc-worktree-start.sh NNN <path> <coord_session_id>` → cria tmux + grava `.coord-id` (INV-26) |
 | 8d | CC-Interface | `flock -w 30 locks/coord.lock claude --resume <coord-id> --permission-mode auto -p "DISPATCH_FIRST_TASK"` → coord despacha `inbox/01.md`, morre |
 
@@ -127,7 +144,7 @@ Seção `§3.2 Decisões Autônomas` no control file do issue também é univers
 | 10 | CC-Interface | Aplica INV-18 em bloco: cada ambiguidade = pergunta concreta com opções |
 | 11 | Marcio | Responde bloco completo |
 | 12 | CC-Interface | Registra em `§3.1 Decisões Antecipadas` do control file |
-| 13 | CC-Interface | Re-varre spec; se restar ambiguidade → volta ao 10 |
+| 13 | CC-Interface | Re-varre spec; se restar ambiguidade → volta ao 10. **Cap operacional: máximo 3 rodadas.** Após a 3ª rodada, ambiguidades remanescentes viram DEC-AUTO no §3.2 (Coord resolve no loop autônomo via ordem de prioridade spec → PROJECT.md → padrão → menor blast radius — passo 30) — não justificam adiar Fase 3. Inflar ambiguidades pra estender Fase 2 indefinidamente é violação de §13.2 regra de uma via |
 | 14 | CC-Interface | Decompõe issue em tasks usando spec desambiguada (regra: 1-5 commits, ~30-90min; micro-tasks merge na próxima — heurística, não regra dura) |
 | 15-16 | CC-Interface ↔ Marcio | Plano de fases apresentado e aprovado |
 
@@ -180,7 +197,7 @@ Seção `§3.2 Decisões Autônomas` no control file do issue também é univers
 
 > Você DEVE entregar, no `report.md`, bloco `## CLAIMS (machine-readable, do not edit)` em JSON com `commit_hash`, `tests{passed,failed,cmd}`, `files_touched`. Ausência → coord marca STOP-HALLUCINATION automaticamente.
 
-Sem essa cláusula explícita, o worker entrega em formato livre e o validator (`cc-validate-task.py` ou equivalente manual) não tem artefato parseável. Observado na rodada #164: worker E3 entregou sem CLAIMS por omissão da Interface ao compor o briefing — validação INV-27 ficou totalmente manual (`git cat-file -e` + `vitest run`), funcional mas frágil. Template de briefing canônico com cláusula CLAIMS deve ser parte de `~/cc-mailbox/templates/worker-briefing.md` (componente da issue formal futura dos scripts).
+Sem essa cláusula explícita, o worker entrega em formato livre e o validator (`cc-validate-task.py` ou equivalente manual) não tem artefato parseável. Observado na rodada #164: worker E3 entregou sem CLAIMS por omissão da Interface ao compor o briefing — validação INV-27 ficou totalmente manual (`git cat-file -e` + `vitest run`). **Mitigado desde #169 v0.30.0**: `~/cc-mailbox/templates/worker-briefing.md` impõe a cláusula CLAIMS canônica e a Interface usa o template como base. Histórico citado para contexto, não como argumento de fragilidade pós-trigger (§13.2 regra de uma via).
 
 **Bloco CLAIMS obrigatório em todo `<N>-report.md` do worker:**
 
@@ -254,7 +271,7 @@ Exemplos:
 | `cc-dispatch-task.sh` | `~/cc-mailbox/bin/` | **IMPLEMENTADO** (#176, v0.35.0) — wrapper §13.8 passos 8d/36: lê `.coord-id`/`.coord-dir`, `flock -w 30 locks/coord.lock`, `cd $COORD_DIR`, `claude --resume --permission-mode auto -p "DISPATCH_FIRST_TASK\|DISPATCH_TASK slug=...\|HUMAN_GATE_RESOLVED ref=..."`. Smoke OK em issue-998. |
 | `~/cc-mailbox/.env` | `~/cc-mailbox/` | Setup manual (EMAIL_PASSWORD iCloud — senha reusada de `~/morning_call_auto/.env` via decisão operacional) |
 
-**Status do protocolo:** **OPERACIONAL END-TO-END** a partir de v0.35.0 (#176). **Validado com rodada real** em worktree sintético `issue-997` (23/04/2026 01:32-01:35 BRT, ~3min, EMAIL_DRY_RUN=0): `cc-spawn-coord.sh` → `COORD_SESSION_ID=f88e64e6-...` → `cc-worktree-start.sh` grava RO + lança listener → `cc-dispatch-task.sh FIRST` → Coord escreve briefing completo do worker em `inbox/01-criar-scratch-file.md` → listener polling pega em ~25s → worker headless `claude -p` executa (cria arquivo, commita `cae656b2`, escreve report com CLAIMS válido `{commit_hash, tests.skipped:true, files_touched}`) → listener faz `TASK_DELIVERED` via `flock + --resume` → Coord acorda, roda `cc-validate-task.py` (exit 0 OK), atualiza control file marcando `[x]` nos critérios (side-effect benéfico não-pedido) → Coord dispara email real `[Espelho #997] FINISHED: E2E dry-run §13 concluído — todas as tasks OK` via `cc-notify-email.py` → email chega no iCloud do Marcio → Coord morre. Loop inteiro sem intervenção humana. **Pendente apenas**: Recovery §13.15 re-testado pós-amendment v0.26.0 (a rodada original usou protocolo anterior).
+**Status do protocolo:** **OPERACIONAL END-TO-END** a partir de v0.35.0 (#176). **Validado com rodada real** em worktree sintético `issue-997` (23/04/2026 01:32-01:35 BRT, ~3min, EMAIL_DRY_RUN=0): `cc-spawn-coord.sh` → `COORD_SESSION_ID=f88e64e6-...` → `cc-worktree-start.sh` grava RO + lança listener → `cc-dispatch-task.sh FIRST` → Coord escreve briefing completo do worker em `inbox/01-criar-scratch-file.md` → listener polling pega em ~25s → worker headless `claude -p` executa (cria arquivo, commita `cae656b2`, escreve report com CLAIMS válido `{commit_hash, tests.skipped:true, files_touched}`) → listener faz `TASK_DELIVERED` via `flock + --resume` → Coord acorda, roda `cc-validate-task.py` (exit 0 OK), atualiza control file marcando `[x]` nos critérios (side-effect benéfico não-pedido) → Coord dispara email real `[Espelho #997] FINISHED: E2E dry-run §13 concluído — todas as tasks OK` via `cc-notify-email.py` → email chega no iCloud do Marcio → Coord morre. Loop inteiro sem intervenção humana. Fast-follow: re-validação do Recovery §13.15 pós-amendment v0.26.0 (não bloqueia execução de novos issues; o protocolo de Recovery está implementado e foi validado historicamente na rodada #164).
 
 **Fast-follows identificados nos dry-runs:**
 - `cc-notify-email.py` em `EMAIL_DRY_RUN=1` não escreve em per-worktree log (só no global); assimetria trivial de 3 linhas

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,5 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-04 | #187 | `feat/issue-187-mep-men` | 27/04/2026 | autônomo |
+| CHUNK-07 | #187 | `feat/issue-187-mep-men` | 27/04/2026 | autônomo |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -11,3 +11,4 @@
 | 1.46.0 | #189 | `feat/issue-189-emotional-engine-real` | 25/04/2026 | consumida (PR #196) |
 | 1.46.1 | #197 | `fix/issue-197-review-meeting-links-post-publish` | 25/04/2026 | consumida (PR #198 squash `af9662b0`) |
 | 1.47.0 | #201 | `refactor/issue-201-calculate-plan-mechanics` | 26/04/2026 | consumida (PR #202 squash `f5fbd87e`) |
+| 1.48.0 | #187 | `feat/issue-187-mep-men` | 27/04/2026 | reservada |

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,10 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.48.0: feat: coleta de MEP/MEN (Maximum Excursion Positiva/Negativa) — Form manual no Trade Entry +
+ *   parser ProfitPro (pts/% → preço) + loader Yahoo Finance 1m + CF enrichTradeWithExcursions
+ *   compute&discard (janela 7d) + integração engine maturidade Stage 3→4 não-bloqueante quando
+ *   `advancedMetricsPresent: false` (issue #187). [RESERVADA — entrada definitiva no encerramento.]
  * - 1.46.1: fix: salvar/atualizar link de reunião e gravação na revisão semanal pós-publicação
  *   (issue #197, PR #198 squash `af9662b0`). Mentor publicava revisão (CLOSED) e ficava preso:
  *   `meetingLink`/`videoLink` editáveis só em DRAFT — caminho real impossível porque link da


### PR DESCRIPTION
## Summary

Fecha 8 brechas no §13 (modo autônomo) e em CLAUDE.md que davam à IA margem para auto-preservação no estado interativo, mesmo após o trigger explícito de Marcio.

Sintoma reportado: depois de \"atacar #NNN em modo autônomo\", a IA continuava perguntando \"tem certeza\", sugerindo interativo, ou citando bugs históricos como justificativa pra não acionar §13.8 Fase 1.

## Brechas fechadas

| # | Local | Antes | Depois |
|---|-------|-------|--------|
| 1 | CLAUDE.md \"Modo Autônomo vs Interativo\" | \"Na dúvida, perguntar\" | Regra de Uma Via com 4 NÃO-PODE |
| 2 | autonomous.md §13.2 (Quando usar X/Y) | Bloco lido como checklist da IA | Relabel \"Guia para Marcio antes do trigger — não consultar pela IA após\" + 5 NÃO-PODE explícitos |
| 3 | autonomous.md §13.3 (universal) | \"Validator também no interativo\" → IA citava como argumento | Adicionado \"controles compartilhados NÃO diluem a diferença entre os modos\" |
| 4 | autonomous.md §13.7 (.coord-dir) | \"Bug observado na rodada #164\" sem mitigação | Nota \"MITIGADO desde #176 v0.35.0 — não justifica preferir interativo\" |
| 5 | autonomous.md §13.8 passo 2 | \"Confirma protocolo\" | \"Inicia execução §13.8 Fase 1 imediatamente (sem perguntar tem certeza)\" |
| 6 | autonomous.md §13.8 passo 8b | Comando manual + bug histórico | cc-spawn-coord.sh recomendado + nota de mitigação |
| 7 | autonomous.md §13.8 passo 13 | Loop de desambiguação sem teto | Cap operacional de 3 rodadas; remanescentes viram DEC-AUTO no §3.2 |
| 8 | autonomous.md §13.9 (CLAIMS history) | \"Funcional mas frágil\" | \"Mitigado desde #169 v0.30.0 com worker-briefing.md template\" |
| 9 | autonomous.md §13.11 (status) | \"**Pendente apenas**\" Recovery | \"Fast-follow: re-validação... não bloqueia execução\" |
| 10 | CLAUDE.md \"Regra de ativação automática\" | Só §4.0 — IA podia ignorar §13 mesmo com trigger | Roteamento por trigger explícito (autônomo → §13.8; default → §4.0) |

## Princípio consolidado

\"Trigger presente → autônomo. Trigger ausente → interativo. Não há terceira via.\"

Único impedimento aceitável pra não executar Fase 1 é **impossibilidade técnica concreta** (script faltando, env quebrado, repo em estado incompatível). Neste caso a IA reporta o impedimento específico e PARA — não converte para interativo.

## Test plan

- [ ] Próximo \"atacar #NNN em modo autônomo\" não dispara pergunta \"tem certeza\"
- [ ] IA não cita \"design em discovery\", \"feature pequena\", etc. como motivo pra ficar em interativo após trigger
- [ ] Loop de desambiguação respeita cap de 3 rodadas
- [ ] CLAUDE.md continua ≤ 200 linhas (atual: 170)
- [ ] autonomous.md ≤ 600 linhas read-cold (atual: 372)

🤖 Generated with [Claude Code](https://claude.com/claude-code)