### PR TITLE
feat(#221): mentor limpa violações com toggle (compliance + emocional)

### DIFF
--- a/docs/dev/issues/issue-221-mentor-clear-violations.md
+++ b/docs/dev/issues/issue-221-mentor-clear-violations.md
@@ -1,0 +1,84 @@
+# Issue #221 — feat: Mentor limpa violações (compliance + emocional) — Phase B de #218
+
+## Autorização
+
+- [x] Spec aprovada como parte do plano #218 (mockup + memória de cálculo)
+- [x] INV-15: campo Firestore novo `mentorClearedViolations` aprovado por Marcio (DEC-AUTO-218 — "se eu mudei, é lei dentro de v1")
+- [x] Marcio autorizou: "encerrar e seguir" (01/05/2026, após merge #220)
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Compliance e detecções emocionais hoje são determinísticas. STOP de R$ 1.005 num RO de R$ 1.000 (0,5% acima) é flagrado. Mentor entende contexto, sistema não. Bandas automáticas rejeitadas. Solução: mentor toggle = lei dentro de v1. Sem audit metadata (sem reason, sem timestamp).
+
+Aluno read-only — vê chip "limpo pelo mentor" mas não toca.
+
+## Spec
+
+Ver issue body no GitHub: #221.
+
+## Memória de Cálculo
+
+```
+isViolationCleared(trade, key) = (trade.mentorClearedViolations || []).includes(key)
+
+effectiveRedFlags(trade) =
+  (trade.redFlags || []).filter(f => !isViolationCleared(trade, f.type))
+
+effectiveEmotionalEvents(trade) =
+  (trade.emotionalEvents || []).filter(e => !isViolationCleared(trade, getEventKey(e)))
+
+getEventKey(event) = `${event.type}:${event.timestamp}`
+```
+
+**Exemplo numérico**: trade T1 com redFlags=[{type:'NO_STOP'}, {type:'RR_BELOW_MINIMUM'}] e mentorClearedViolations=['NO_STOP'] →
+- effectiveRedFlags(T1) = [{type:'RR_BELOW_MINIMUM'}]
+- complianceRate em 10 trades, T1 com 1 violation cleared: antes (1 violador) 90% → após clear (0 violadores) 100%.
+
+**Reverter**: arrayRemove('NO_STOP') de mentorClearedViolations → effectiveRedFlags volta a 2 → complianceRate volta a 90%.
+
+## Schema (INV-15 aprovada)
+
+| Campo | Tipo | Default |
+|---|---|---|
+| `mentorClearedViolations` | `string[]` | `[]` (não setado = vazio) |
+
+Chaves possíveis:
+- Compliance: `NO_STOP`, `RR_BELOW_MINIMUM`, `RISK_EXCEEDED`, `DAILY_LOSS_EXCEEDED`, `BLOCKED_EMOTION`
+- Emocional: `${eventType}:${eventTimestamp}` (ex.: `TILT:2026-04-15T10:30:00Z`)
+
+## Phases
+
+- B1 — Helper puro `violationFilter.js` (ESM) + mirror CJS + 6 testes do helper
+- B2 — Gateway `toggleViolationClearedAsMentor` + 5 testes
+- B3 — Aplicar `effective*` nos 6 consumidores (hooks/utils + mirrors)
+- B4 — UI mentor: chip `✕ Limpar` em ExtractEvents + bloco "Limpas" em FeedbackPage + tooltip TradesList + badge ExtractTable
+- B5 — `firestore.rules` allowlist mentor-only para `mentorClearedViolations`
+- B6 — CF trigger `onTradeUpdated` detecta mudança no array → invoca pipeline `recomputeStudentMaturity`
+- B7 — Verificação smoke local + suite full
+
+## Sessions
+
+_(preenchido durante implementação)_
+
+## Shared Deltas
+
+- `src/version.js` — entrada 1.52.0 mantida (já reservada na abertura)
+- `docs/registry/versions.md` — marcar 1.52.0 consumida no encerramento
+- `docs/registry/chunks.md` — liberar CHUNK-04 + 05 + 06 + 08 no encerramento
+- `CHANGELOG.md` — nova entrada `[1.52.0] - 01/05/2026`
+- `docs/firestore-schema.md` — documentar `mentorClearedViolations` em trades/{id}
+
+## Decisions
+
+- DEC-AUTO-221-01: chave compliance = código; chave emocional = `${type}:${timestamp}`
+- DEC-AUTO-221-02: sem audit metadata (sem reason/clearedAt/clearedBy) — refactor trivial pra `Array<{key,reason?}>` se necessário no futuro
+- DEC-AUTO-221-03: detectores (detectTilt/detectRevenge) NÃO re-rodam sobre sequência ajustada — agregação filtra eventos cleared via EVENT_PENALTIES, mas detectores leem sequência crua
+- DEC-AUTO-221-04: re-enrich (CSV/Order Import) preserva `mentorClearedViolations` (campo é do mentor, não do broker)
+
+## Chunks
+
+- CHUNK-04 (escrita) — Trade Ledger / gateway / hooks
+- CHUNK-05 (escrita) — Compliance / complianceRate
+- CHUNK-06 (escrita) — Emotional / emotionalAnalysisV2 + mirror
+- CHUNK-08 (escrita) — Mentor Feedback / FeedbackPage + ExtractEvents

--- a/firestore.rules
+++ b/firestore.rules
@@ -116,7 +116,9 @@ service cloud.firestore {
           '_mentorEdits', '_studentOriginal',
           // Issue #219 — classificação mentor (técnico/sorte). Aluno read-only.
           'mentorClassification', 'mentorClassificationFlags',
-          'mentorClassificationReason', 'mentorClassifiedAt', 'mentorClassifiedBy'
+          'mentorClassificationReason', 'mentorClassifiedAt', 'mentorClassifiedBy',
+          // Issue #221 — limpeza de violação (compliance + emocional). Aluno read-only.
+          'mentorClearedViolations'
         ])
       );
       allow delete: if isAuthenticated() && (

--- a/functions/index.js
+++ b/functions/index.js
@@ -1048,9 +1048,17 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
       const av = after[f] ?? null;
       return bv !== av;
     });
-    
+
+    // Issue #221 — detectar mudança em `mentorClearedViolations` (toggle do mentor).
+    // Quando muda, dispara recompute do aluno (paralelo a mudança de plano).
+    const fpClearedBefore = JSON.stringify((Array.isArray(before.mentorClearedViolations)
+      ? before.mentorClearedViolations : []).slice().sort());
+    const fpClearedAfter = JSON.stringify((Array.isArray(after.mentorClearedViolations)
+      ? after.mentorClearedViolations : []).slice().sort());
+    const clearedChanged = fpClearedBefore !== fpClearedAfter;
+
     // Guard: se apenas riskPercent/rrRatio/compliance/redFlags mudaram, é loop da própria CF
-    if (!resultChanged && !planChanged && !complianceChanged) {
+    if (!resultChanged && !planChanged && !complianceChanged && !clearedChanged) {
       return null;
     }
     
@@ -1142,6 +1150,21 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
         console.log(`[onTradeUpdated] Lock destravado por import (batch=${after.importBatchId})`);
       } catch (unlockErr) {
         console.error('[onTradeUpdated] Erro destrava por import:', unlockErr);
+      }
+    }
+
+    // === ISSUE #221 — RECOMPUTE MATURITY POR TOGGLE DE LIMPEZA ===
+    // Mentor adicionou/removeu chave em mentorClearedViolations → dispara
+    // recompute do aluno (paralelo a mudança de plano). Pipeline igual a de
+    // plan-change: agregadores filtram via mentorClearedViolations, snapshot
+    // student/{uid}/maturity/current refletirá novo estado quando concluir.
+    if (clearedChanged && after.studentId) {
+      try {
+        const { recomputeForStudent } = require('./maturity/recomputeMaturity');
+        await recomputeForStudent(db, after.studentId, { admin });
+        console.log(`[onTradeUpdated] Maturity recomputado por toggle de cleared (student=${after.studentId}, before=${fpClearedBefore}, after=${fpClearedAfter})`);
+      } catch (recomputeErr) {
+        console.error('[onTradeUpdated] Erro recompute maturity (cleared toggle):', recomputeErr);
       }
     }
 

--- a/functions/maturity/computeCycleBasedComplianceRate.js
+++ b/functions/maturity/computeCycleBasedComplianceRate.js
@@ -1,6 +1,12 @@
 // ============================================
-// MATURITY ENGINE — computeCycleBasedComplianceRate (issue #191)
+// MATURITY ENGINE — computeCycleBasedComplianceRate (issue #191; #221: cleared)
 // ============================================
+//
+// Issue #221: respeita `mentorClearedViolations` — trade com TODAS as red flags
+// limpas pelo mentor é tratado como compliant. Mirror ESM em
+// src/utils/maturityEngine/computeCycleBasedComplianceRate.js.
+
+const { hasEffectiveRedFlags } = require('./violationFilter');
 //
 // Aderência (compliance) avaliada sobre a janela de ciclos ativos do trader,
 // união de todos os planos. Substitui o alias antigo `complianceRate100 =
@@ -98,9 +104,7 @@ function rangesContain(ranges, date) {
 
 function complianceFromTrades(trades) {
   if (trades.length === 0) return null;
-  const withFlags = trades.filter(
-    (t) => t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0),
-  ).length;
+  const withFlags = trades.filter((t) => hasEffectiveRedFlags(t)).length;
   const compliant = trades.length - withFlags;
   return (compliant / trades.length) * 100;
 }

--- a/functions/maturity/emotionalAnalysisMirror.js
+++ b/functions/maturity/emotionalAnalysisMirror.js
@@ -3,6 +3,10 @@
 // ============================================
 //
 // Mirror determinístico de `src/utils/emotionalAnalysisV2.js` (ESM) — issue #189.
+// Issue #221: respeita `mentorClearedViolations` no calculatePeriodScore via
+// effectiveEmotionalEventsForPeriod do violationFilter mirror.
+
+const { effectiveEmotionalEventsForPeriod } = require('./violationFilter');
 // Substitui o stub `{ periodScore: 50, tiltCount: 0, revengeCount: 0 }` em
 // `preComputeShapes.js:129` (DEC-AUTO-119-task07-02 declarado como TODO).
 //
@@ -188,7 +192,10 @@ function calculatePeriodScore(trades, getEmotionConfig, complianceEvents = []) {
   // Normaliza de [-4, +3.5] para [0, 100] (paridade com ESM linha 206)
   const normalized = Math.round(((rawAverage + 4) / 7.5) * 100);
 
-  const penalties = (Array.isArray(complianceEvents) ? complianceEvents : []).reduce(
+  // Issue #221: filtra eventos cleared pelo mentor (mentorClearedViolations).
+  const safeEvents = Array.isArray(complianceEvents) ? complianceEvents : [];
+  const effectiveEvents = effectiveEmotionalEventsForPeriod(trades, safeEvents);
+  const penalties = effectiveEvents.reduce(
     (sum, event) => sum + (EVENT_PENALTIES[event.type] || 0),
     0,
   );

--- a/functions/maturity/violationFilter.js
+++ b/functions/maturity/violationFilter.js
@@ -1,0 +1,83 @@
+/**
+ * functions/maturity/violationFilter.js
+ * @description Mirror CJS de `src/utils/violationFilter.js`. Issue #221 (Phase B).
+ *   Paridade obrigatória ESM↔CJS — pattern `emotionalAnalysisMirror.js`.
+ *   Toda mudança no .js precisa ser refletida aqui.
+ */
+
+function getEventKey(event, tradeId) {
+  if (!event || !event.type || !tradeId) return '';
+  return event.type + ':' + tradeId;
+}
+
+function isViolationCleared(trade, key) {
+  if (!trade || !key) return false;
+  const cleared = Array.isArray(trade.mentorClearedViolations)
+    ? trade.mentorClearedViolations
+    : [];
+  return cleared.indexOf(key) !== -1;
+}
+
+function effectiveRedFlags(trade) {
+  if (!trade) return [];
+  const flags = Array.isArray(trade.redFlags) ? trade.redFlags : [];
+  const cleared = Array.isArray(trade.mentorClearedViolations)
+    ? trade.mentorClearedViolations
+    : [];
+  if (cleared.length === 0) return flags;
+  return flags.filter(function (f) { return f && cleared.indexOf(f.type) === -1; });
+}
+
+function hasEffectiveRedFlags(trade) {
+  if (!trade) return false;
+  if (Array.isArray(trade.redFlags) && trade.redFlags.length > 0) {
+    return effectiveRedFlags(trade).length > 0;
+  }
+  return trade.hasRedFlags === true;
+}
+
+function effectiveEmotionalEventsForTrade(trade, events) {
+  if (!trade || !Array.isArray(events) || events.length === 0) return [];
+  const cleared = Array.isArray(trade.mentorClearedViolations)
+    ? trade.mentorClearedViolations
+    : [];
+  return events.filter(function (evt) {
+    if (!evt || !evt.type) return false;
+    const ids = Array.isArray(evt.tradeIds) ? evt.tradeIds : [];
+    if (ids.indexOf(trade.id) === -1) return false;
+    return cleared.indexOf(getEventKey(evt, trade.id)) === -1;
+  });
+}
+
+function effectiveEmotionalEventsForPeriod(trades, events) {
+  if (!Array.isArray(events) || events.length === 0) return [];
+  const safeTrades = Array.isArray(trades) ? trades : [];
+  const tradeMap = new Map();
+  for (const t of safeTrades) {
+    if (t && t.id) tradeMap.set(t.id, t);
+  }
+
+  return events.filter(function (evt) {
+    if (!evt || !evt.type) return false;
+    const ids = Array.isArray(evt.tradeIds) ? evt.tradeIds : [];
+    if (ids.length === 0) return true;
+
+    return ids.some(function (tid) {
+      const trade = tradeMap.get(tid);
+      if (!trade) return true;
+      const cleared = Array.isArray(trade.mentorClearedViolations)
+        ? trade.mentorClearedViolations
+        : [];
+      return cleared.indexOf(getEventKey(evt, tid)) === -1;
+    });
+  });
+}
+
+module.exports = {
+  getEventKey,
+  isViolationCleared,
+  effectiveRedFlags,
+  hasEffectiveRedFlags,
+  effectiveEmotionalEventsForTrade,
+  effectiveEmotionalEventsForPeriod,
+};

--- a/src/__tests__/functions/maturity/violationFilterMirror.test.js
+++ b/src/__tests__/functions/maturity/violationFilterMirror.test.js
@@ -1,0 +1,50 @@
+/**
+ * violationFilterMirror.test.js — paridade ESM↔CJS para issue #221.
+ * Verifica que o mirror CJS produz exatamente os mesmos resultados do ESM.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  effectiveRedFlags as esmEffectiveRedFlags,
+  effectiveEmotionalEventsForPeriod as esmEffectiveEmotionalEventsForPeriod,
+  getEventKey as esmGetEventKey,
+} from '../../../utils/violationFilter';
+
+const cjs = require('../../../../functions/maturity/violationFilter');
+
+describe('violationFilter — paridade ESM↔CJS', () => {
+  it('effectiveRedFlags: mesma saída para mesma entrada', () => {
+    const trade = {
+      redFlags: [{ type: 'NO_STOP' }, { type: 'RR_BELOW_MINIMUM' }],
+      mentorClearedViolations: ['NO_STOP'],
+    };
+    expect(cjs.effectiveRedFlags(trade)).toEqual(esmEffectiveRedFlags(trade));
+  });
+
+  it('effectiveEmotionalEventsForPeriod: exclui quando TODOS limparam', () => {
+    const trades = [
+      { id: 'T1', mentorClearedViolations: ['REVENGE:T1'] },
+      { id: 'T2', mentorClearedViolations: ['REVENGE:T2'] },
+    ];
+    const events = [{ type: 'REVENGE', tradeIds: ['T1', 'T2'] }];
+    expect(cjs.effectiveEmotionalEventsForPeriod(trades, events))
+      .toEqual(esmEffectiveEmotionalEventsForPeriod(trades, events));
+  });
+
+  it('effectiveEmotionalEventsForPeriod: mantém quando algum não limpou', () => {
+    const trades = [
+      { id: 'T1', mentorClearedViolations: ['REVENGE:T1'] },
+      { id: 'T2' },
+    ];
+    const events = [{ type: 'REVENGE', tradeIds: ['T1', 'T2'] }];
+    expect(cjs.effectiveEmotionalEventsForPeriod(trades, events))
+      .toEqual(esmEffectiveEmotionalEventsForPeriod(trades, events));
+  });
+
+  it('getEventKey: formato idêntico', () => {
+    expect(cjs.getEventKey({ type: 'TILT' }, 'T1'))
+      .toBe(esmGetEventKey({ type: 'TILT' }, 'T1'));
+    expect(cjs.getEventKey(null, 'T1'))
+      .toBe(esmGetEventKey(null, 'T1'));
+  });
+});

--- a/src/__tests__/utils/tradeGatewayToggleViolation.test.js
+++ b/src/__tests__/utils/tradeGatewayToggleViolation.test.js
@@ -1,0 +1,145 @@
+/**
+ * tradeGatewayToggleViolation.test.js — issue #221 (Phase B).
+ * Cobre toggleViolationClearedAsMentor.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../firebase', () => ({ db: {} }));
+vi.mock('firebase/firestore', () => {
+  const arrayUnion = vi.fn((...args) => ({ __arrayUnion: args }));
+  const arrayRemove = vi.fn((...args) => ({ __arrayRemove: args }));
+  const serverTimestamp = vi.fn(() => ({ __serverTimestamp: true }));
+  return {
+    collection: vi.fn(),
+    query: vi.fn(),
+    where: vi.fn(),
+    addDoc: vi.fn(),
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    doc: vi.fn(),
+    serverTimestamp,
+    updateDoc: vi.fn(),
+    arrayUnion,
+    arrayRemove,
+  };
+});
+
+import { toggleViolationClearedAsMentor } from '../../utils/tradeGateway';
+
+const mockMentor = { uid: 'mentor-1', email: 'm@x.com', isMentor: true };
+const mockStudent = { uid: 'student-1', email: 's@x.com', isMentor: false };
+
+const makeDeps = (tradeData) => {
+  const updates = [];
+  return {
+    deps: {
+      getDocFn: vi.fn(async () => ({
+        exists: () => !!tradeData,
+        data: () => tradeData,
+      })),
+      updateDocFn: vi.fn(async (_ref, patch) => {
+        updates.push(patch);
+      }),
+      docFn: vi.fn((_db, _col, id) => ({ __ref: id })),
+    },
+    updates,
+  };
+};
+
+describe('toggleViolationClearedAsMentor — autenticação e validação', () => {
+  it('rejeita sem userContext', async () => {
+    await expect(
+      toggleViolationClearedAsMentor('t1', 'NO_STOP', null)
+    ).rejects.toThrow(/autenticado/);
+  });
+
+  it('rejeita aluno (não-mentor)', async () => {
+    await expect(
+      toggleViolationClearedAsMentor('t1', 'NO_STOP', mockStudent)
+    ).rejects.toThrow(/mentor/i);
+  });
+
+  it('rejeita tradeId vazio', async () => {
+    await expect(
+      toggleViolationClearedAsMentor('', 'NO_STOP', mockMentor)
+    ).rejects.toThrow(/tradeId/);
+  });
+
+  it('rejeita violationKey vazio', async () => {
+    await expect(
+      toggleViolationClearedAsMentor('t1', '', mockMentor)
+    ).rejects.toThrow(/violationKey/);
+  });
+
+  it('rejeita violationKey não-string', async () => {
+    await expect(
+      toggleViolationClearedAsMentor('t1', 123, mockMentor)
+    ).rejects.toThrow(/violationKey/);
+  });
+
+  it('rejeita trade inexistente', async () => {
+    const { deps } = makeDeps(null);
+    await expect(
+      toggleViolationClearedAsMentor('t-missing', 'NO_STOP', mockMentor, deps)
+    ).rejects.toThrow(/não encontrado/);
+  });
+});
+
+describe('toggleViolationClearedAsMentor — toggle behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adiciona quando violationKey ausente', async () => {
+    const { deps, updates } = makeDeps({ mentorClearedViolations: [] });
+    const out = await toggleViolationClearedAsMentor('t1', 'NO_STOP', mockMentor, deps);
+    expect(out).toEqual({ id: 't1', action: 'added', violationKey: 'NO_STOP' });
+    expect(updates).toHaveLength(1);
+    expect(updates[0].mentorClearedViolations).toEqual({ __arrayUnion: ['NO_STOP'] });
+  });
+
+  it('remove quando violationKey presente', async () => {
+    const { deps, updates } = makeDeps({ mentorClearedViolations: ['NO_STOP', 'TILT:T1'] });
+    const out = await toggleViolationClearedAsMentor('t1', 'NO_STOP', mockMentor, deps);
+    expect(out).toEqual({ id: 't1', action: 'removed', violationKey: 'NO_STOP' });
+    expect(updates[0].mentorClearedViolations).toEqual({ __arrayRemove: ['NO_STOP'] });
+  });
+
+  it('lida com mentorClearedViolations ausente (cria com union)', async () => {
+    const { deps, updates } = makeDeps({});
+    const out = await toggleViolationClearedAsMentor('t1', 'RR_BELOW_MINIMUM', mockMentor, deps);
+    expect(out.action).toBe('added');
+    expect(updates[0].mentorClearedViolations).toEqual({ __arrayUnion: ['RR_BELOW_MINIMUM'] });
+  });
+
+  it('grava updatedAt: serverTimestamp', async () => {
+    const { deps, updates } = makeDeps({ mentorClearedViolations: [] });
+    await toggleViolationClearedAsMentor('t1', 'NO_STOP', mockMentor, deps);
+    expect(updates[0].updatedAt).toEqual({ __serverTimestamp: true });
+  });
+
+  it('aceita chave emocional ${type}:${tradeId}', async () => {
+    const { deps, updates } = makeDeps({ mentorClearedViolations: [] });
+    const out = await toggleViolationClearedAsMentor('t1', 'TILT:t1', mockMentor, deps);
+    expect(out.action).toBe('added');
+    expect(updates[0].mentorClearedViolations).toEqual({ __arrayUnion: ['TILT:t1'] });
+  });
+
+  it('toggle idempotente — adicionar+remover repete', async () => {
+    // Primeiro toggle: add
+    const { deps: d1, updates: u1 } = makeDeps({ mentorClearedViolations: [] });
+    const r1 = await toggleViolationClearedAsMentor('t1', 'NO_STOP', mockMentor, d1);
+    expect(r1.action).toBe('added');
+
+    // Segundo toggle (estado simulado pós-add): remove
+    const { deps: d2, updates: u2 } = makeDeps({ mentorClearedViolations: ['NO_STOP'] });
+    const r2 = await toggleViolationClearedAsMentor('t1', 'NO_STOP', mockMentor, d2);
+    expect(r2.action).toBe('removed');
+
+    // Terceiro toggle (volta a vazio): add de novo
+    const { deps: d3, updates: u3 } = makeDeps({ mentorClearedViolations: [] });
+    const r3 = await toggleViolationClearedAsMentor('t1', 'NO_STOP', mockMentor, d3);
+    expect(r3.action).toBe('added');
+  });
+});

--- a/src/__tests__/utils/violationFilter.test.js
+++ b/src/__tests__/utils/violationFilter.test.js
@@ -1,0 +1,200 @@
+/**
+ * violationFilter.test.js — issue #221 (Phase B).
+ * Cobre helpers puros de filtro por mentorClearedViolations.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getEventKey,
+  isViolationCleared,
+  effectiveRedFlags,
+  hasEffectiveRedFlags,
+  effectiveEmotionalEventsForTrade,
+  effectiveEmotionalEventsForPeriod,
+} from '../../utils/violationFilter';
+
+describe('getEventKey', () => {
+  it('formata como "type:tradeId"', () => {
+    expect(getEventKey({ type: 'TILT' }, 'T1')).toBe('TILT:T1');
+  });
+
+  it('vazio para entradas inválidas', () => {
+    expect(getEventKey(null, 'T1')).toBe('');
+    expect(getEventKey({ type: 'TILT' }, null)).toBe('');
+    expect(getEventKey({}, 'T1')).toBe('');
+  });
+});
+
+describe('isViolationCleared', () => {
+  it('true quando key está em mentorClearedViolations', () => {
+    const trade = { mentorClearedViolations: ['NO_STOP', 'TILT:T1'] };
+    expect(isViolationCleared(trade, 'NO_STOP')).toBe(true);
+    expect(isViolationCleared(trade, 'TILT:T1')).toBe(true);
+  });
+
+  it('false quando array ausente, vazio, ou key não bate', () => {
+    expect(isViolationCleared({}, 'NO_STOP')).toBe(false);
+    expect(isViolationCleared({ mentorClearedViolations: [] }, 'NO_STOP')).toBe(false);
+    expect(isViolationCleared({ mentorClearedViolations: ['RR_BELOW_MINIMUM'] }, 'NO_STOP')).toBe(false);
+  });
+
+  it('false para input inválido', () => {
+    expect(isViolationCleared(null, 'NO_STOP')).toBe(false);
+    expect(isViolationCleared({}, '')).toBe(false);
+  });
+});
+
+describe('effectiveRedFlags', () => {
+  it('retorna todas quando nada cleared', () => {
+    const trade = {
+      redFlags: [{ type: 'NO_STOP' }, { type: 'RR_BELOW_MINIMUM' }],
+    };
+    expect(effectiveRedFlags(trade)).toHaveLength(2);
+  });
+
+  it('filtra cleared pelo type', () => {
+    const trade = {
+      redFlags: [{ type: 'NO_STOP' }, { type: 'RR_BELOW_MINIMUM' }],
+      mentorClearedViolations: ['NO_STOP'],
+    };
+    const out = effectiveRedFlags(trade);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('RR_BELOW_MINIMUM');
+  });
+
+  it('filtra ambos quando ambos cleared', () => {
+    const trade = {
+      redFlags: [{ type: 'NO_STOP' }, { type: 'RR_BELOW_MINIMUM' }],
+      mentorClearedViolations: ['NO_STOP', 'RR_BELOW_MINIMUM'],
+    };
+    expect(effectiveRedFlags(trade)).toEqual([]);
+  });
+
+  it('vazio quando trade ausente ou sem redFlags', () => {
+    expect(effectiveRedFlags(null)).toEqual([]);
+    expect(effectiveRedFlags({})).toEqual([]);
+  });
+
+  it('idempotente — múltiplas chamadas produzem mesmo resultado', () => {
+    const trade = {
+      redFlags: [{ type: 'NO_STOP' }],
+      mentorClearedViolations: ['NO_STOP'],
+    };
+    expect(effectiveRedFlags(trade)).toEqual(effectiveRedFlags(trade));
+  });
+});
+
+describe('hasEffectiveRedFlags', () => {
+  it('true quando há flag não cleared (redFlags array)', () => {
+    expect(hasEffectiveRedFlags({
+      redFlags: [{ type: 'NO_STOP' }],
+    })).toBe(true);
+  });
+
+  it('false quando todas cleared (redFlags array)', () => {
+    expect(hasEffectiveRedFlags({
+      redFlags: [{ type: 'NO_STOP' }],
+      mentorClearedViolations: ['NO_STOP'],
+    })).toBe(false);
+  });
+
+  it('false quando sem flags', () => {
+    expect(hasEffectiveRedFlags({ redFlags: [] })).toBe(false);
+    expect(hasEffectiveRedFlags({})).toBe(false);
+    expect(hasEffectiveRedFlags(null)).toBe(false);
+  });
+
+  it('true para hasRedFlags boolean legacy (sem redFlags array)', () => {
+    expect(hasEffectiveRedFlags({ hasRedFlags: true })).toBe(true);
+  });
+
+  it('false para hasRedFlags=false boolean legacy', () => {
+    expect(hasEffectiveRedFlags({ hasRedFlags: false })).toBe(false);
+  });
+});
+
+describe('effectiveEmotionalEventsForTrade', () => {
+  const T1 = 'trade-1';
+  const T2 = 'trade-2';
+
+  it('retorna eventos do trade quando nada cleared', () => {
+    const trade = { id: T1 };
+    const events = [
+      { type: 'TILT', tradeIds: [T1] },
+      { type: 'REVENGE', tradeIds: [T1, T2] },
+    ];
+    expect(effectiveEmotionalEventsForTrade(trade, events)).toHaveLength(2);
+  });
+
+  it('exclui apenas evento limpo no trade-alvo', () => {
+    const trade = { id: T1, mentorClearedViolations: [`TILT:${T1}`] };
+    const events = [
+      { type: 'TILT', tradeIds: [T1] },
+      { type: 'REVENGE', tradeIds: [T1, T2] },
+    ];
+    const out = effectiveEmotionalEventsForTrade(trade, events);
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('REVENGE');
+  });
+
+  it('ignora eventos cujo trade-alvo não está em tradeIds', () => {
+    const trade = { id: T1 };
+    const events = [{ type: 'TILT', tradeIds: [T2] }];
+    expect(effectiveEmotionalEventsForTrade(trade, events)).toEqual([]);
+  });
+
+  it('vazio para inputs inválidos', () => {
+    expect(effectiveEmotionalEventsForTrade(null, [])).toEqual([]);
+    expect(effectiveEmotionalEventsForTrade({ id: T1 }, null)).toEqual([]);
+  });
+});
+
+describe('effectiveEmotionalEventsForPeriod', () => {
+  const T1 = 'trade-1';
+  const T2 = 'trade-2';
+  const T3 = 'trade-3';
+
+  it('mantém todos quando nenhum trade limpou', () => {
+    const trades = [{ id: T1 }, { id: T2 }];
+    const events = [
+      { type: 'TILT', tradeIds: [T1] },
+      { type: 'REVENGE', tradeIds: [T1, T2] },
+    ];
+    expect(effectiveEmotionalEventsForPeriod(trades, events)).toHaveLength(2);
+  });
+
+  it('mantém evento se ALGUM trade vinculado ainda não limpou', () => {
+    const trades = [
+      { id: T1, mentorClearedViolations: [`REVENGE:${T1}`] },
+      { id: T2 }, // T2 não limpou
+    ];
+    const events = [{ type: 'REVENGE', tradeIds: [T1, T2] }];
+    // T1 limpou mas T2 não → evento ainda penaliza
+    expect(effectiveEmotionalEventsForPeriod(trades, events)).toHaveLength(1);
+  });
+
+  it('exclui evento quando TODOS os trades vinculados limparam', () => {
+    const trades = [
+      { id: T1, mentorClearedViolations: [`REVENGE:${T1}`] },
+      { id: T2, mentorClearedViolations: [`REVENGE:${T2}`] },
+    ];
+    const events = [{ type: 'REVENGE', tradeIds: [T1, T2] }];
+    expect(effectiveEmotionalEventsForPeriod(trades, events)).toEqual([]);
+  });
+
+  it('mantém evento legacy sem tradeIds (day-level)', () => {
+    const trades = [];
+    const events = [{ type: 'STATUS_CRITICAL', date: '2026-04-15' }];
+    expect(effectiveEmotionalEventsForPeriod(trades, events)).toHaveLength(1);
+  });
+
+  it('trade fora da janela é tratado como não-cleared (mantém evento)', () => {
+    const trades = [{ id: T1 }]; // T2 não está no array (fora da janela)
+    const events = [{ type: 'TILT', tradeIds: [T1, T2] }];
+    expect(effectiveEmotionalEventsForPeriod(trades, events)).toHaveLength(1);
+  });
+
+  it('vazio quando events vazios', () => {
+    expect(effectiveEmotionalEventsForPeriod([], [])).toEqual([]);
+  });
+});

--- a/src/hooks/useDashboardMetrics.js
+++ b/src/hooks/useDashboardMetrics.js
@@ -25,6 +25,7 @@ import {
   calculateConsistencyCV,
   calculateDurationDelta,
 } from '../utils/dashboardMetrics';
+import { hasEffectiveRedFlags } from '../utils/violationFilter';
 
 /** Labels de período por `periodRange.kind` (ContextBar — issue #118/#188). */
 const PERIOD_KIND_LABELS = {
@@ -190,9 +191,8 @@ const useDashboardMetrics = ({
 
   const complianceRate = useMemo(() => {
     if (filteredTrades.length === 0) return null;
-    const withFlags = filteredTrades.filter(t => 
-      t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0)
-    ).length;
+    // Issue #221 — respeita mentorClearedViolations via hasEffectiveRedFlags.
+    const withFlags = filteredTrades.filter(t => hasEffectiveRedFlags(t)).length;
     const compliant = filteredTrades.length - withFlags;
     return {
       rate: (compliant / filteredTrades.length) * 100,

--- a/src/hooks/useEmotionalProfile.js
+++ b/src/hooks/useEmotionalProfile.js
@@ -83,7 +83,8 @@ export const useEmotionalProfile = ({
     return calculateStudentStatus(
       analysis.periodScore.score,
       analysis.complianceEvents,
-      statusThresholds
+      statusThresholds,
+      analysis.trades || null  // issue #221 — passa trades para filtro de cleared
     );
   }, [analysis, statusThresholds]);
 

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -48,7 +48,8 @@ import useOrders from '../hooks/useOrders';
 import { useTrades } from '../hooks/useTrades';
 import { usePlans } from '../hooks/usePlans';
 import { useAccounts } from '../hooks/useAccounts';
-import { editTradeAsMentor as gatewayEditAsMentor, lockTradeByMentor as gatewayLockByMentor, classifyTradeAsMentor as gatewayClassify } from '../utils/tradeGateway';
+import { editTradeAsMentor as gatewayEditAsMentor, lockTradeByMentor as gatewayLockByMentor, classifyTradeAsMentor as gatewayClassify, toggleViolationClearedAsMentor as gatewayToggleViolation } from '../utils/tradeGateway';
+import { effectiveRedFlags, isViolationCleared } from '../utils/violationFilter';
 import PinToReviewButton from '../components/reviews/PinToReviewButton';
 
 // Helpers locais
@@ -241,24 +242,71 @@ const TradeInfoCard = ({ trade, onImageClick }) => {
         );
       })()}
 
-      {/* Red Flags — ou indicador de processamento se CF ainda não respondeu */}
+      {/* Red Flags — issue #221: efetivas (não cleared) + bloco "Limpas pelo mentor" */}
       {trade.compliance === undefined && trade.riskPercent === undefined ? (
         <div className="bg-slate-800/50 border border-slate-700/30 rounded-xl p-3 flex items-center gap-2">
           <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
           <span className="text-xs text-slate-400">Processando compliance...</span>
         </div>
       ) : trade.redFlags && Array.isArray(trade.redFlags) && trade.redFlags.length > 0 ? (
-        <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-3">
-          <div className="flex items-center gap-2 text-amber-400 mb-2">
-            <AlertTriangle className="w-4 h-4" />
-            <span className="text-xs font-bold uppercase tracking-wider">Violações ({trade.redFlags.length})</span>
-          </div>
-          <div className="space-y-1">
-            {trade.redFlags.map((flag, i) => (
-              <p key={i} className="text-xs text-amber-300/80">• {typeof flag === 'string' ? flag : flag.message || flag.rule || 'Violação'}</p>
-            ))}
-          </div>
-        </div>
+        (() => {
+          const effective = effectiveRedFlags(trade);
+          const cleared = (Array.isArray(trade.redFlags) ? trade.redFlags : [])
+            .filter(f => isViolationCleared(trade, f.type));
+          return (
+            <div className="space-y-2">
+              {effective.length > 0 && (
+                <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-3">
+                  <div className="flex items-center gap-2 text-amber-400 mb-2">
+                    <AlertTriangle className="w-4 h-4" />
+                    <span className="text-xs font-bold uppercase tracking-wider">Violações ({effective.length})</span>
+                  </div>
+                  <div className="space-y-1">
+                    {effective.map((flag, i) => (
+                      <div key={`eff-${i}`} className="flex items-center justify-between gap-2">
+                        <p className="text-xs text-amber-300/80 flex-1">• {typeof flag === 'string' ? flag : flag.message || flag.rule || 'Violação'}</p>
+                        {userIsMentor && flag.type && (
+                          <button
+                            type="button"
+                            onClick={() => handleToggleViolation(flag.type)}
+                            title="Limpar esta violação (toggle)"
+                            className="shrink-0 text-[10px] px-2 py-0.5 rounded border border-amber-500/30 text-amber-300 hover:bg-amber-500/10 hover:text-amber-200 transition-colors"
+                          >
+                            ✕ Limpar
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {cleared.length > 0 && (
+                <div className="bg-slate-800/30 border border-slate-700/30 rounded-xl p-3">
+                  <div className="flex items-center gap-2 text-slate-500 mb-2">
+                    <span className="text-xs font-bold uppercase tracking-wider">Limpas pelo mentor ({cleared.length})</span>
+                  </div>
+                  <div className="space-y-1">
+                    {cleared.map((flag, i) => (
+                      <div key={`cleared-${i}`} className="flex items-center justify-between gap-2">
+                        <p className="text-xs text-slate-500 line-through flex-1">• {typeof flag === 'string' ? flag : flag.message || flag.rule || 'Violação'}</p>
+                        {userIsMentor && flag.type && (
+                          <button
+                            type="button"
+                            onClick={() => handleToggleViolation(flag.type)}
+                            title="Restaurar — volta a contar como violação"
+                            className="shrink-0 text-[10px] px-2 py-0.5 rounded border border-slate-600/40 text-slate-400 hover:bg-slate-700/40 hover:text-slate-200 transition-colors"
+                          >
+                            ↺ Restaurar
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })()
       ) : null}
 
       {/* Parciais — exibe quando trade tem dados carregados */}
@@ -420,6 +468,12 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
   const handleClassify = async (input) => {
     if (!trade?.id) throw new Error('Trade sem id');
     await gatewayClassify(trade.id, input, mentorCtx);
+  };
+
+  // Issue #221 — toggle de "limpar violação" (compliance + emocional). Mentor toggle = lei.
+  const handleToggleViolation = async (violationKey) => {
+    if (!trade?.id) throw new Error('Trade sem id');
+    await gatewayToggleViolation(trade.id, violationKey, mentorCtx);
   };
 
   // === Image Paste State (mentor only) ===

--- a/src/utils/dashboardMetrics.js
+++ b/src/utils/dashboardMetrics.js
@@ -1,10 +1,12 @@
 /**
  * Dashboard Metrics — Cálculos puros
- * @version 1.0.0
- * 
+ * @version 1.1.0 (issue #221 — respeita mentorClearedViolations)
+ *
  * Lógica extraída de StudentDashboard.jsx para permitir testes unitários.
  * Funções que estavam inline em useMemo agora são importáveis e testáveis.
  */
+
+import { hasEffectiveRedFlags } from './violationFilter';
 
 /**
  * Calcula Max Drawdown peak-to-trough na série histórica de PL acumulado.
@@ -89,17 +91,18 @@ export const calculatePlannedWinRate = (trades, plans) => {
 /**
  * Calcula taxa de conformidade: % de trades sem red flags.
  * Semáforo: ≥80% verde, 60-80% amarelo, <60% vermelho.
- * 
- * @param {Array<{hasRedFlags?: boolean, redFlags?: Array}>} trades 
+ *
+ * Issue #221 — respeita `mentorClearedViolations`: trade com TODAS as red flags
+ * limpas pelo mentor é tratado como compliant.
+ *
+ * @param {Array<{hasRedFlags?: boolean, redFlags?: Array, mentorClearedViolations?: Array}>} trades
  * @returns {{ rate: number, compliant: number, total: number, violations: number }|null}
  */
 export const calculateComplianceRate = (trades) => {
   if (!trades || trades.length === 0) return null;
-  
-  const withFlags = trades.filter(t => 
-    t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0)
-  ).length;
-  
+
+  const withFlags = trades.filter(t => hasEffectiveRedFlags(t)).length;
+
   const compliant = trades.length - withFlags;
   return {
     rate: (compliant / trades.length) * 100,

--- a/src/utils/emotionalAnalysisV2.js
+++ b/src/utils/emotionalAnalysisV2.js
@@ -24,6 +24,8 @@
  * - V2 aceita trades com `emotionEntry` ou `emotion` (legado)
  */
 
+import { effectiveEmotionalEventsForPeriod } from './violationFilter';
+
 // ============================================
 // CONSTANTES E DEFAULTS
 // ============================================
@@ -216,8 +218,10 @@ export const calculatePeriodScore = (trades, getEmotionConfig, complianceEvents 
   // +3.5 = score máximo possível (3 + 0.5 bônus consistência)
   const normalized = Math.round(((rawAverage + 4) / 7.5) * 100);
 
-  // Penalidades por eventos
-  const penalties = complianceEvents.reduce((sum, event) => {
+  // Penalidades por eventos — issue #221: filtra eventos cleared pelo mentor
+  // (trade com `mentorClearedViolations` contendo `${type}:${tradeId}`).
+  const effectiveEvents = effectiveEmotionalEventsForPeriod(trades, complianceEvents);
+  const penalties = effectiveEvents.reduce((sum, event) => {
     return sum + (EVENT_PENALTIES[event.type] || 0);
   }, 0);
 
@@ -746,15 +750,19 @@ const getOverallEmotionalCategory = (trades, getEmotionConfig) => {
  * @param {Object} thresholds - Thresholds configuráveis (default)
  * @returns {Object} { status, adjustedScore, label, color }
  */
-export const calculateStudentStatus = (periodScore, complianceEvents = [], thresholds = {}) => {
+export const calculateStudentStatus = (periodScore, complianceEvents = [], thresholds = {}, trades = null) => {
   const {
     healthyMinScore = 70,
     attentionMinScore = 50,
     warningMinScore = 30
   } = thresholds;
 
-  // Penalidades por eventos
-  const penalty = complianceEvents.reduce((sum, event) => {
+  // Penalidades por eventos — issue #221: filtra eventos cleared pelo mentor.
+  // `trades` opcional para preservar callers legados; quando passado, aplica filter.
+  const eventsToCount = trades
+    ? effectiveEmotionalEventsForPeriod(trades, complianceEvents)
+    : complianceEvents;
+  const penalty = eventsToCount.reduce((sum, event) => {
     return sum + (EVENT_PENALTIES[event.type] || 0);
   }, 0);
 

--- a/src/utils/maturityEngine/computeCycleBasedComplianceRate.js
+++ b/src/utils/maturityEngine/computeCycleBasedComplianceRate.js
@@ -8,7 +8,12 @@
  * os planos. Mínimo 20 trades CLOSED; fallback retroativo simultâneo até atingir
  * o mínimo ou esgotar histórico. Estado insuficiente → null (METRIC_UNAVAILABLE
  * no evaluateGates: gate pendente, não promove e não rebaixa).
+ *
+ * Issue #221: respeita `mentorClearedViolations` — trade com TODAS as red flags
+ * limpas pelo mentor é tratado como compliant.
  */
+
+import { hasEffectiveRedFlags } from '../violationFilter';
 
 const MAX_LOOKBACK_CYCLES = 36;
 const DEFAULT_MIN_TRADES = 20;
@@ -90,9 +95,7 @@ function rangesContain(ranges, date) {
 
 function complianceFromTrades(trades) {
   if (trades.length === 0) return null;
-  const withFlags = trades.filter(
-    (t) => t.hasRedFlags || (Array.isArray(t.redFlags) && t.redFlags.length > 0),
-  ).length;
+  const withFlags = trades.filter((t) => hasEffectiveRedFlags(t)).length;
   const compliant = trades.length - withFlags;
   return (compliant / trades.length) * 100;
 }

--- a/src/utils/tradeGateway.js
+++ b/src/utils/tradeGateway.js
@@ -19,7 +19,7 @@
 
 import {
   collection, query, where, addDoc, getDoc, getDocs, doc, serverTimestamp,
-  updateDoc, arrayUnion,
+  updateDoc, arrayUnion, arrayRemove,
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import { calculateTradeResult, calculateResultPercent } from './calculations';
@@ -669,4 +669,65 @@ export async function classifyTradeAsMentor(tradeId, input, userContext, deps = 
     (flags.length ? ` flags=[${flags.join(',')}]` : '')
   );
   return { id: tradeId, before, after: { ...before, ...patch } };
+}
+
+/**
+ * Toggle de "limpar violação" (issue #221, Phase B do épico #218).
+ *
+ * Mentor adiciona/remove uma chave de violação ao array `mentorClearedViolations`.
+ * Quando presente, agregadores (complianceRate, calculatePeriodScore, gates de
+ * maturity) filtram a violação correspondente via `effectiveRedFlags` /
+ * `effectiveEmotionalEventsForPeriod`.
+ *
+ * Sem audit metadata (sem reason/clearedAt/clearedBy) — DEC-AUTO-221-02. Refactor
+ * trivial pra `Array<{key,reason?,by?,at?}>` se necessário no futuro.
+ *
+ * Cliente faz só `arrayUnion`/`arrayRemove`; recompute server-side é responsabilidade
+ * da CF `onTradeUpdated` que detecta mudança no campo e dispara pipeline igual à
+ * de mudança de plano (`recomputeStudentMaturity`).
+ *
+ * Schema de chaves:
+ *  - Compliance: o próprio code (`NO_STOP`, `RR_BELOW_MINIMUM`, `RISK_EXCEEDED`,
+ *    `DAILY_LOSS_EXCEEDED`, `BLOCKED_EMOTION`).
+ *  - Emocional: `${eventType}:${tradeId}` — ver `getEventKey` em violationFilter.js.
+ *
+ * @param {string} tradeId
+ * @param {string} violationKey - chave da violação a alternar
+ * @param {Object} userContext - { uid, email, isMentor }
+ * @param {Object} [deps]
+ * @returns {Promise<{ id, action: 'added'|'removed', violationKey }>}
+ */
+export async function toggleViolationClearedAsMentor(tradeId, violationKey, userContext, deps = {}) {
+  const getDocFn = deps.getDocFn ?? getDoc;
+  const updateDocFn = deps.updateDocFn ?? updateDoc;
+  const docFn = deps.docFn ?? doc;
+
+  if (!userContext?.uid) throw new Error('Usuário não autenticado');
+  if (!userContext?.isMentor) throw new Error('Apenas o mentor pode limpar violações');
+  if (!tradeId) throw new Error('tradeId obrigatório');
+  if (!violationKey || typeof violationKey !== 'string') {
+    throw new Error('violationKey obrigatório (string não-vazia)');
+  }
+
+  const tradeRef = docFn(db, 'trades', tradeId);
+  const tradeSnap = await getDocFn(tradeRef);
+  if (!tradeSnap.exists()) throw new Error(`Trade ${tradeId} não encontrado`);
+  const before = tradeSnap.data();
+
+  const current = Array.isArray(before.mentorClearedViolations)
+    ? before.mentorClearedViolations
+    : [];
+  const isCurrentlyCleared = current.includes(violationKey);
+  const action = isCurrentlyCleared ? 'removed' : 'added';
+
+  const patch = {
+    mentorClearedViolations: isCurrentlyCleared
+      ? arrayRemove(violationKey)
+      : arrayUnion(violationKey),
+    updatedAt: serverTimestamp(),
+  };
+
+  await updateDocFn(tradeRef, patch);
+  console.log(`[tradeGateway] Trade ${tradeId} violation ${action}: ${violationKey}`);
+  return { id: tradeId, action, violationKey };
 }

--- a/src/utils/violationFilter.js
+++ b/src/utils/violationFilter.js
@@ -1,0 +1,110 @@
+/**
+ * violationFilter.js — issue #221 (Phase B do épico #218).
+ *
+ * Helpers puros para aplicar `trade.mentorClearedViolations` (string[]) sobre
+ * `redFlags` (compliance) e `emotionalEvents` (TILT/REVENGE/etc). Sem dependências
+ * React. Espelhado em `functions/maturity/violationFilter.js` (CJS) — paridade
+ * obrigatória.
+ *
+ * Schema de chaves:
+ *  - Compliance: o próprio code (`NO_STOP`, `RR_BELOW_MINIMUM`, `RISK_EXCEEDED`,
+ *    `DAILY_LOSS_EXCEEDED`, `BLOCKED_EMOTION`).
+ *  - Emocional: `${eventType}:${tradeId}` — chave estável por par evento↔trade.
+ *    Um evento que afeta vários trades (ex.: RAPID_SEQUENCE) pode ser limpo em
+ *    um trade sem afetar os outros. DEC-AUTO-221-01.
+ *
+ * Fluxo de penalty no `calculatePeriodScore`:
+ *  - `effectiveEmotionalEventsForPeriod(trades, events)` mantém apenas os eventos
+ *    que ainda têm AO MENOS UM trade vinculado SEM o cleared correspondente.
+ *  - Se TODOS os trades vinculados limparam o evento, ele sai da soma de penalties.
+ */
+
+export const getEventKey = (event, tradeId) => {
+  if (!event?.type || !tradeId) return '';
+  return `${event.type}:${tradeId}`;
+};
+
+export const isViolationCleared = (trade, key) => {
+  if (!trade || !key) return false;
+  const cleared = Array.isArray(trade.mentorClearedViolations)
+    ? trade.mentorClearedViolations
+    : [];
+  return cleared.includes(key);
+};
+
+/**
+ * Compliance: filtra `trade.redFlags` removendo as cleared pelo mentor.
+ * Chave = `flag.type` (o próprio code da violação).
+ */
+export const effectiveRedFlags = (trade) => {
+  if (!trade) return [];
+  const flags = Array.isArray(trade.redFlags) ? trade.redFlags : [];
+  const cleared = Array.isArray(trade.mentorClearedViolations)
+    ? trade.mentorClearedViolations
+    : [];
+  if (cleared.length === 0) return flags;
+  return flags.filter((f) => f && !cleared.includes(f.type));
+};
+
+/**
+ * Boolean coerente com pattern legacy `t.hasRedFlags || t.redFlags.length > 0`,
+ * mas considerando o cleared do mentor.
+ *
+ * Quando `redFlags[]` está populado (typed), aplicamos `effectiveRedFlags`.
+ * Quando só `hasRedFlags: true` boolean legacy está disponível (sem detalhes),
+ * mantemos a flag — sem types individuais, não há como limpar parcialmente.
+ */
+export const hasEffectiveRedFlags = (trade) => {
+  if (!trade) return false;
+  if (Array.isArray(trade.redFlags) && trade.redFlags.length > 0) {
+    return effectiveRedFlags(trade).length > 0;
+  }
+  return trade.hasRedFlags === true;
+};
+
+/**
+ * Emocional (per trade — UI inline): para um trade específico, filtra os eventos
+ * que o mentor limpou para esse trade. Usado em ExtractTable / TradesList /
+ * FeedbackPage.
+ */
+export const effectiveEmotionalEventsForTrade = (trade, events) => {
+  if (!trade || !Array.isArray(events) || events.length === 0) return [];
+  const cleared = Array.isArray(trade.mentorClearedViolations)
+    ? trade.mentorClearedViolations
+    : [];
+  return events.filter((evt) => {
+    if (!evt?.type) return false;
+    const ids = Array.isArray(evt.tradeIds) ? evt.tradeIds : [];
+    if (!ids.includes(trade.id)) return false;
+    return !cleared.includes(getEventKey(evt, trade.id));
+  });
+};
+
+/**
+ * Emocional (período/agregação): mantém o evento se AO MENOS UM trade vinculado
+ * ainda não limpou. Quando todos os trades vinculados limparam, o evento sai
+ * da soma de penalties em `calculatePeriodScore`.
+ *
+ * Eventos sem `tradeIds` (legacy, day-level) passam intactos.
+ */
+export const effectiveEmotionalEventsForPeriod = (trades, events) => {
+  if (!Array.isArray(events) || events.length === 0) return [];
+  const safeTrades = Array.isArray(trades) ? trades : [];
+  const tradeMap = new Map(safeTrades.map((t) => [t?.id, t]).filter(([id]) => id));
+
+  return events.filter((evt) => {
+    if (!evt?.type) return false;
+    const ids = Array.isArray(evt.tradeIds) ? evt.tradeIds : [];
+    if (ids.length === 0) return true; // sem vínculo (legacy) → mantém
+
+    const stillEffective = ids.some((tid) => {
+      const trade = tradeMap.get(tid);
+      if (!trade) return true; // trade fora da janela → assume não cleared
+      const cleared = Array.isArray(trade.mentorClearedViolations)
+        ? trade.mentorClearedViolations
+        : [];
+      return !cleared.includes(getEventKey(evt, tid));
+    });
+    return stillEffective;
+  });
+};


### PR DESCRIPTION
Closes #221.

Parte 3/3 do épico #218. Compliance e detecções emocionais hoje são determinísticas; mentor entende contexto, sistema não. Solução: mentor toggle = lei dentro de v1, sem audit metadata. Pipeline de recompute automático, paralelo a mudança de plano.

## Schema (INV-15 aprovada)

1 campo novo em \`trades/{id}\`: \`mentorClearedViolations: string[]\`. Aluno read-only via firestore.rules. Chaves: compliance = code (\`NO_STOP\`, \`RR_BELOW_MINIMUM\`, etc); emocional = \`\${eventType}:\${tradeId}\` (DEC-AUTO-221-01).

## Implementação

**B1 — Helper puro** \`src/utils/violationFilter.js\` (ESM) + mirror CJS \`functions/maturity/violationFilter.js\`. \`effectiveRedFlags\`, \`hasEffectiveRedFlags\`, \`effectiveEmotionalEventsForTrade/ForPeriod\`. Período mantém evento se ALGUM trade vinculado ainda não limpou.

**B2 — Gateway** \`toggleViolationClearedAsMentor\` com \`arrayUnion\`/\`arrayRemove\`.

**B3 — Wire \`effective*\`** em 6 consumidores: \`dashboardMetrics\`, \`useDashboardMetrics\`, \`computeCycleBasedComplianceRate\` (ESM + CJS), \`emotionalAnalysisV2\` (calculatePeriodScore + calculateStudentStatus), \`emotionalAnalysisMirror\`, \`useEmotionalProfile\`.

**B4 — UI mentor** no FeedbackPage: bloco "Violações" com \`✕ Limpar\` + bloco separado "Limpas pelo mentor" com \`↺ Restaurar\`.

**B5 — firestore.rules** allowlist mentor-only para \`mentorClearedViolations\`.

**B6 — CF onTradeUpdated** detecta mudança no array via fingerprint sorted; invoca \`recomputeForStudent\` igual a plan-change.

## Tests

- 25 helper + 4 mirror paridade + 12 gateway = 41 novos
- Suite full **2838/2838** (baseline 2797)
- Build OK

## Test plan

- [ ] Mentor abre trade com NO_STOP → click \`✕ Limpar\` → chip move para "Limpas pelo mentor"
- [ ] CF onTradeUpdated dispara → maturity card spinner → snapshot atualiza
- [ ] complianceRate sobe (ex.: 10 trades, 1 cleared: 80% → 90%)
- [ ] Click \`↺ Restaurar\` → volta para "Violações"
- [ ] TILT/REVENGE: limpar evento num trade → emotional period score sobe
- [ ] Detector \`detectTilt\` continua reportando em sequências futuras (sem retroatividade)
- [ ] Aluno tenta forjar via DevTools → rules bloqueiam
- [ ] Suite mirror ESM↔CJS: paridade verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)