### PR TITLE
fix(#231): cc-worktree-start.sh aponta para scripts/cc-watchdog.sh canônico

### DIFF
--- a/docs/dev/issues/issue-231-watchdog-canonical.md
+++ b/docs/dev/issues/issue-231-watchdog-canonical.md
@@ -1,0 +1,40 @@
+# Issue #231 — fix: cc-worktree-start.sh lança versão velha do watchdog
+
+## Autorização
+
+- [x] Mockup — N/A (mudança em script + docs, sem UI)
+- [x] Memória de cálculo — N/A (sem fórmula)
+- [x] Marcio autorizou — chat: "abre issue e resolve" em 01/05/2026
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Crosscheck pós-#227 detectou `cc-worktree-start.sh:226` apontando pra versão velha do watchdog (`~/cc-mailbox/bin/cc-watchdog.sh`, 316L) em vez da canônica (`scripts/cc-watchdog.sh`, 459L). Loop autônomo recente usou TTL fixo + 3 tipos genéricos em vez de 7 granulares + retry pós-quota do #178.
+
+## Spec
+
+Ver issue body no GitHub: #231.
+
+## Phases
+
+- F1 — `scripts/cc-worktree-start.sh:226`: trocar `$HOME/cc-mailbox/bin/cc-watchdog.sh` por `$REPO/scripts/cc-watchdog.sh` (`$REPO` já definido na linha 57).
+- F2 — `docs/protocols/autonomous.md`: pequena nota documentando política `scripts/` canônica para infra autônoma duplicada (`cc-watchdog.sh`, `cc-status.sh`); `~/cc-mailbox/bin/` versões dos duplicados são deprecated.
+
+## Sessions
+
+_(preenchido durante execução)_
+
+## Shared Deltas
+
+- `scripts/cc-worktree-start.sh` — 1 linha (F1).
+- `docs/protocols/autonomous.md` — nota curta (F2).
+- Sem `src/version.js`, sem reserva, sem CHUNK locks.
+
+## Decisions
+
+- Não tocar `~/cc-mailbox/bin/cc-watchdog.sh` ou `~/.claude/hooks/check-closing.sh.bak` no PR — fora do repo. Cleanup local fica no PR body como nota operacional.
+- Não converter `cc-status.sh` em symlink ou wrapper: arquivos byte-idênticos hoje, sem dor; documentação de política basta.
+
+## Chunks
+
+Nenhum CHUNK de produto envolvido.

--- a/docs/protocols/autonomous.md
+++ b/docs/protocols/autonomous.md
@@ -278,6 +278,8 @@ Exemplos:
 - `cc-notify-email.py` em `EMAIL_DRY_RUN=1` não escreve em per-worktree log (só no global); assimetria trivial de 3 linhas
 - Criar worktree novo a partir do `main` pós-merge #172 pega a versão refatorada do `cc-worktree-start.sh` automaticamente (nota operacional: worktrees criados ANTES do merge continuam com script antigo até recriarem)
 
+**Política de SoT para infra autônoma duplicada (#231):** scripts que vivem em `scripts/` (repo, versionado) são canônicos. Cópias antigas em `~/cc-mailbox/bin/` (não versionadas) que existirem para os mesmos arquivos — `cc-watchdog.sh`, `cc-status.sh` — são deprecated; consumidores programáticos (ex.: `cc-worktree-start.sh:226`) apontam para `$REPO/scripts/`. Cleanup local das cópias velhas em `~/cc-mailbox/bin/` é decisão operacional do Marcio (fora do repo). Scripts que existem APENAS em `~/cc-mailbox/bin/` (`cc-notify-email.py`, `cc-validate-task.py`, `cc-spawn-coord.sh`, `cc-dispatch-task.sh`) seguem lá até fast-follow do `cc-notify-email.py:262` ser executado.
+
 ### 13.12 Decisões de Design (Bugs 1-10)
 
 Ver histórico em `/mnt/c/000-Marcio/Temp/proto-autonomo-state.md` para o design completo. Síntese:

--- a/scripts/cc-worktree-start.sh
+++ b/scripts/cc-worktree-start.sh
@@ -223,7 +223,12 @@ fi
 # Detecta stall em sessões autônomas §13: Classe 1 resume da Coord com API
 # error, Classe 2 worker travado, Classe 3 tmux/listener morto.
 # Opt-out: CC_WATCHDOG_DISABLE=1
-WATCHDOG_SCRIPT="$HOME/cc-mailbox/bin/cc-watchdog.sh"
+#
+# Issue #231: aponta para o repo (versionado) — autonomous.md:265 declara
+# scripts/cc-watchdog.sh canônico. ~/cc-mailbox/bin/cc-watchdog.sh é a
+# versão histórica do #178 ANTES da extensão para 7 tipos WATCHDOG_CLASS_*
+# + TTL configurável + retry pós-quota; deprecated, pode ser deletada localmente.
+WATCHDOG_SCRIPT="$REPO/scripts/cc-watchdog.sh"
 WATCHDOG_PIDFILE="$MAILBOX/.watchdog-pid"
 if [ "${CC_WATCHDOG_DISABLE:-}" = "1" ]; then
   echo "[start] Watchdog desabilitado via CC_WATCHDOG_DISABLE=1"


### PR DESCRIPTION
Closes #231

## Summary

Bug em produção: \`cc-worktree-start.sh:226\` lançava \`~/cc-mailbox/bin/cc-watchdog.sh\` (316L, versão histórica) em vez de \`scripts/cc-watchdog.sh\` (459L, canônica). Loop autônomo recente rodou sem TTL configurável, sem 7 tipos \`WATCHDOG_CLASS_*\`, sem retry agendado pós-quota — features do #178 (PR #179, v0.38.0).

- **Fix:** linha 226 → \`WATCHDOG_SCRIPT="\$REPO/scripts/cc-watchdog.sh"\` (\`\$REPO\` já definido na linha 57)
- **Doc:** \`autonomous.md\` ganha nota explícita de política — \`scripts/\` é SoT canônico; \`~/cc-mailbox/bin/\` versões dos duplicados são deprecated

## Cleanup local (operador, fora do repo)

```bash
rm ~/cc-mailbox/bin/cc-watchdog.sh           # versão velha agora não-utilizada
rm ~/cc-mailbox/bin/cc-status.sh             # idêntico a scripts/cc-status.sh
rm ~/.claude/hooks/check-closing.sh.bak      # backup leftover
```

## Out of scope

- \`cc-notify-whatsapp.sh\` ausente (LOW PRIORITY documentado em autonomous.md:264)
- Scripts run-once de issues fechadas (\`issue-183\`, \`issue-201\`, \`issue-210\`, \`migrate-emotions.js\`, \`setup-emotional-v2-test.js\`) — política a definir se virar dor

## Test plan

- [x] \`bash -n scripts/cc-worktree-start.sh\` → syntax OK
- [x] \`git diff --stat\`: 2 arquivos (script + doc)
- [ ] Próximo loop autônomo (qualquer issue futuro com \`atacar #NNN em modo autônomo\`) → log do watchdog deve mostrar \`WATCHDOG_SESSION_START\` com TTL 86400s, e tipos \`WATCHDOG_CLASS_*\` aparecerão em stalls (em vez de tipos genéricos)

## Versão / chunks

- Sem reserva de versão (precedente: #214/#216/#225/#227 — script/doc-only)
- Sem CHUNK locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)