### PR TITLE
refactor(#233): cc-close-issue.sh auto-deploy de CF no gate 0a

### DIFF
--- a/docs/dev/issues/issue-233-cf-autodeploy.md
+++ b/docs/dev/issues/issue-233-cf-autodeploy.md
@@ -1,0 +1,43 @@
+# Issue #233 — refactor: cc-close-issue.sh auto-deploy de CF no gate 0a
+
+## Autorização
+
+- [x] Mockup — N/A (mudança em script + docs, sem UI)
+- [x] Memória de cálculo — N/A (sem fórmula)
+- [x] Marcio autorizou — chat: "coloque no (1) e implementa - abre issue e implementa" em 01/05/2026
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Encerramento #229 demonstrou que marker explícito + autorização per-deploy bloqueia o flow. Se squash tocou `functions/` e operador está rodando `cc-close-issue.sh`, deploy é parte do encerramento, não decisão à parte.
+
+## Spec
+
+Ver issue body no GitHub: #233.
+
+## Phases
+
+- F1 — `scripts/cc-close-issue.sh` gate `0a`: auto-deploy via `firebase deploy --only functions`. Pré-check de `firebase` CLI. Marker existente preserva backcompat (skip deploy + consume marker).
+- F2 — `docs/protocols/closing.md`: atualizar descrição do gate `0a` para refletir auto-deploy.
+- F3 — `docs/protocols/closing-manual.md`: atualizar §0a do recovery (operador continua deployando manualmente em recovery — script não está em jogo).
+
+## Sessions
+
+_(preenchido durante execução)_
+
+## Shared Deltas
+
+- `scripts/cc-close-issue.sh` — passo `0a` reescrito com auto-deploy + backcompat.
+- `docs/protocols/closing.md` — descrição do passo `0a` atualizada.
+- `docs/protocols/closing-manual.md` — §0a mantém deploy manual (sem mudança vs hoje).
+- Sem `src/version.js`, sem reserva, sem CHUNK locks.
+
+## Decisions
+
+- Backcompat via marker: operador que prefere deployar manualmente antes do script ainda pode (`touch .cf-deployed-${PR}` → skip auto-deploy). Cobre caso de revert PR sem CF mudou e hotfix sem deploy.
+- Pré-check de `firebase` CLI (`command -v firebase`) ANTES de tentar deploy: aborta com mensagem clara se não instalada. Evita falha confusa no meio do encerramento.
+- Pré-check de auth (`firebase projects:list`) — overkill, vamos confiar que `firebase deploy` falha graceful se desautenticado. Mensagem de erro do firebase já é clara.
+
+## Chunks
+
+Nenhum CHUNK de produto envolvido.

--- a/docs/protocols/closing-manual.md
+++ b/docs/protocols/closing-manual.md
@@ -13,9 +13,11 @@
 
 ## Sequência (não pular passos)
 
-### 0a. Gate de Cloud Functions deploy (issue #225)
+### 0a. Gate de Cloud Functions deploy (issues #225/#233)
 
 Se o squash do PR tocou `functions/`, rodar `firebase deploy --only functions` antes de prosseguir. Recovery manual não usa o marker `.cf-deployed-${PR}` — o operador é o próprio juiz da paridade prod↔main. Esquecer este passo = casos #211/#210/#221 (CF mergeada fora de prod).
+
+> **Diferença do flow normal (`cc-close-issue.sh`):** desde #233 o script auto-deploya. Recovery manual é por definição operador-dirigido, então o deploy fica explícito aqui.
 
 ### 1. Atualizar `docs/dev/issues/issue-NNN-*.md`
 Resumo do que foi feito, decisões DEC-xxx, arquivos tocados, comandos git executados, testes rodados, pendências.

--- a/docs/protocols/closing.md
+++ b/docs/protocols/closing.md
@@ -21,11 +21,12 @@
 O script orquestra 9 etapas (`[0/8]` a `[8/8]`, com gate `[0a/8]` adicional) e aborta no primeiro erro. Numeração casa com os prints do terminal:
 
 - **`[0/8]` Pré-checks** — `gh pr list` confirma PR mergeado com `Closes #NNN`; `gh issue view` confirma state=CLOSED.
-- **`[0a/8]` Gate de Cloud Functions deploy** (issue #225) — se o squash do PR tocou `functions/`, exige marker file `.cf-deployed-${PR}` no repo root confirmando deploy. Aborta com comando de retomada caso ausente:
-   ```
-   firebase deploy --only functions && touch .cf-deployed-${PR}
-   ```
-   Marker é deletado após verificação (não vai para git). Substitui o alerta não-bloqueante histórico (#216) que permitia esquecer o deploy e quebrar paridade prod↔main.
+- **`[0a/8]` Gate de Cloud Functions deploy** (issues #225/#233) — se o squash do PR tocou `functions/`, script roda `firebase deploy --only functions` automaticamente (#233). Falha do deploy aborta o encerramento (paridade prod↔main preservada). Pré-check da `firebase` CLI aborta com mensagem clara se não instalada.
+   - **Override manual:** marker `.cf-deployed-${PR}` no repo root mantém suporte a operadores que preferem deploy ANTES do script (revert PR sem mudança real em CF, hotfix com fluxo especial). Marker presente → skip auto-deploy + delete marker. Cria com:
+     ```
+     firebase deploy --only functions && touch .cf-deployed-${PR}
+     ```
+   - **Histórico:** #216 introduziu alerta não-bloqueante (esquecível); #225 endureceu para marker explícito (fricção de autorização per-deploy); #233 internalizou o deploy no script (eliminou autorização, manteve marker como escape hatch).
 - **`[1/8]` Sync main** — `git pull --rebase origin main`.
 - **`[2/8]` Snapshot defensivo** — `gh issue view + gh pr view --json` para `.archive-snapshots/issue-NNN.json` (resiliência a edição/perda de issue body).
 - **`[3/8]` Deltas curtos** (formato Fase 2 — GitHub é SSoT do detalhe):

--- a/scripts/cc-close-issue.sh
+++ b/scripts/cc-close-issue.sh
@@ -89,31 +89,45 @@ echo "  PR #${PR} (sha ${PR_SHA:0:8}) tipo=${PR_TYPE} ver=${VER:-none}"
 echo "  resumo: ${PR_SUMMARY}"
 
 # ---------- 0a. Gate bloqueante de Cloud Functions deploy ----------
-# Bug histórico: o alerta original no fim do script (#216) era não-bloqueante
-# — Marcio podia esquecer e deixar CF mergeada fora de prod (paridade
-# prod↔main quebrada). Casos #211/#210 e #221 mergearam mudança em
-# `functions/` sem deploy imediato. Fix (issue #225 — Parte D): se o squash
-# tocou `functions/`, exige marker file `.cf-deployed-${PR}` confirmando
-# deploy antes de prosseguir. Operador roda no main após o merge:
-#   firebase deploy --only functions && touch .cf-deployed-${PR}
-# Marker é deletado após verificação (não vai pro git).
+# Histórico:
+#   #216 — alerta não-bloqueante no fim do script; #211/#210/#221 mergearam
+#          functions/ sem deploy (paridade prod↔main quebrada na surdina).
+#   #225 — gate bloqueante exigindo marker explícito `.cf-deployed-${PR}`;
+#          eliminava o esquecimento mas adicionava fricção (operador rodava
+#          firebase deploy + touch antes do script).
+#   #233 — auto-deploy: se squash tocou functions/, script roda
+#          `firebase deploy --only functions` automaticamente. Falha aborta
+#          o encerramento (paridade preservada). Marker mantido como
+#          override para operadores que prefiram deploy manual ANTES do
+#          script (revert PR sem mudança real em CF, hotfix com fluxo
+#          especial). Backcompat: marker presente → skip auto-deploy.
 echo "[0a/8] Gate de Cloud Functions deploy…"
 CF_FILES=$(git show --name-only --format= "$PR_SHA" 2>/dev/null | grep -E "^functions/" || true)
 CF_DEPLOY_MARKER="$REPO/.cf-deployed-${PR}"
 if [ -n "$CF_FILES" ]; then
   if [ -f "$CF_DEPLOY_MARKER" ]; then
-    echo "  [ok] PR #${PR} tocou functions/ — marker presente, deploy confirmado pelo operador"
+    echo "  [ok] PR #${PR} tocou functions/ — marker presente, deploy já feito pelo operador (skip auto-deploy)"
     $DRY_RUN || rm -f "$CF_DEPLOY_MARKER"
   else
-    echo >&2
-    echo "❌ PR #${PR} tocou Cloud Functions mas deploy não foi confirmado:" >&2
-    echo "$CF_FILES" | sed 's/^/    /' >&2
-    echo >&2
-    echo "Rode no main após o merge:" >&2
-    echo "    firebase deploy --only functions && touch ${CF_DEPLOY_MARKER}" >&2
-    echo >&2
-    echo "Depois rode novamente: scripts/cc-close-issue.sh ${ISSUE}" >&2
-    abort "CF deploy pendente — abortando para preservar paridade prod↔main"
+    echo "  PR #${PR} tocou functions/:"
+    echo "$CF_FILES" | sed 's/^/    /'
+    if ! command -v firebase >/dev/null 2>&1; then
+      echo >&2
+      echo "❌ firebase CLI não instalada — não é possível auto-deploy" >&2
+      echo "Instale: npm install -g firebase-tools" >&2
+      echo "Ou deploy manual: firebase deploy --only functions && touch ${CF_DEPLOY_MARKER}" >&2
+      abort "firebase CLI ausente — abortando para preservar paridade prod↔main"
+    fi
+    if $DRY_RUN; then
+      echo "  [dry-run] firebase deploy --only functions"
+    else
+      echo "  Auto-deploy via firebase (#233)…"
+      if firebase deploy --only functions; then
+        echo "  [ok] CF deploy concluído"
+      else
+        abort "firebase deploy --only functions falhou — abortando para preservar paridade prod↔main"
+      fi
+    fi
   fi
 else
   echo "  [skip] PR não tocou functions/"


### PR DESCRIPTION
Closes #233

## Summary

Encerramento #229 expôs a fricção do gate atual de CF deploy: marker explícito + autorização per-deploy bloqueava sessões Claude pedindo permissão pra `firebase deploy`. Auto-deploy direto elimina o gate humano.

- **F1** — gate `0a` reescrito: auto-deploy via `firebase deploy --only functions`. Pré-check `command -v firebase` aborta com mensagem clara se ausente. Falha do deploy aborta o encerramento (paridade prod↔main preservada).
- **Backcompat** — marker `.cf-deployed-${PR}` ainda funciona como override (skip auto-deploy + delete marker). Cobre revert PR sem mudança real em CF e hotfix com fluxo especial.
- **F2** — `closing.md` gate `0a` atualizado com nova descrição + histórico `#216→#225→#233`.
- **F3** — `closing-manual.md` ganha nota explicando que recovery manual continua operador-dirigido.

## Histórico do gate

| Issue | Comportamento |
|-------|---------------|
| #216 | Alerta não-bloqueante no fim do script (esquecível — #211/#210/#221 mergearam sem deploy) |
| #225 | Gate bloqueante exigindo marker explícito (operador deploya antes do script) |
| #233 | Auto-deploy direto (este PR — script deploya, marker vira override opcional) |

## Test plan

- [x] `bash -n scripts/cc-close-issue.sh` → syntax OK
- [x] `command -v firebase` → 15.12.0 disponível
- [ ] Próximo encerramento que toque \`functions/\` (sem marker) → script roda `firebase deploy --only functions` e prossegue se OK
- [ ] Próximo encerramento que toque \`functions/\` (com marker pré-criado) → skip auto-deploy + delete marker
- [ ] Encerramento sem `functions/` → caminho `[skip] PR não tocou functions/` (testado em #225/#227/#231)

## Versão / chunks

- Sem reserva (precedente #214/#216/#225/#227/#231 — script/doc-only)
- Sem CHUNK locks

🤖 Generated with [Claude Code](https://claude.com/claude-code)