### PR TITLE
fix(#212): cc-close-issue.sh corrompe registry/versions.md (delimitador sed)

### DIFF
--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -1,16 +1,16 @@
-# Registry — Versões Reservadas (write-hot) consumida (PR #209 squash `adb39591`) 
- consumida (PR #209 squash `adb39591`) 
-> Reservada na Abertura (§4.0 passo "reservar próximo minor"); consumida no Encerramento (§4.3 passo "finalizar entrada CHANGELOG"). consumida (PR #209 squash `adb39591`) 
- consumida (PR #209 squash `adb39591`) 
-| Versão | Issue | Branch | Data reserva | Status | consumida (PR #209 squash `adb39591`) 
-|--------|-------|--------|--------------|--------| consumida (PR #209 squash `adb39591`) 
-| 1.43.1 | #183 | `fix/issue-183-plan-studentid-override` | 24/04/2026 | consumida (PR #186 squash `e46f2051`) | consumida (PR #209 squash `adb39591`) 
-| 1.44.0 | #119 | `feat/issue-119-maturidade-engine` | 23/04/2026 (reservada como 1.43.0) | consumida como 1.44.0 (PR #192) — bump mecânico após #183 consumir 1.43.1 antes do merge | consumida (PR #209 squash `adb39591`) 
-| 1.45.0 | #188 | `fix/issue-188-feedback-lock-currency-context` | 24/04/2026 | consumida (PR #195 squash `a7b89c89`) | consumida (PR #209 squash `adb39591`) 
-| 1.44.1 | #191 | `fix/issue-191-compliance-recente-ciclo` | 24/04/2026 | consumida (PR #194 squash `eb4ff2ec`) | consumida (PR #209 squash `adb39591`) 
-| 1.46.0 | #189 | `feat/issue-189-emotional-engine-real` | 25/04/2026 | consumida (PR #196) | consumida (PR #209 squash `adb39591`) 
-| 1.46.1 | #197 | `fix/issue-197-review-meeting-links-post-publish` | 25/04/2026 | consumida (PR #198 squash `af9662b0`) | consumida (PR #209 squash `adb39591`) 
-| 1.47.0 | #201 | `refactor/issue-201-calculate-plan-mechanics` | 26/04/2026 | consumida (PR #202 squash `f5fbd87e`) | consumida (PR #209 squash `adb39591`) 
-| 1.48.0 | #187 | `feat/issue-187-mep-men` | 27/04/2026 | reservada | consumida (PR #209 squash `adb39591`) 
-| 1.49.0 | #208 | `feat/issue-208-execution-behavior-sensor` | 29/04/2026 | reservada | consumida (PR #209 squash `adb39591`) 
-| 1.49.1 | #210 | `chore/issue-210-remove-takeaways-legacy` | 30/04/2026 | reservada |
+# Registry — Versões Reservadas (write-hot)
+
+> Reservada na Abertura (§4.0 passo "reservar próximo minor"); consumida no Encerramento (§4.3 passo "finalizar entrada CHANGELOG").
+
+| Versão | Issue | Branch | Data reserva | Status |
+|--------|-------|--------|--------------|--------|
+| 1.43.1 | #183 | `fix/issue-183-plan-studentid-override` | 24/04/2026 | consumida (PR #186 squash `e46f2051`) |
+| 1.44.0 | #119 | `feat/issue-119-maturidade-engine` | 23/04/2026 (reservada como 1.43.0) | consumida como 1.44.0 (PR #192) — bump mecânico após #183 consumir 1.43.1 antes do merge |
+| 1.45.0 | #188 | `fix/issue-188-feedback-lock-currency-context` | 24/04/2026 | consumida (PR #195 squash `a7b89c89`) |
+| 1.44.1 | #191 | `fix/issue-191-compliance-recente-ciclo` | 24/04/2026 | consumida (PR #194 squash `eb4ff2ec`) |
+| 1.46.0 | #189 | `feat/issue-189-emotional-engine-real` | 25/04/2026 | consumida (PR #196) |
+| 1.46.1 | #197 | `fix/issue-197-review-meeting-links-post-publish` | 25/04/2026 | consumida (PR #198 squash `af9662b0`) |
+| 1.47.0 | #201 | `refactor/issue-201-calculate-plan-mechanics` | 26/04/2026 | consumida (PR #202 squash `f5fbd87e`) |
+| 1.48.0 | #187 | `feat/issue-187-mep-men` | 27/04/2026 | reservada |
+| 1.49.0 | #208 | `feat/issue-208-execution-behavior-sensor` | 29/04/2026 | consumida (PR #209 squash `adb39591`) |
+| 1.49.1 | #210 | `chore/issue-210-remove-takeaways-legacy` | 30/04/2026 | consumida (PR #211 squash `2f7a6a78`) |

--- a/scripts/cc-close-issue.sh
+++ b/scripts/cc-close-issue.sh
@@ -166,13 +166,16 @@ elif [ -n "$VER" ]; then
 fi
 
 # 3d. registry/versions.md — marcar consumida
+# Delimitador `~` evita conflito com `|` literal das colunas da tabela e com
+# `[^|]` no regex. Bug histórico (issue #212): usar `s|...|` com `[^|]` quebra
+# parser GNU sed — delimitador dentro da char class é tratado como fim do
+# pattern e o regex degenerado casa todas as linhas do arquivo.
 if [ -n "$VER" ]; then
-  REPLACE="| ${VER} | #${ISSUE} | "
   CONSUMED_NOTE="consumida (PR #${PR} squash \`${PR_SHA:0:8}\`)"
   if $DRY_RUN; then
     echo "  [dry-run] registry/versions.md ← marcar v${VER} como '${CONSUMED_NOTE}'"
   else
-    sed -i -E "s|^(\| ${VER} \| #${ISSUE} \| [^|]+ \| [^|]+ \|) [^|]+ \|$|\1 ${CONSUMED_NOTE} |" "$REPO/docs/registry/versions.md"
+    sed -i -E "s~^(\| ${VER} \| #${ISSUE} \| [^|]+ \| [^|]+ \|) [^|]+ \|\$~\1 ${CONSUMED_NOTE} |~" "$REPO/docs/registry/versions.md"
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Delimitador `|` do `sed -E "s|...[^|]+...|"` em `scripts/cc-close-issue.sh:175` colidia com `[^|]` no regex. GNU sed parser não trata delimitador como escapado dentro de char class — o `|` em `[^|]` terminava o pattern prematuramente, regex degenerado casava tudo, replacement virava append em cada linha. Bug aparecia silenciosamente desde #199 (introdução do script) mas só foi exposto no #208 (1º uso real; encerramentos anteriores foram manuais).
- Fix: delimitador `~` (improvável em markdown). `|` final do replacement adicionado (também perdido pelo bug).
- Cleanup: `docs/registry/versions.md` reescrito a partir do estado correto pré-#208 + entradas v1.49.0 (#208) e v1.49.1 (#210) marcadas como consumidas.

## Test plan

- [x] Reprodução do bug com input idêntico ao do #208 → confirma corrupção em todas as linhas
- [x] Sed corrigido aplicado no mesmo input → substituição cirúrgica, demais linhas intactas, `|` final preservado
- [x] versions.md reescrito reflete histórico real (10 versões consumidas + v1.48.0 reservada para #187)
- [ ] `cc-close-issue.sh 210 --dry-run` em main pós-merge mostra apenas linha v1.49.1 sendo modificada

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #212