### PR TITLE
fix(#216): cc-close-issue.sh — alerta CF deploy manual

### DIFF
--- a/scripts/cc-close-issue.sh
+++ b/scripts/cc-close-issue.sh
@@ -314,6 +314,23 @@ else
   echo "  [skip] nenhuma branch local issue-${ISSUE}-*"
 fi
 
+# ---------- 9. Alerta CF deploy ----------
+# Cloud Functions deploya manualmente (`firebase deploy --only functions`).
+# Se o squash commit do PR tocou `functions/`, imprime alerta no fim do output
+# pra evitar que CF mergeada fique fora de prod por esquecimento. Não bloqueia
+# (deploy é fora do flow). Issue histórico: #211/#210 mergeou mudança em
+# `functions/reviews/createWeeklyReview.js` sem deploy — por sorte benigna.
+if [ -n "$PR_SHA" ]; then
+  CF_FILES=$(git show --name-only --format= "$PR_SHA" 2>/dev/null | grep -E "^functions/" || true)
+  if [ -n "$CF_FILES" ]; then
+    echo
+    echo "⚠️  [ALERTA] PR #${PR} tocou Cloud Functions — deploy manual necessário:"
+    echo "$CF_FILES" | sed 's/^/    /'
+    echo
+    echo "    Comando:  firebase deploy --only functions"
+  fi
+fi
+
 echo
 echo "Encerramento #${ISSUE} ${VER:+v${VER}} completo."
 $DRY_RUN && echo "(dry-run — nada foi modificado)"


### PR DESCRIPTION
## Summary

CF no Firebase deploya manualmente (`firebase deploy --only functions`). Script de encerramento não alerta quando o PR mergeado tocou `functions/`. PR #211 (issue #210) mergeou mudança em `createWeeklyReview.js` sem deploy — benigna, mas se fosse funcional teria virado bug silencioso em prod.

## Changes

`scripts/cc-close-issue.sh`:
- Novo bloco "9. Alerta CF deploy" após [8/8]
- Detector via `git show --name-only --format= "$PR_SHA" | grep ^functions/`
- Se non-empty → imprime lista de arquivos + comando exato `firebase deploy --only functions`
- Não bloqueia (deploy é manual, fora do flow)

## Test plan

- [x] `bash -n` passa
- [x] PR #211 histórico (sha 2f7a6a78, tocou CF) → detector retorna `functions/reviews/createWeeklyReview.js`
- [x] PR #215 histórico (sha 61c65002, só script) → detector silencioso
- [ ] Encerramento real do próprio #216 (sem CF) → sem alerta — valida path negativo no flow live

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)