### PR TITLE
feat: redesign card Consistência Operacional — Sharpe+CV norm+MEP/MEN+Selic (#235)

### DIFF
--- a/.deccs-235.md
+++ b/.deccs-235.md
@@ -1,0 +1,17 @@
+- **DEC-AUTO-235-01** (2026-05-02): rfr = Selic histórica diária via BCB SGS-11 descontada apenas em dias com trade; fallback hardcoded quando cache vazio.
+- **DEC-AUTO-235-02** (2026-05-02): N mínimo por `adjustmentCycle` — Mensal=10, Trimestral=30, Semestral=60, Anual=120; abaixo retorna `null` (estado "Insuficiente — opere mais X dias").
+- **DEC-AUTO-235-03** (2026-05-02): Sharpe per-ciclo anualizado por √252 (252 dias úteis) — padrão indústria; variância amostral N-1 (Bessel) consistente com `computeSharpe` legado.
+- **DEC-AUTO-235-04** (2026-05-02): Sharpe-no-ciclo NÃO entra em gate de maturity v1 — gates rolling (`monthlySharpe`/`annualSharpe`) continuam intactos.
+- **DEC-AUTO-235-05** (2026-05-02): Threshold semáforo Sharpe — >2 excelente · 1.5–2 bom · 1–1.5 ok · 0–1 fraco · <0 destrói.
+- **DEC-AUTO-235-06** (2026-05-02): Sortino NÃO entra na v1 — escopo separado (fast-follow se skew negativa for relevante).
+- **DEC-AUTO-235-07** (2026-05-02): Visualização vive no card "Consistência Operacional" do StudentDashboard; quando #72 Fase 1 aterrissar, também no `CycleSummary`.
+- **DEC-AUTO-235-08** (2026-05-02): Schema cache Selic (INV-15 aprovada via `#issuecomment-4364111738`) — subcollection `systemConfig/selic/history/{YYYY-MM-DD}` + doc-pai `systemConfig/selic` com metadata.
+- **DEC-AUTO-235-09** (2026-05-02): Fallback Selic indisponível — constante hardcoded em `functions/marketData/selicFallback.js` (atual 14.75% a.a.), atualizada manualmente em PR; `rfrSource: 'fallback'`.
+- **DEC-AUTO-235-10** (2026-05-02): Selic faltante para dia operado — carry-forward (último valor conhecido) + flag `rfrInterpolated: true` no audit; gap maior que threshold → fallback constante.
+- **DEC-AUTO-235-11** (2026-05-02): Padrão de orquestração — CF própria `fetchSelicDaily` (cron diário 09h BRT `America/Sao_Paulo`); refatorar para gateway se chegarmos a ≥5 jobs diários OU dependência entre jobs.
+- **DEC-AUTO-235-12** (2026-05-02): CV normalizado SUBSTITUI CV puro no card de Consistência Operacional (não coexistem na UI nova); plano sem `targetRR` → métrica null + CTA "definir RR alvo no plano".
+- **DEC-AUTO-235-13** (2026-05-02): Threshold semáforo CV normalizado — ≤1.2 verde · 1.2–1.5 âmbar · 1.5–2.0 laranja · >2.0 vermelho · <0.5 âmbar (suspeitamente estável).
+- **DEC-AUTO-235-14** (2026-05-02): Fonte da WR para CV esperado — WR efetiva do aluno na janela do ciclo (mais responsivo); fallback `plan.expectedWinRate` quando amostra <minDays.
+- **DEC-AUTO-235-15** (2026-05-02): MEP/MEN coverage threshold — `coverage < 0.7` exibe badge `⚠ MEP/MEN em N de M trades` no card (transparência de amostra).
+- **DEC-AUTO-235-16** (2026-05-02): Migração de Revisão Semanal — reviews já fechadas mantêm CV puro (`coefVariation`) congelado SEM mitigação técnica (sem backfill, sem label "legado", sem tooltip, sem banner); novos snapshots ganham `cvNormalized`; mentor humano explica descontinuidade caso a caso. Risco UX absorvido por proximidade Marcio↔alunos + amostra pequena.
+- **DEC-AUTO-235-17** (2026-05-02): Sharpe rolling no engine de maturity (`monthlySharpe`/`annualSharpe`) INALTERADO — gates `sharpe-1_2`/`sharpe-1_5` calibrados em #119 ficam com `rfr=0`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -293,5 +293,20 @@ service cloud.firestore {
       allow read: if isAuthenticated() && (isOwner(studentId) || isMentor());
       allow write: if false;
     }
+
+    // ========== Selic Cache — Risk-free rate diária BCB SGS-11 (CHUNK-09, issue #235) ==========
+    // INV-15 aprovada — comment #issuecomment-4364111738.
+    // Doc raiz + subcollection history/<YYYY-MM-DD>. Apenas CF/Admin SDK escreve
+    // (fetchSelicDaily diária + bootstrap run-once). Qualquer usuário autenticado lê
+    // (consumido pelo helper getSelicForDate em UI e CFs).
+    match /systemConfig/selic {
+      allow read: if isAuthenticated();
+      allow write: if false;
+
+      match /history/{dateId} {
+        allow read: if isAuthenticated();
+        allow write: if false;
+      }
+    }
   }
 }

--- a/functions/__tests__/cycleConsistency/computeAvgExcursion.test.js
+++ b/functions/__tests__/cycleConsistency/computeAvgExcursion.test.js
@@ -1,0 +1,182 @@
+/**
+ * computeAvgExcursion.test.js — issue #235 F1.3 (CJS mirror)
+ *
+ * Cobre os mesmos 9 cenários do espelho ESM, consumindo o módulo CJS via
+ * createRequire. Assertivas idênticas — qualquer divergência indica drift
+ * entre os dois lados do mirror.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  computeAvgExcursion,
+  excursionPctForTrade,
+} = require('../../cycleConsistency/computeAvgExcursion');
+
+describe('computeAvgExcursion (CJS)', () => {
+  it('C1 — janela vazia retorna null com insufficientReason no_trades', () => {
+    const result = computeAvgExcursion([], '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeNull();
+    expect(result.avgMEN).toBeNull();
+    expect(result.coverage).toBe(0);
+    expect(result.coverageBelowThreshold).toBe(false);
+    expect(result.totalTrades).toBe(0);
+    expect(result.tradesWithData).toBe(0);
+    expect(result.insufficientReason).toBe('no_trades');
+    expect(result.coverageLabel).toBeUndefined();
+  });
+
+  it('C2 — trades só com mepPrice/menPrice null retorna no_excursion_data', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: null, menPrice: null },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: null, menPrice: null },
+      { date: '04/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: null, menPrice: null },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeNull();
+    expect(result.avgMEN).toBeNull();
+    expect(result.coverage).toBe(0);
+    expect(result.totalTrades).toBe(3);
+    expect(result.tradesWithData).toBe(0);
+    expect(result.insufficientReason).toBe('no_excursion_data');
+  });
+
+  it('C3 — LONG happy path: 5 trades entry=100 mep=102 men=99 → +2.0% / -1.0% coverage 1.0', () => {
+    const trades = Array.from({ length: 5 }, (_, i) => ({
+      date: `0${i + 2}/02/2026`,
+      status: 'CLOSED',
+      side: 'LONG',
+      entry: 100,
+      mepPrice: 102,
+      menPrice: 99,
+    }));
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+    expect(result.coverage).toBe(1.0);
+    expect(result.coverageBelowThreshold).toBe(false);
+    expect(result.coverageLabel).toBeUndefined();
+    expect(result.totalTrades).toBe(5);
+    expect(result.tradesWithData).toBe(5);
+    expect(result.insufficientReason).toBeUndefined();
+  });
+
+  it('C4 — SHORT happy path: entry=100 mep=98 men=101 → +2.0% / -1.0% (sinais invertidos)', () => {
+    const trades = Array.from({ length: 4 }, (_, i) => ({
+      date: `0${i + 2}/02/2026`,
+      status: 'CLOSED',
+      side: 'SHORT',
+      entry: 100,
+      mepPrice: 98,
+      menPrice: 101,
+    }));
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+    expect(result.coverage).toBe(1.0);
+    expect(result.coverageBelowThreshold).toBe(false);
+    expect(result.tradesWithData).toBe(4);
+  });
+
+  it('C5 — coverage 4/10 < 0.7 → coverageBelowThreshold true + label apropriado', () => {
+    const withData = Array.from({ length: 4 }, (_, i) => ({
+      date: `0${i + 2}/02/2026`,
+      status: 'CLOSED',
+      side: 'LONG',
+      entry: 100,
+      mepPrice: 102,
+      menPrice: 99,
+    }));
+    const withoutData = Array.from({ length: 6 }, (_, i) => ({
+      date: `${(i + 6).toString().padStart(2, '0')}/02/2026`,
+      status: 'CLOSED',
+      side: 'LONG',
+      entry: 100,
+      mepPrice: null,
+      menPrice: null,
+    }));
+    const result = computeAvgExcursion([...withData, ...withoutData], '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(10);
+    expect(result.tradesWithData).toBe(4);
+    expect(result.coverage).toBeCloseTo(0.4, 10);
+    expect(result.coverageBelowThreshold).toBe(true);
+    expect(result.coverageLabel).toBe('⚠ MEP/MEN em 4 de 10 trades');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+  });
+
+  it('C6 — mix LONG+SHORT no ciclo, médias agregadas corretamente', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG',  entry: 100, mepPrice: 104, menPrice: 98 },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG',  entry: 100, mepPrice: 104, menPrice: 98 },
+      { date: '04/02/2026', status: 'CLOSED', side: 'SHORT', entry: 200, mepPrice: 196, menPrice: 202 },
+      { date: '05/02/2026', status: 'CLOSED', side: 'SHORT', entry: 200, mepPrice: 196, menPrice: 202 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.tradesWithData).toBe(4);
+    expect(result.avgMEP).toBeCloseTo(3.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.5, 10);
+    expect(result.coverage).toBe(1.0);
+  });
+
+  it('C7 — side inválido (BUY) é pulado, não conta em tradesWithData', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '04/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '05/02/2026', status: 'CLOSED', side: 'BUY',  entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '06/02/2026', status: 'CLOSED', side: 'BUY',  entry: 100, mepPrice: 102, menPrice: 99 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(5);
+    expect(result.tradesWithData).toBe(3);
+    expect(result.coverage).toBeCloseTo(0.6, 10);
+    expect(result.coverageBelowThreshold).toBe(true);
+    expect(result.coverageLabel).toBe('⚠ MEP/MEN em 3 de 5 trades');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+  });
+
+  it('C8 — entry=0 (e entry inválido) é pulado para evitar divisão por zero', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG', entry: 0,   mepPrice: 102, menPrice: 99 },
+      { date: '04/02/2026', status: 'CLOSED', side: 'LONG', entry: -10, mepPrice: 102, menPrice: 99 },
+      { date: '05/02/2026', status: 'CLOSED', side: 'LONG', entry: NaN, mepPrice: 102, menPrice: 99 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(4);
+    expect(result.tradesWithData).toBe(1);
+    expect(result.coverage).toBeCloseTo(0.25, 10);
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+  });
+
+  it('C9 — excursionPctForTrade puro: LONG, SHORT, inválido, sem dado', () => {
+    expect(excursionPctForTrade({ side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 }))
+      .toEqual({ mepPct: 2.0, menPct: -1.0 });
+    expect(excursionPctForTrade({ side: 'SHORT', entry: 100, mepPrice: 98, menPrice: 101 }))
+      .toEqual({ mepPct: 2.0, menPct: -1.0 });
+    expect(excursionPctForTrade({ side: 'BUY', entry: 100, mepPrice: 102, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: undefined, entry: 100, mepPrice: 102, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: 'LONG', entry: 100, mepPrice: null, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: 'LONG', entry: 100, mepPrice: 102, menPrice: undefined })).toBeNull();
+    expect(excursionPctForTrade({ side: 'LONG', entry: 0, mepPrice: 102, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: 'LONG', entry: NaN, mepPrice: 102, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade(null)).toBeNull();
+  });
+
+  it('helper — filtra fora-janela e status != CLOSED', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '03/02/2026', status: 'OPEN',   side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '01/01/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '01/03/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(1);
+    expect(result.tradesWithData).toBe(1);
+  });
+});

--- a/functions/__tests__/cycleConsistency/computeCVNormalized.test.js
+++ b/functions/__tests__/cycleConsistency/computeCVNormalized.test.js
@@ -1,0 +1,194 @@
+/**
+ * computeCVNormalized.test.js — issue #235 F1.2 (CJS mirror)
+ *
+ * Cobre os mesmos 10 cenários do espelho ESM, consumindo o módulo CJS
+ * via createRequire. Assertivas idênticas — qualquer divergência indica
+ * drift entre os dois lados do mirror.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  computeCVNormalized,
+  groupTradesByDay,
+  effectiveWinRate,
+  computeCvObserved,
+  computeCvExpected,
+  resolveWinRate,
+} = require('../../cycleConsistency/computeCVNormalized');
+
+// ── Fixtures (cópia do espelho ESM — sincronia sob lock) ───────────────────
+
+const CALIB_TRADES = [
+  { date: '02/02/2026', result: -100, status: 'CLOSED' },
+  { date: '03/02/2026', result: -100, status: 'CLOSED' },
+  { date: '04/02/2026', result: -100, status: 'CLOSED' },
+  { date: '05/02/2026', result: +300, status: 'CLOSED' },
+  { date: '06/02/2026', result: -100, status: 'CLOSED' },
+  { date: '09/02/2026', result: -100, status: 'CLOSED' },
+  { date: '10/02/2026', result: +300, status: 'CLOSED' },
+  { date: '11/02/2026', result: -100, status: 'CLOSED' },
+  { date: '12/02/2026', result: -100, status: 'CLOSED' },
+  { date: '13/02/2026', result: +300, status: 'CLOSED' },
+];
+
+describe('computeCVNormalized (CJS)', () => {
+  it('C1 — janela vazia retorna null com insufficientReason min_days', () => {
+    const result = computeCVNormalized([], { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.cvObs).toBeNull();
+    expect(result.cvExp).toBeNull();
+    expect(result.daysWithTrade).toBe(0);
+    expect(result.insufficientReason).toBe('min_days');
+    expect(result.label).toBe('Insuficiente · ≥5 dias');
+  });
+
+  it('C2 — 4 dias com trade (< minDays=5) retorna null min_days', () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '05/02/2026', result: 75, status: 'CLOSED' },
+    ];
+    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(4);
+    expect(result.insufficientReason).toBe('min_days');
+  });
+
+  it('C3 — plan sem targetRR retorna null no_target_rr com label apropriado', () => {
+    const result = computeCVNormalized(CALIB_TRADES, {}, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(10);
+    expect(result.insufficientReason).toBe('no_target_rr');
+    expect(result.label).toBe('Plano sem RR alvo definido — definir para ativar métrica');
+  });
+
+  it('C4 — calibração spec issue body (7L+3G@3R, 10 dias) → cv_normalized ≈ 1.05 ± 0.05', () => {
+    const result = computeCVNormalized(
+      CALIB_TRADES,
+      { targetRR: 3 },
+      '2026-02-01',
+      '2026-02-28'
+    );
+    expect(result.daysWithTrade).toBe(10);
+    expect(result.value).not.toBeNull();
+    expect(result.cvObs).toBeCloseTo(9.66, 1);
+    expect(result.cvExp).toBeCloseTo(9.165, 2);
+    expect(result.value).toBeGreaterThan(1.00);
+    expect(result.value).toBeLessThan(1.10);
+  });
+
+  it('C5 — plano breakeven (WR efetiva 0.25 / RR 3 → mean_exp 0) retorna null breakeven_plan', () => {
+    const trades = [
+      { date: '02/02/2026', result: +500, status: 'CLOSED' },
+      { date: '02/02/2026', result: +500, status: 'CLOSED' },
+      { date: '03/02/2026', result: -50, status: 'CLOSED' },
+      { date: '03/02/2026', result: -50, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '05/02/2026', result: -50, status: 'CLOSED' },
+      { date: '06/02/2026', result: -50, status: 'CLOSED' },
+    ];
+    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(5);
+    expect(result.insufficientReason).toBe('breakeven_plan');
+    expect(result.label).toBe('Plano com expectância nula — métrica indefinida');
+  });
+
+  it('C6 — mean_obs ≈ 0 (P&L diário simétrico) retorna null zero_obs_mean', () => {
+    const trades = [
+      { date: '02/02/2026', result: +1000, status: 'CLOSED' },
+      { date: '03/02/2026', result: -1000, status: 'CLOSED' },
+      { date: '04/02/2026', result: +1000, status: 'CLOSED' },
+      { date: '05/02/2026', result: -1000, status: 'CLOSED' },
+      { date: '06/02/2026', result: +1000, status: 'CLOSED' },
+      { date: '09/02/2026', result: -1000, status: 'CLOSED' },
+    ];
+    const result = computeCVNormalized(trades, { targetRR: 2 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(6);
+    expect(result.insufficientReason).toBe('zero_obs_mean');
+    expect(result.cvExp).not.toBeNull();
+    expect(result.label).toBe('P&L médio diário próximo de zero — CV indefinido');
+  });
+
+  it('C7 — happy path: WR efetiva difere de plan.expectedWinRate, helper usa a efetiva', () => {
+    const result = computeCVNormalized(
+      CALIB_TRADES,
+      { targetRR: 3, expectedWinRate: 0.50 },
+      '2026-02-01',
+      '2026-02-28'
+    );
+    expect(result.value).not.toBeNull();
+    expect(result.cvExp).toBeCloseTo(9.165, 2);
+    expect(result.value).toBeGreaterThan(1.00);
+    expect(result.value).toBeLessThan(1.10);
+  });
+
+  it('C8 — fallback plan.expectedWinRate quando WR efetiva indefinida (resolveWinRate)', () => {
+    expect(resolveWinRate([], { expectedWinRate: 0.42 })).toBe(0.42);
+    expect(resolveWinRate([], {})).toBeNull();
+    expect(resolveWinRate([], null)).toBeNull();
+
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '02/02/2026', result: -50, status: 'CLOSED' },
+      { date: '02/02/2026', result: -50, status: 'CLOSED' },
+    ];
+    expect(resolveWinRate(trades, { expectedWinRate: 0.99 })).toBe(0.5);
+  });
+
+  it('C9 — effectiveWinRate puro: 7L+3G → 0.3', () => {
+    expect(effectiveWinRate(CALIB_TRADES)).toBeCloseTo(0.3, 10);
+    expect(effectiveWinRate([])).toBeNull();
+    expect(effectiveWinRate([{ result: 100, status: 'CLOSED' }])).toBe(1);
+    expect(effectiveWinRate([{ result: -100, status: 'CLOSED' }])).toBe(0);
+    const mixed = [
+      { result: 100, status: 'OPEN' },
+      { result: 100, status: 'CLOSED' },
+      { result: 'NaN', status: 'CLOSED' },
+      { result: -50, status: 'CLOSED' },
+    ];
+    expect(effectiveWinRate(mixed)).toBeCloseTo(0.5, 10);
+  });
+
+  it('C10 — computeCvExpected(0.3, 3): mean=0.20, std≈1.833, cv≈9.165', () => {
+    const out = computeCvExpected(0.3, 3);
+    expect(out.mean).toBeCloseTo(0.20, 10);
+    expect(out.std).toBeCloseTo(Math.sqrt(3.36), 6);
+    expect(out.cv).toBeCloseTo(9.165, 2);
+
+    const breakeven = computeCvExpected(0.25, 3);
+    expect(breakeven.cv).toBeNull();
+    expect(Math.abs(breakeven.mean)).toBeLessThan(1e-9);
+  });
+
+  it('helper — computeCvObserved sample N-1, edge cases', () => {
+    expect(computeCvObserved([])).toEqual({ cv: null, mean: 0, std: 0 });
+    const single = computeCvObserved([100]);
+    expect(single.mean).toBe(100);
+    expect(single.std).toBe(0);
+    expect(single.cv).toBe(0);
+    expect(computeCvObserved([0]).cv).toBeNull();
+    expect(computeCvObserved([100, -100, 100, -100]).cv).toBeNull();
+  });
+
+  it('helper — groupTradesByDay filtra fora-janela e status != CLOSED', () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'OPEN' },
+      { date: '01/01/2026', result: 999, status: 'CLOSED' },
+      { date: '05/02/2026', result: 150, status: 'CLOSED' },
+      { date: '05/02/2026', result: 50, status: 'CLOSED' },
+    ];
+    const map = groupTradesByDay(trades, '2026-02-01', '2026-02-28');
+    expect(map.size).toBe(2);
+    expect(map.get('2026-02-02')).toBe(100);
+    expect(map.get('2026-02-05')).toBe(200);
+  });
+});

--- a/functions/__tests__/cycleConsistency/computeCVNormalized.test.js
+++ b/functions/__tests__/cycleConsistency/computeCVNormalized.test.js
@@ -36,7 +36,7 @@ const CALIB_TRADES = [
 
 describe('computeCVNormalized (CJS)', () => {
   it('C1 — janela vazia retorna null com insufficientReason min_days', () => {
-    const result = computeCVNormalized([], { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized([], { rrTarget: 3 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.cvObs).toBeNull();
     expect(result.cvExp).toBeNull();
@@ -52,13 +52,13 @@ describe('computeCVNormalized (CJS)', () => {
       { date: '04/02/2026', result: -50, status: 'CLOSED' },
       { date: '05/02/2026', result: 75, status: 'CLOSED' },
     ];
-    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized(trades, { rrTarget: 3 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(4);
     expect(result.insufficientReason).toBe('min_days');
   });
 
-  it('C3 — plan sem targetRR retorna null no_target_rr com label apropriado', () => {
+  it('C3 — plan sem rrTarget retorna null no_target_rr com label apropriado', () => {
     const result = computeCVNormalized(CALIB_TRADES, {}, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(10);
@@ -69,7 +69,7 @@ describe('computeCVNormalized (CJS)', () => {
   it('C4 — calibração spec issue body (7L+3G@3R, 10 dias) → cv_normalized ≈ 1.05 ± 0.05', () => {
     const result = computeCVNormalized(
       CALIB_TRADES,
-      { targetRR: 3 },
+      { rrTarget: 3 },
       '2026-02-01',
       '2026-02-28'
     );
@@ -92,7 +92,7 @@ describe('computeCVNormalized (CJS)', () => {
       { date: '05/02/2026', result: -50, status: 'CLOSED' },
       { date: '06/02/2026', result: -50, status: 'CLOSED' },
     ];
-    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized(trades, { rrTarget: 3 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(5);
     expect(result.insufficientReason).toBe('breakeven_plan');
@@ -108,7 +108,7 @@ describe('computeCVNormalized (CJS)', () => {
       { date: '06/02/2026', result: +1000, status: 'CLOSED' },
       { date: '09/02/2026', result: -1000, status: 'CLOSED' },
     ];
-    const result = computeCVNormalized(trades, { targetRR: 2 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized(trades, { rrTarget: 2 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(6);
     expect(result.insufficientReason).toBe('zero_obs_mean');
@@ -116,10 +116,10 @@ describe('computeCVNormalized (CJS)', () => {
     expect(result.label).toBe('P&L médio diário próximo de zero — CV indefinido');
   });
 
-  it('C7 — happy path: WR efetiva difere de plan.expectedWinRate, helper usa a efetiva', () => {
+  it('C7 — happy path: helper usa WR efetiva quando trades suficientes (ignora fallback breakeven)', () => {
     const result = computeCVNormalized(
       CALIB_TRADES,
-      { targetRR: 3, expectedWinRate: 0.50 },
+      { rrTarget: 3 },
       '2026-02-01',
       '2026-02-28'
     );
@@ -129,10 +129,12 @@ describe('computeCVNormalized (CJS)', () => {
     expect(result.value).toBeLessThan(1.10);
   });
 
-  it('C8 — fallback plan.expectedWinRate quando WR efetiva indefinida (resolveWinRate)', () => {
-    expect(resolveWinRate([], { expectedWinRate: 0.42 })).toBe(0.42);
-    expect(resolveWinRate([], {})).toBeNull();
+  it('C8 — fallback breakeven 1/(1+RR) quando WR efetiva indefinida (resolveWinRate)', () => {
+    expect(resolveWinRate([], 2)).toBeCloseTo(1 / 3, 10);
+    expect(resolveWinRate([], 1)).toBeCloseTo(0.5, 10);
+    expect(resolveWinRate([], 0)).toBeNull();
     expect(resolveWinRate([], null)).toBeNull();
+    expect(resolveWinRate([], undefined)).toBeNull();
 
     const trades = [
       { date: '02/02/2026', result: 100, status: 'CLOSED' },
@@ -140,7 +142,7 @@ describe('computeCVNormalized (CJS)', () => {
       { date: '02/02/2026', result: -50, status: 'CLOSED' },
       { date: '02/02/2026', result: -50, status: 'CLOSED' },
     ];
-    expect(resolveWinRate(trades, { expectedWinRate: 0.99 })).toBe(0.5);
+    expect(resolveWinRate(trades, 99)).toBe(0.5);
   });
 
   it('C9 — effectiveWinRate puro: 7L+3G → 0.3', () => {

--- a/functions/__tests__/cycleConsistency/computeCycleSharpe.test.js
+++ b/functions/__tests__/cycleConsistency/computeCycleSharpe.test.js
@@ -1,0 +1,179 @@
+/**
+ * computeCycleSharpe.test.js — issue #235 F1.1 (CJS mirror)
+ *
+ * Cobre os mesmos 8 cenários do espelho ESM, consumindo o módulo CJS
+ * via createRequire. Assertivas idênticas — qualquer divergência indica
+ * drift entre os dois lados do mirror.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  computeCycleSharpe,
+  groupTradesByDay,
+  dailyReturnsFromGroups,
+  meanStdSample,
+} = require('../../cycleConsistency/computeCycleSharpe');
+
+// ── Fixtures (cópia do espelho ESM — sincronia sob lock) ───────────────────
+
+const FEV_2026_TRADES = [
+  { date: '02/02/2026', result: 400, status: 'CLOSED' },
+  { date: '02/02/2026', result: 200, status: 'CLOSED' },
+  { date: '03/02/2026', result: -300, status: 'CLOSED' },
+  { date: '03/02/2026', result: -500, status: 'CLOSED' },
+  { date: '04/02/2026', result: 800, status: 'CLOSED' },
+  { date: '04/02/2026', result: 700, status: 'CLOSED' },
+  { date: '04/02/2026', result: 500, status: 'CLOSED' },
+  { date: '05/02/2026', result: 200, status: 'CLOSED' },
+  { date: '06/02/2026', result: -500, status: 'CLOSED' },
+  { date: '09/02/2026', result: 600, status: 'CLOSED' },
+  { date: '09/02/2026', result: 800, status: 'CLOSED' },
+  { date: '10/02/2026', result: 400, status: 'CLOSED' },
+  { date: '10/02/2026', result: 400, status: 'CLOSED' },
+  { date: '11/02/2026', result: -400, status: 'CLOSED' },
+];
+
+const SELIC_FEV_2026 = 14.75 / 252 / 100;
+
+const fakeSelic = (rate, source = 'BCB-SGS-11') =>
+  async () => ({ rateDaily: rate, source, isFallback: source === 'FALLBACK' });
+
+describe('computeCycleSharpe (CJS)', () => {
+  it('C1 — janela vazia retorna null com insufficientReason min_days', async () => {
+    const result = await computeCycleSharpe([], '2026-02-01', '2026-02-28', 100000, {
+      getSelicForDateFn: fakeSelic(SELIC_FEV_2026),
+    });
+    expect(result).toEqual({
+      value: null,
+      daysWithTrade: 0,
+      source: 'BCB',
+      insufficientReason: 'min_days',
+      fallbackUsed: false,
+    });
+  });
+
+  it('C2 — 4 dias com trade (< minDays=5) retorna null min_days', async () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '05/02/2026', result: 75, status: 'CLOSED' },
+    ];
+    const result = await computeCycleSharpe(trades, '2026-02-01', '2026-02-28', 100000, {
+      getSelicForDateFn: fakeSelic(SELIC_FEV_2026),
+    });
+    expect(result.value).toBeNull();
+    expect(result.insufficientReason).toBe('min_days');
+    expect(result.daysWithTrade).toBe(4);
+    expect(result.fallbackUsed).toBe(false);
+  });
+
+  it('C3 — FEV/2026 com Selic descontada → Sharpe ~5.75 (target 5.86 ± 0.5)', async () => {
+    const result = await computeCycleSharpe(
+      FEV_2026_TRADES,
+      '2026-02-01',
+      '2026-02-28',
+      100000,
+      { getSelicForDateFn: fakeSelic(SELIC_FEV_2026) }
+    );
+    expect(result.daysWithTrade).toBe(8);
+    expect(result.source).toBe('BCB');
+    expect(result.fallbackUsed).toBe(false);
+    expect(result.value).not.toBeNull();
+    expect(result.value).toBeGreaterThan(5.36);
+    expect(result.value).toBeLessThan(6.36);
+  });
+
+  it('C4 — FEV/2026 com rfr=0 → Sharpe ~6.70 (target 6.80 ± 0.5)', async () => {
+    const result = await computeCycleSharpe(
+      FEV_2026_TRADES,
+      '2026-02-01',
+      '2026-02-28',
+      100000,
+      { getSelicForDateFn: fakeSelic(0, 'BCB-SGS-11') }
+    );
+    expect(result.value).not.toBeNull();
+    expect(result.value).toBeGreaterThan(6.30);
+    expect(result.value).toBeLessThan(7.30);
+  });
+
+  it('C5 — variância zero (mesmo PL todo dia) retorna null zero_variance', async () => {
+    const trades = [
+      { date: '02/02/2026', result: 500, status: 'CLOSED' },
+      { date: '03/02/2026', result: 500, status: 'CLOSED' },
+      { date: '04/02/2026', result: 500, status: 'CLOSED' },
+      { date: '05/02/2026', result: 500, status: 'CLOSED' },
+      { date: '06/02/2026', result: 500, status: 'CLOSED' },
+    ];
+    const result = await computeCycleSharpe(trades, '2026-02-01', '2026-02-28', 100000, {
+      getSelicForDateFn: fakeSelic(SELIC_FEV_2026),
+    });
+    expect(result.value).toBeNull();
+    expect(result.insufficientReason).toBe('zero_variance');
+    expect(result.daysWithTrade).toBe(5);
+  });
+
+  it('C6 — multi-day fallback parcial → source MIXED, fallbackUsed true', async () => {
+    const mixedFn = async (dateIso) => {
+      const isFallback = dateIso === '2026-02-06' || dateIso === '2026-02-09';
+      return {
+        rateDaily: SELIC_FEV_2026,
+        source: isFallback ? 'FALLBACK' : 'BCB-SGS-11',
+        isFallback,
+      };
+    };
+    const result = await computeCycleSharpe(
+      FEV_2026_TRADES,
+      '2026-02-01',
+      '2026-02-28',
+      100000,
+      { getSelicForDateFn: mixedFn }
+    );
+    expect(result.source).toBe('MIXED');
+    expect(result.fallbackUsed).toBe(true);
+    expect(result.daysWithTrade).toBe(8);
+  });
+
+  it('C7 — groupTradesByDay filtra fora-janela e status != CLOSED', () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'OPEN' },
+      { date: '04/02/2026', result: 300, status: 'REVIEWED' },
+      { date: '01/01/2026', result: 999, status: 'CLOSED' },
+      { date: '01/03/2026', result: 999, status: 'CLOSED' },
+      { date: '05/02/2026', result: 150, status: 'CLOSED' },
+      { date: '05/02/2026', result: 50,  status: 'CLOSED' },
+      { date: 'lixo',       result: 100, status: 'CLOSED' },
+      { date: '06/02/2026', result: 'NaN', status: 'CLOSED' },
+    ];
+    const map = groupTradesByDay(trades, '2026-02-01', '2026-02-28');
+    expect(map.size).toBe(2);
+    expect(map.get('2026-02-02')).toBe(100);
+    expect(map.get('2026-02-05')).toBe(200);
+  });
+
+  it('C8 — meanStdSample com 1 item retorna std=0; agregações puras', () => {
+    expect(meanStdSample([])).toEqual({ mean: 0, std: 0 });
+    expect(meanStdSample([5])).toEqual({ mean: 5, std: 0 });
+    const r = meanStdSample([1, 2, 3, 4, 5]);
+    expect(r.mean).toBeCloseTo(3, 10);
+    expect(r.std).toBeCloseTo(Math.sqrt(2.5), 10);
+  });
+
+  it('helper — dailyReturnsFromGroups produz ordenação asc e divide por plStart', () => {
+    const map = new Map([
+      ['2026-02-05', 200],
+      ['2026-02-02', 600],
+      ['2026-02-03', -800],
+    ]);
+    const out = dailyReturnsFromGroups(map, 100000);
+    expect(out).toEqual([
+      { dateIso: '2026-02-02', dailyReturn: 0.006 },
+      { dateIso: '2026-02-03', dailyReturn: -0.008 },
+      { dateIso: '2026-02-05', dailyReturn: 0.002 },
+    ]);
+  });
+});

--- a/functions/__tests__/marketData/fetchSelicDaily.test.js
+++ b/functions/__tests__/marketData/fetchSelicDaily.test.js
@@ -1,0 +1,265 @@
+/**
+ * fetchSelicDaily.test.js — issue #235 F0.1
+ *
+ * Cobre 6 cenários:
+ *  1. Sucesso 1ª tentativa
+ *  2. Retry — 1ª e 2ª falham, 3ª sucesso
+ *  3. Todas falham → grava lastError, NÃO grava history, NÃO throw
+ *  4. Payload vazio (final de semana) → atualiza lastFetchedAt apenas
+ *  5. Idempotência — history já existe com source BCB-SGS-11
+ *  6. Schema lock — payload com campo extra não quebra
+ *
+ * Firestore stub: doc/collection com `set`, `get`, `batch` registrando
+ * em estruturas locais. Não depende de firebase-admin em runtime de teste.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { runFetchSelicDaily, parsePayload, brToIso } = require('../../marketData/fetchSelicDaily');
+
+// ── Firestore stub ──────────────────────────────────────────
+
+function createDbStub() {
+  const docs = new Map(); // path -> data
+
+  function makeDocRef(path) {
+    return {
+      path,
+      collection: (sub) => makeColRef(`${path}/${sub}`),
+      get: async () => {
+        const data = docs.get(path);
+        return {
+          exists: data !== undefined,
+          data: () => data,
+        };
+      },
+      set: async (data, opts = {}) => {
+        if (opts.merge) {
+          const prev = docs.get(path) ?? {};
+          docs.set(path, { ...prev, ...data });
+        } else {
+          docs.set(path, { ...data });
+        }
+      },
+    };
+  }
+  function makeColRef(path) {
+    return {
+      path,
+      doc: (id) => makeDocRef(`${path}/${id}`),
+    };
+  }
+
+  function makeBatch() {
+    const ops = [];
+    return {
+      set: (ref, data, opts = {}) => {
+        ops.push({ ref, data, opts });
+      },
+      commit: async () => {
+        for (const op of ops) {
+          await op.ref.set(op.data, op.opts);
+        }
+      },
+    };
+  }
+
+  return {
+    _docs: docs,
+    collection: (name) => makeColRef(name),
+    batch: makeBatch,
+  };
+}
+
+// ── Fetch mock helpers ──────────────────────────────────────
+
+const mockFetchOk = (payload) =>
+  vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  });
+
+const mockFetchFail = (status = 503) => ({
+  ok: false,
+  status,
+  json: async () => null,
+});
+
+// ── Setup comum ─────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-05-02T15:00:00Z'); // 12:00 BRT — alvo D-1 = 01/05/2026
+const TARGET_ISO = '2026-05-01';
+
+const baseDeps = (db, fetchFn, overrides = {}) => ({
+  db,
+  fetchFn,
+  now: () => FIXED_NOW,
+  attempts: 3,
+  backoffBase: 1, // backoff irrelevante via sleepFn
+  timeoutMs: 100,
+  sleepFn: async () => {},
+  timestamp: { now: () => 'TS' },
+  ...overrides,
+});
+
+describe('fetchSelicDaily — runFetchSelicDaily', () => {
+  let db;
+  beforeEach(() => {
+    db = createDbStub();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cenário 1: sucesso 1ª tentativa grava doc + history', async () => {
+    const fetchFn = mockFetchOk([{ data: '01/05/2026', valor: '0.04953' }]);
+    const result = await runFetchSelicDaily(baseDeps(db, fetchFn));
+
+    expect(result).toEqual({
+      ok: true,
+      status: 'written',
+      date: TARGET_ISO,
+      rateDaily: 0.0004953,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn.mock.calls[0][0]).toMatch(/dataInicial=01%2F05%2F2026/);
+
+    expect(db._docs.get(`systemConfig/selic/history/${TARGET_ISO}`)).toEqual({
+      date: TARGET_ISO,
+      rateDaily: 0.0004953,
+      source: 'BCB-SGS-11',
+      fetchedAt: 'TS',
+    });
+    expect(db._docs.get('systemConfig/selic')).toEqual({
+      lastDate: TARGET_ISO,
+      lastRate: 0.0004953,
+      lastFetchedAt: 'TS',
+      source: 'BCB-SGS-11',
+      lastError: null,
+    });
+  });
+
+  it('cenário 2: 1ª e 2ª falham com 503, 3ª sucesso → grava normal sem lastError', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(mockFetchFail(503))
+      .mockResolvedValueOnce(mockFetchFail(503))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => [{ data: '01/05/2026', valor: '0.04953' }],
+      });
+
+    const result = await runFetchSelicDaily(baseDeps(db, fetchFn));
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('written');
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(db._docs.get('systemConfig/selic').lastError).toBe(null);
+    expect(db._docs.has(`systemConfig/selic/history/${TARGET_ISO}`)).toBe(true);
+  });
+
+  it('cenário 3: 3 erros consecutivos gravam lastError, NÃO throw, NÃO grava history', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(mockFetchFail(500));
+
+    const result = await runFetchSelicDaily(baseDeps(db, fetchFn));
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe('error');
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    const doc = db._docs.get('systemConfig/selic');
+    expect(doc).toBeDefined();
+    expect(doc.lastError).toMatchObject({
+      code: 'http_500',
+      message: 'HTTP 500',
+      attemptedAt: 'TS',
+    });
+    expect(db._docs.has(`systemConfig/selic/history/${TARGET_ISO}`)).toBe(false);
+  });
+
+  it('cenário 4: payload vazio → não grava history, atualiza lastFetchedAt e zera lastError', async () => {
+    const fetchFn = mockFetchOk([]);
+    const result = await runFetchSelicDaily(baseDeps(db, fetchFn));
+
+    expect(result).toEqual({ ok: true, status: 'no_data' });
+    expect(db._docs.has(`systemConfig/selic/history/${TARGET_ISO}`)).toBe(false);
+    const doc = db._docs.get('systemConfig/selic');
+    expect(doc.lastFetchedAt).toBe('TS');
+    expect(doc.lastError).toBe(null);
+    expect(doc.source).toBe('BCB-SGS-11');
+    expect(doc.lastDate).toBeUndefined();
+  });
+
+  it('cenário 5: idempotente — history já existe com source BCB-SGS-11 pula escrita', async () => {
+    db._docs.set(`systemConfig/selic/history/${TARGET_ISO}`, {
+      date: TARGET_ISO,
+      rateDaily: 0.0004953,
+      source: 'BCB-SGS-11',
+      fetchedAt: 'PREV',
+    });
+
+    const fetchFn = mockFetchOk([{ data: '01/05/2026', valor: '0.04953' }]);
+    const result = await runFetchSelicDaily(baseDeps(db, fetchFn));
+
+    expect(result).toEqual({
+      ok: true,
+      status: 'skipped_idempotent',
+      date: TARGET_ISO,
+      rateDaily: 0.0004953,
+    });
+    // history não foi sobrescrito
+    expect(db._docs.get(`systemConfig/selic/history/${TARGET_ISO}`).fetchedAt).toBe('PREV');
+    // metadata atualizado
+    expect(db._docs.get('systemConfig/selic').lastFetchedAt).toBe('TS');
+  });
+
+  it('cenário 6: schema lock — payload com campo extra parseia normalmente', async () => {
+    const fetchFn = mockFetchOk([{ data: '01/05/2026', valor: '0.04953', foo: 'bar', extra: 42 }]);
+    const result = await runFetchSelicDaily(baseDeps(db, fetchFn));
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe('written');
+    expect(result.rateDaily).toBe(0.0004953);
+    // campo extra não vaza para o doc gravado
+    const hist = db._docs.get(`systemConfig/selic/history/${TARGET_ISO}`);
+    expect(hist).toEqual({
+      date: TARGET_ISO,
+      rateDaily: 0.0004953,
+      source: 'BCB-SGS-11',
+      fetchedAt: 'TS',
+    });
+    expect(hist.foo).toBeUndefined();
+  });
+});
+
+// ── Sanidade do parser ──────────────────────────────────────
+
+describe('fetchSelicDaily — parsePayload (sanity)', () => {
+  it('rejeita payload não-array', () => {
+    expect(parsePayload({ error: 'oops' })).toBeNull();
+    expect(parsePayload(null)).toBeNull();
+  });
+  it('rejeita item sem data ou valor', () => {
+    expect(parsePayload([{ data: '01/05/2026' }])).toBeNull();
+    expect(parsePayload([{ valor: '0.04' }])).toBeNull();
+  });
+  it('rejeita data malformada', () => {
+    expect(parsePayload([{ data: '2026-05-01', valor: '0.04' }])).toBeNull();
+  });
+  it('aceita campo extra', () => {
+    const out = parsePayload([{ data: '01/05/2026', valor: '0.04953', foo: 1 }]);
+    expect(out).toEqual([{ date: '2026-05-01', rateDaily: 0.0004953 }]);
+  });
+});
+
+describe('fetchSelicDaily — brToIso', () => {
+  it('converte DD/MM/YYYY → YYYY-MM-DD', () => {
+    expect(brToIso('01/05/2026')).toBe('2026-05-01');
+  });
+  it('rejeita formato inválido', () => {
+    expect(brToIso('2026-05-01')).toBeNull();
+    expect(brToIso('1/5/26')).toBeNull();
+  });
+});

--- a/functions/__tests__/marketData/getSelicForDate.test.js
+++ b/functions/__tests__/marketData/getSelicForDate.test.js
@@ -1,0 +1,237 @@
+/**
+ * getSelicForDate.test.js — issue #235 F0.3 (CJS mirror)
+ *
+ * Cobre os mesmos 7 cenários do espelho ESM, com stub Firestore admin
+ * (chained API: collection().doc().collection().where().orderBy().limit().get()).
+ *
+ *  C1 — exact hit
+ *  C2 — carry-forward 1 dia
+ *  C3 — carry-forward 5 dias (dentro do default 7)
+ *  C4 — gap > maxCarryForwardDays → fallback
+ *  C5 — coleção vazia → fallback
+ *  C6 — erro Firestore (.get() throw) → fallback + log
+ *  C7 — daysDiffIso atravessa virada de mês/ano sem drift
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  getSelicForDate,
+  daysDiffIso,
+  SELIC_FALLBACK_DAILY,
+} = require('../../marketData/getSelicForDate');
+
+// ── Firestore admin stub ────────────────────────────────────
+//
+// API admin (chained):
+//   db.collection('systemConfig').doc('selic').collection('history')
+//     .doc(date).get()                                  → DocumentSnapshot {exists, data()}
+//   .where(...).orderBy(...).limit(1).get()             → QuerySnapshot {empty, docs[]}
+
+function createAdminDbStub({ historyDocs = {}, queryRows = [], queryThrows = null } = {}) {
+  const docCalls = [];
+  const queryCalls = { where: [], orderBy: [], limit: [] };
+
+  const historyCol = {
+    doc: (id) => {
+      docCalls.push(id);
+      return {
+        get: async () => {
+          const data = historyDocs[id];
+          return {
+            exists: data !== undefined,
+            data: () => data,
+          };
+        },
+      };
+    },
+    where: (field, op, value) => {
+      queryCalls.where.push([field, op, value]);
+      return historyCol;
+    },
+    orderBy: (field, dir) => {
+      queryCalls.orderBy.push([field, dir]);
+      return historyCol;
+    },
+    limit: (n) => {
+      queryCalls.limit.push(n);
+      return historyCol;
+    },
+    get: async () => {
+      if (queryThrows) throw queryThrows;
+      return {
+        empty: queryRows.length === 0,
+        docs: queryRows.map((r) => ({ data: () => r })),
+      };
+    },
+  };
+
+  return {
+    _docCalls: docCalls,
+    _queryCalls: queryCalls,
+    collection: (name) => {
+      if (name !== 'systemConfig') throw new Error(`unexpected col ${name}`);
+      return {
+        doc: (id) => {
+          if (id !== 'selic') throw new Error(`unexpected doc ${id}`);
+          return {
+            collection: (sub) => {
+              if (sub !== 'history') throw new Error(`unexpected sub ${sub}`);
+              return historyCol;
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getSelicForDate (CJS)', () => {
+  it('C1 — exact hit retorna doc do dia sem carry-forward nem fallback', async () => {
+    const db = createAdminDbStub({
+      historyDocs: {
+        '2026-05-02': { date: '2026-05-02', rateDaily: 0.00052531, source: 'BCB-SGS-11' },
+      },
+    });
+
+    const result = await getSelicForDate('2026-05-02', { db });
+
+    expect(result).toEqual({
+      rateDaily: 0.00052531,
+      source: 'BCB-SGS-11',
+      dateUsed: '2026-05-02',
+      isCarryForward: false,
+      isFallback: false,
+    });
+    expect(db._docCalls).toEqual(['2026-05-02']);
+    // não chamou a query (where/orderBy/limit)
+    expect(db._queryCalls.where).toHaveLength(0);
+  });
+
+  it('C2 — sábado faz carry-forward para sexta (1 dia)', async () => {
+    const db = createAdminDbStub({
+      historyDocs: {}, // sábado não tem doc
+      queryRows: [{ date: '2026-05-01', rateDaily: 0.00052531, source: 'BCB-SGS-11' }],
+    });
+
+    const result = await getSelicForDate('2026-05-02', { db });
+
+    expect(result).toEqual({
+      rateDaily: 0.00052531,
+      source: 'BCB-SGS-11',
+      dateUsed: '2026-05-01',
+      isCarryForward: true,
+      isFallback: false,
+    });
+    expect(db._queryCalls.where).toEqual([['date', '<=', '2026-05-02']]);
+    expect(db._queryCalls.orderBy).toEqual([['date', 'desc']]);
+    expect(db._queryCalls.limit).toEqual([1]);
+  });
+
+  it('C3 — gap de 5 dias dentro do default (7) → carry-forward', async () => {
+    const db = createAdminDbStub({
+      queryRows: [{ date: '2026-04-25', rateDaily: 0.00052531, source: 'BCB-SGS-11' }],
+    });
+
+    const result = await getSelicForDate('2026-04-30', { db });
+
+    expect(result.isCarryForward).toBe(true);
+    expect(result.isFallback).toBe(false);
+    expect(result.dateUsed).toBe('2026-04-25');
+  });
+
+  it('C4 — gap > maxCarryForwardDays → fallback', async () => {
+    const db = createAdminDbStub({
+      queryRows: [{ date: '2026-04-01', rateDaily: 0.00052531, source: 'BCB-SGS-11' }],
+    });
+
+    const result = await getSelicForDate('2026-04-30', { db });
+
+    expect(result).toEqual({
+      rateDaily: SELIC_FALLBACK_DAILY,
+      source: 'FALLBACK',
+      dateUsed: null,
+      isCarryForward: false,
+      isFallback: true,
+    });
+  });
+
+  it('C4b — limite customizado: maxCarryForwardDays=2 com gap=3 → fallback', async () => {
+    const db = createAdminDbStub({
+      queryRows: [{ date: '2026-04-27', rateDaily: 0.00052531, source: 'BCB-SGS-11' }],
+    });
+
+    const result = await getSelicForDate('2026-04-30', { db, maxCarryForwardDays: 2 });
+
+    expect(result.isFallback).toBe(true);
+  });
+
+  it('C5 — coleção vazia → fallback', async () => {
+    const db = createAdminDbStub({ queryRows: [] });
+
+    const result = await getSelicForDate('2026-05-02', { db });
+
+    expect(result).toEqual({
+      rateDaily: SELIC_FALLBACK_DAILY,
+      source: 'FALLBACK',
+      dateUsed: null,
+      isCarryForward: false,
+      isFallback: true,
+    });
+  });
+
+  it('C6 — .get() da query throw → fallback + log estruturado, NUNCA throw', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const fsErr = Object.assign(new Error('UNAVAILABLE'), { code: 'unavailable' });
+    const db = createAdminDbStub({ queryThrows: fsErr });
+
+    const result = await getSelicForDate('2026-05-02', { db });
+
+    expect(result.isFallback).toBe(true);
+    expect(result.source).toBe('FALLBACK');
+    expect(result.rateDaily).toBe(SELIC_FALLBACK_DAILY);
+    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy.mock.calls[0][0]).toMatch(/getSelicForDate/);
+    expect(errSpy.mock.calls[0][0]).toMatch(/unavailable/);
+    errSpy.mockRestore();
+  });
+
+  it('C6b — fallbackRateDaily customizado é respeitado', async () => {
+    const db = createAdminDbStub({ queryRows: [] });
+
+    const result = await getSelicForDate('2026-05-02', { db, fallbackRateDaily: 0.0009 });
+
+    expect(result.rateDaily).toBe(0.0009);
+    expect(result.isFallback).toBe(true);
+  });
+
+  it('C7 — daysDiffIso sem timezone drift (atravessa mês e ano)', () => {
+    expect(daysDiffIso('2026-03-01', '2026-02-28')).toBe(1);
+    expect(daysDiffIso('2024-03-01', '2024-02-28')).toBe(2);
+    expect(daysDiffIso('2026-01-01', '2025-12-31')).toBe(1);
+    expect(daysDiffIso('2026-05-02', '2026-05-01')).toBe(1);
+    expect(daysDiffIso('2026-05-02', '2026-05-02')).toBe(0);
+    expect(daysDiffIso('2026-04-01', '2026-04-30')).toBe(-29);
+  });
+
+  it('C8 — exact hit existe mas dado vazio: usa schema gravado tal qual', async () => {
+    // garante que extraímos rateDaily/source do data() sem fallback espúrio
+    const db = createAdminDbStub({
+      historyDocs: {
+        '2026-05-02': { date: '2026-05-02', rateDaily: 0.0006, source: 'BCB-SGS-11' },
+      },
+    });
+
+    const result = await getSelicForDate('2026-05-02', { db });
+
+    expect(result.rateDaily).toBe(0.0006);
+    expect(result.source).toBe('BCB-SGS-11');
+    expect(result.isFallback).toBe(false);
+  });
+});

--- a/functions/__tests__/scripts/issue-235-bootstrap-selic-history.test.js
+++ b/functions/__tests__/scripts/issue-235-bootstrap-selic-history.test.js
@@ -1,0 +1,515 @@
+/**
+ * issue-235-bootstrap-selic-history.test.js — issue #235 F0.2
+ *
+ * Cobre 5 cenários (A..E) + sanity das funções puras:
+ *   A — parsePayload BCB SGS-11 válido (1 e múltiplos itens, campo extra)
+ *   B — chunkBatch divide N=1234 em 3 batches (500/500/234)
+ *   C — iterateDateRange("2024-01-01", "2024-01-05") retorna 5 datas
+ *   D — dry-run com 10 fetched, 3 já existentes → would_write=7, skipped=3
+ *   E — execute com erro de batch → registra em errors[], continua subsequentes
+ *
+ * O script bootstrap é ESM (.mjs); importado direto via import nativo do
+ * Vitest (não precisa createRequire).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  parsePayload,
+  chunkBatch,
+  iterateDateRange,
+  chunkDateRange,
+  brToIso,
+  isoToBr,
+  runBootstrap,
+  SOURCE,
+} from '../../../scripts/issue-235-bootstrap-selic-history.mjs';
+
+// ── Firestore stub ──────────────────────────────────────────
+
+function createDbStub({ existingHistoryDates = [], commitFailures = [] } = {}) {
+  const docs = new Map();
+  for (const d of existingHistoryDates) {
+    docs.set(`systemConfig/selic/history/${d}`, {
+      date: d,
+      rateDaily: 0.0001,
+      source: SOURCE,
+      fetchedAt: 'PREV',
+    });
+  }
+  let commitCallCount = 0;
+
+  function makeDocRef(path) {
+    return {
+      path,
+      collection: (sub) => makeColRef(`${path}/${sub}`),
+      get: async () => {
+        const data = docs.get(path);
+        return { exists: data !== undefined, data: () => data };
+      },
+      set: async (data, opts = {}) => {
+        if (opts.merge) {
+          const prev = docs.get(path) ?? {};
+          docs.set(path, { ...prev, ...data });
+        } else {
+          docs.set(path, { ...data });
+        }
+      },
+    };
+  }
+  function makeColRef(path) {
+    return { path, doc: (id) => makeDocRef(`${path}/${id}`) };
+  }
+  function makeBatch() {
+    const ops = [];
+    return {
+      set: (ref, data, opts = {}) => ops.push({ ref, data, opts }),
+      commit: async () => {
+        const idx = commitCallCount++;
+        if (commitFailures.includes(idx)) {
+          const err = new Error(`simulated batch failure #${idx}`);
+          err.code = 'commit_fail';
+          throw err;
+        }
+        for (const op of ops) await op.ref.set(op.data, op.opts);
+      },
+    };
+  }
+
+  return {
+    _docs: docs,
+    _commitCallCount: () => commitCallCount,
+    collection: (name) => makeColRef(name),
+    batch: makeBatch,
+  };
+}
+
+const mockFetchOk = (payload) =>
+  vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  });
+
+const buildBrItems = (isoDates, valor = '0.04953') =>
+  isoDates.map((iso) => ({ data: isoToBr(iso), valor }));
+
+// ── A — parsePayload BCB SGS-11 válido ──────────────────────
+
+describe('Cenário A — parsePayload BCB SGS-11 válido', () => {
+  it('parseia 1 item simples', () => {
+    expect(parsePayload([{ data: '01/05/2026', valor: '0.04953' }])).toEqual([
+      { date: '2026-05-01', rateDaily: 0.0004953 },
+    ]);
+  });
+
+  it('parseia múltiplos itens preservando ordem', () => {
+    const out = parsePayload([
+      { data: '01/05/2026', valor: '0.04953' },
+      { data: '02/05/2026', valor: '0.05000' },
+      { data: '05/05/2026', valor: '0.04500' },
+    ]);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toEqual({ date: '2026-05-01', rateDaily: 0.0004953 });
+    expect(out[1]).toEqual({ date: '2026-05-02', rateDaily: 0.0005 });
+    expect(out[2].date).toBe('2026-05-05');
+    expect(out[2].rateDaily).toBeCloseTo(0.00045, 10);
+  });
+
+  it('aceita campo extra sem vazar para o output', () => {
+    const out = parsePayload([{ data: '01/05/2026', valor: '0.04953', foo: 1, extra: 'bar' }]);
+    expect(out).toEqual([{ date: '2026-05-01', rateDaily: 0.0004953 }]);
+    expect(out[0]).not.toHaveProperty('foo');
+  });
+
+  it('retorna [] quando payload BCB é vazio (fim de semana)', () => {
+    expect(parsePayload([])).toEqual([]);
+  });
+
+  it('rejeita payload com schema inválido', () => {
+    expect(parsePayload(null)).toBeNull();
+    expect(parsePayload({ error: 'oops' })).toBeNull();
+    expect(parsePayload([{ data: '01/05/2026' }])).toBeNull();
+    expect(parsePayload([{ valor: '0.04' }])).toBeNull();
+    expect(parsePayload([{ data: '2026-05-01', valor: '0.04' }])).toBeNull();
+    expect(parsePayload([{ data: '01/05/2026', valor: 'NaN-text' }])).toBeNull();
+  });
+});
+
+// ── B — chunkBatch ──────────────────────────────────────────
+
+describe('Cenário B — chunkBatch divide N=1234 em 3 batches (500/500/234)', () => {
+  it('divide 1234 itens em [500, 500, 234] com size=500', () => {
+    const arr = Array.from({ length: 1234 }, (_, i) => i);
+    const chunks = chunkBatch(arr, 500);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toHaveLength(500);
+    expect(chunks[1]).toHaveLength(500);
+    expect(chunks[2]).toHaveLength(234);
+    // Cobertura completa, sem duplicação.
+    expect(chunks.flat()).toEqual(arr);
+  });
+
+  it('lida com array vazio', () => {
+    expect(chunkBatch([], 500)).toEqual([]);
+  });
+
+  it('lida com array menor que size', () => {
+    expect(chunkBatch([1, 2, 3], 500)).toEqual([[1, 2, 3]]);
+  });
+
+  it('rejeita argumentos inválidos', () => {
+    expect(() => chunkBatch('nope', 500)).toThrow(TypeError);
+    expect(() => chunkBatch([1], 0)).toThrow(RangeError);
+    expect(() => chunkBatch([1], -1)).toThrow(RangeError);
+    expect(() => chunkBatch([1], 1.5)).toThrow(RangeError);
+  });
+});
+
+// ── C — iterateDateRange ────────────────────────────────────
+
+describe('Cenário C — iterateDateRange("2024-01-01", "2024-01-05") retorna 5 datas', () => {
+  it('inclusivo nas duas pontas, 5 dias consecutivos', () => {
+    expect(iterateDateRange('2024-01-01', '2024-01-05')).toEqual([
+      '2024-01-01',
+      '2024-01-02',
+      '2024-01-03',
+      '2024-01-04',
+      '2024-01-05',
+    ]);
+  });
+
+  it('mesmo dia → 1 entrada', () => {
+    expect(iterateDateRange('2024-03-15', '2024-03-15')).toEqual(['2024-03-15']);
+  });
+
+  it('atravessa virada de mês', () => {
+    expect(iterateDateRange('2024-01-30', '2024-02-02')).toEqual([
+      '2024-01-30',
+      '2024-01-31',
+      '2024-02-01',
+      '2024-02-02',
+    ]);
+  });
+
+  it('atravessa ano bissexto (29/02/2024)', () => {
+    expect(iterateDateRange('2024-02-28', '2024-03-01')).toEqual([
+      '2024-02-28',
+      '2024-02-29',
+      '2024-03-01',
+    ]);
+  });
+
+  it('from > to retorna []', () => {
+    expect(iterateDateRange('2024-12-31', '2024-01-01')).toEqual([]);
+  });
+
+  it('rejeita ISO mal formado', () => {
+    expect(() => iterateDateRange('2024-1-1', '2024-01-05')).toThrow(RangeError);
+    expect(() => iterateDateRange('not-a-date', '2024-01-05')).toThrow(RangeError);
+  });
+});
+
+describe('chunkDateRange — divide janela em sub-janelas de até 365 dias', () => {
+  it('janela curta cabe em 1 chunk', () => {
+    const r = chunkDateRange('2024-01-01', '2024-01-05');
+    expect(r).toEqual([{ from: '2024-01-01', to: '2024-01-05' }]);
+  });
+
+  it('janela > 365 dias é dividida', () => {
+    const r = chunkDateRange('2024-01-01', '2025-12-31', 365);
+    expect(r.length).toBeGreaterThanOrEqual(2);
+    // O primeiro chunk começa no from original
+    expect(r[0].from).toBe('2024-01-01');
+    // O último chunk termina no to original
+    expect(r[r.length - 1].to).toBe('2025-12-31');
+  });
+});
+
+// ── D — Dry-run idempotente: 10 fetched, 3 existentes ───────
+
+describe('Cenário D — dry-run com 10 fetched, 3 existentes → would_write=7, skipped=3', () => {
+  it('conta corretamente sem gravar', async () => {
+    const dates = [
+      '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05', '2024-01-08',
+      '2024-01-09', '2024-01-10', '2024-01-11', '2024-01-12', '2024-01-15',
+    ];
+    const existing = ['2024-01-03', '2024-01-08', '2024-01-12'];
+
+    const db = createDbStub({ existingHistoryDates: existing });
+    const fetchFn = mockFetchOk(buildBrItems(dates));
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-02',
+      to: '2024-01-15',
+      mode: 'dryrun',
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.mode).toBe('dryrun');
+    expect(summary.fetched_count).toBe(10);
+    expect(summary.skipped).toBe(3);
+    expect(summary.would_write).toBe(7);
+    expect(summary).not.toHaveProperty('wrote');
+    expect(summary.errors).toEqual([]);
+
+    // Nenhum doc novo gravado — só os 3 pré-existentes.
+    expect(db._commitCallCount()).toBe(0);
+    const newWrites = [...db._docs.keys()].filter(
+      (k) => k.startsWith('systemConfig/selic/history/') && !existing.includes(k.split('/').pop())
+    );
+    expect(newWrites).toEqual([]);
+    // Parent doc não foi tocado.
+    expect(db._docs.has('systemConfig/selic')).toBe(false);
+  });
+
+  it('idempotência: rodar dry-run após execute completa → would_write=0, skipped=N', async () => {
+    const dates = ['2024-01-02', '2024-01-03', '2024-01-04'];
+    const db = createDbStub({ existingHistoryDates: dates });
+    const fetchFn = mockFetchOk(buildBrItems(dates));
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-02',
+      to: '2024-01-04',
+      mode: 'dryrun',
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.would_write).toBe(0);
+    expect(summary.skipped).toBe(3);
+  });
+});
+
+// ── E — Execute com batch error ─────────────────────────────
+
+describe('Cenário E — execute com erro de batch registra em errors[] e continua', () => {
+  it('1ª batch falha, 2ª e 3ª commitam; errors[] tem 1 entrada', async () => {
+    // 10 itens, batchSize=4 → 3 batches (4/4/2). Falhar o batch idx=0.
+    const dates = [
+      '2024-02-01', '2024-02-02', '2024-02-05', '2024-02-06',
+      '2024-02-07', '2024-02-08', '2024-02-09', '2024-02-12',
+      '2024-02-13', '2024-02-14',
+    ];
+    const db = createDbStub({ commitFailures: [0] });
+    const fetchFn = mockFetchOk(buildBrItems(dates));
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-02-01',
+      to: '2024-02-14',
+      mode: 'execute',
+      batchSize: 4,
+      timestamp: { now: () => 'TS' },
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    // Função NÃO joga; retorna summary com errors.
+    expect(summary.mode).toBe('execute');
+    expect(summary.fetched_count).toBe(10);
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0].phase).toBe('commit');
+    expect(summary.errors[0].batch).toBe(1);
+    expect(summary.errors[0].size).toBe(4);
+    expect(summary.errors[0].code).toBe('commit_fail');
+
+    // Batches 2 e 3 commitaram: 4 + 2 = 6 docs gravados.
+    expect(summary.wrote).toBe(6);
+
+    // Parent doc atualizado com a maior data efetivamente gravada.
+    const parent = db._docs.get('systemConfig/selic');
+    expect(parent).toBeDefined();
+    expect(parent.source).toBe(SOURCE);
+    expect(parent.lastError).toBeNull();
+    expect(parent.lastDate).toBe('2024-02-14');
+  });
+
+  it('falha em todos os batches → wrote=0 e parent doc NÃO é atualizado', async () => {
+    const dates = ['2024-03-01', '2024-03-04'];
+    const db = createDbStub({ commitFailures: [0] });
+    const fetchFn = mockFetchOk(buildBrItems(dates));
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-03-01',
+      to: '2024-03-04',
+      mode: 'execute',
+      batchSize: 500,
+      timestamp: { now: () => 'TS' },
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.wrote).toBe(0);
+    expect(summary.errors).toHaveLength(1);
+    expect(db._docs.has('systemConfig/selic')).toBe(false);
+  });
+
+  it('execute sucesso completo grava history + parent {lastDate, lastRate}', async () => {
+    const dates = ['2024-01-02', '2024-01-03', '2024-01-04'];
+    const db = createDbStub();
+    const fetchFn = mockFetchOk(buildBrItems(dates, '0.05000'));
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-02',
+      to: '2024-01-04',
+      mode: 'execute',
+      batchSize: 500,
+      timestamp: { now: () => 'TS' },
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.wrote).toBe(3);
+    expect(summary.errors).toEqual([]);
+
+    // Schema 1:1 com a CF.
+    expect(db._docs.get('systemConfig/selic/history/2024-01-02')).toEqual({
+      date: '2024-01-02',
+      rateDaily: 0.0005,
+      source: SOURCE,
+      fetchedAt: 'TS',
+    });
+
+    // Parent: lastDate = max(dates), lastRate = 0.0005, lastError = null.
+    expect(db._docs.get('systemConfig/selic')).toEqual({
+      lastDate: '2024-01-04',
+      lastRate: 0.0005,
+      lastFetchedAt: 'TS',
+      source: SOURCE,
+      lastError: null,
+    });
+  });
+
+  it('NÃO regride lastDate quando bootstrap roda sobre janela antiga', async () => {
+    // Parent doc já tem lastDate=2026-05-01. Bootstrap roda em 2024-01.
+    const db = createDbStub();
+    db._docs.set('systemConfig/selic', {
+      lastDate: '2026-05-01',
+      lastRate: 0.0006,
+      source: SOURCE,
+      lastError: null,
+    });
+
+    const dates = ['2024-01-02', '2024-01-03'];
+    const fetchFn = mockFetchOk(buildBrItems(dates));
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-02',
+      to: '2024-01-03',
+      mode: 'execute',
+      batchSize: 500,
+      timestamp: { now: () => 'TS' },
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.wrote).toBe(2);
+    // Parent permanece com lastDate=2026-05-01 (não regride).
+    const parent = db._docs.get('systemConfig/selic');
+    expect(parent.lastDate).toBe('2026-05-01');
+    expect(parent.lastRate).toBe(0.0006);
+    // History foi gravado normalmente.
+    expect(db._docs.has('systemConfig/selic/history/2024-01-02')).toBe(true);
+    expect(db._docs.has('systemConfig/selic/history/2024-01-03')).toBe(true);
+  });
+});
+
+// ── Sanity das funções de data ──────────────────────────────
+
+describe('brToIso / isoToBr', () => {
+  it('brToIso converte DD/MM/YYYY → YYYY-MM-DD', () => {
+    expect(brToIso('01/05/2026')).toBe('2026-05-01');
+    expect(brToIso('29/02/2024')).toBe('2024-02-29');
+  });
+
+  it('brToIso rejeita formato inválido', () => {
+    expect(brToIso('2026-05-01')).toBeNull();
+    expect(brToIso('1/5/26')).toBeNull();
+  });
+
+  it('isoToBr converte YYYY-MM-DD → DD/MM/YYYY', () => {
+    expect(isoToBr('2026-05-01')).toBe('01/05/2026');
+    expect(isoToBr('2024-02-29')).toBe('29/02/2024');
+  });
+
+  it('isoToBr rejeita formato inválido', () => {
+    expect(isoToBr('01/05/2026')).toBeNull();
+    expect(isoToBr('not-a-date')).toBeNull();
+  });
+
+  it('roundtrip BR↔ISO preserva dados', () => {
+    expect(brToIso(isoToBr('2024-07-15'))).toBe('2024-07-15');
+    expect(isoToBr(brToIso('15/07/2024'))).toBe('15/07/2024');
+  });
+});
+
+// ── Sanity da contract: payload vazio no fetch ──────────────
+
+describe('runBootstrap — payload vazio retorna fetched_count=0', () => {
+  it('dry-run sobre janela sem dados (fim de semana puro) → would_write=0', async () => {
+    const db = createDbStub();
+    const fetchFn = mockFetchOk([]);
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-06',
+      to: '2024-01-07',
+      mode: 'dryrun',
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.fetched_count).toBe(0);
+    expect(summary.would_write).toBe(0);
+    expect(summary.skipped).toBe(0);
+    expect(summary.errors).toEqual([]);
+  });
+
+  it('schema inválido vira erro phase=parse', async () => {
+    const db = createDbStub();
+    const fetchFn = mockFetchOk({ error: 'service unavailable' });
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-02',
+      to: '2024-01-05',
+      mode: 'dryrun',
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.fetched_count).toBe(0);
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0].phase).toBe('parse');
+    expect(summary.errors[0].code).toBe('bad_schema');
+  });
+
+  it('HTTP 5xx vira erro phase=fetch', async () => {
+    const db = createDbStub();
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => null,
+    });
+
+    const summary = await runBootstrap({
+      db,
+      fetchFn,
+      from: '2024-01-02',
+      to: '2024-01-05',
+      mode: 'dryrun',
+      now: () => new Date('2026-05-02T15:00:00Z'),
+    });
+
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0].phase).toBe('fetch');
+    expect(summary.errors[0].code).toBe('http_503');
+  });
+});

--- a/functions/cycleConsistency/computeAvgExcursion.js
+++ b/functions/cycleConsistency/computeAvgExcursion.js
@@ -1,0 +1,146 @@
+// ============================================
+// CYCLE CONSISTENCY — Cloud Functions copy
+// ============================================
+//
+// ⚠️ ESPELHO de src/utils/cycleConsistency/computeAvgExcursion.js — MANTER SINCRONIZADO ⚠️
+// Qualquer alteração aqui replica em src/, e vice-versa (#119/#191).
+//
+// MEP médio (Máxima Excursão Positiva) e MEN médio (Máxima Excursão Negativa)
+// em % por entry, agregados sobre os trades CLOSED dentro do ciclo.
+//
+// Algoritmo (memória de cálculo, body do issue #235 §3):
+//
+//   Para cada trade t com mepPrice/menPrice != null && entry > 0:
+//     Se LONG:
+//       mepPct_t = ((t.mepPrice - t.entry) / t.entry) × 100
+//       menPct_t = ((t.menPrice - t.entry) / t.entry) × 100
+//     Se SHORT:
+//       mepPct_t = ((t.entry - t.mepPrice) / t.entry) × 100
+//       menPct_t = ((t.entry - t.menPrice) / t.entry) × 100
+//
+//   avgMEP   = mean(mepPct_t) sobre trades com dado disponível
+//   avgMEN   = mean(menPct_t) sobre trades com dado disponível
+//   coverage = N_with_mep_men / N_total_trades_in_cycle
+//
+// Coverage display: se `coverage < coverageThreshold` (default 0.7), exibir
+// `⚠ MEP/MEN em N de M trades` (transparência de amostra).
+//
+// Função pura: zero Firestore, zero I/O.
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+function parseDateToIso(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  const m = BR_DATE_RE.exec(value);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return null;
+}
+
+function excursionPctForTrade(trade) {
+  if (!trade) return null;
+
+  const entry = typeof trade.entry === 'number' ? trade.entry : Number(trade.entry);
+  if (!Number.isFinite(entry) || entry <= 0) return null;
+
+  const mep = typeof trade.mepPrice === 'number' ? trade.mepPrice : Number(trade.mepPrice);
+  const men = typeof trade.menPrice === 'number' ? trade.menPrice : Number(trade.menPrice);
+  if (trade.mepPrice == null || trade.menPrice == null) return null;
+  if (!Number.isFinite(mep) || !Number.isFinite(men)) return null;
+
+  if (trade.side === 'LONG') {
+    return {
+      mepPct: ((mep - entry) / entry) * 100,
+      menPct: ((men - entry) / entry) * 100,
+    };
+  }
+  if (trade.side === 'SHORT') {
+    return {
+      mepPct: ((entry - mep) / entry) * 100,
+      menPct: ((entry - men) / entry) * 100,
+    };
+  }
+  return null;
+}
+
+/**
+ * MEP/MEN médio per-ciclo. Pure function — zero Firestore.
+ *
+ * @param {Array<{date:string,status:string,side:string,entry:number,mepPrice:number|null,menPrice:number|null}>} trades
+ * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
+ * @param {Object} [opts]
+ * @param {number} [opts.coverageThreshold=0.7]
+ */
+function computeAvgExcursion(trades, cycleStart, cycleEnd, opts = {}) {
+  const coverageThreshold =
+    typeof opts.coverageThreshold === 'number' ? opts.coverageThreshold : 0.7;
+
+  const inWindow = [];
+  if (Array.isArray(trades)) {
+    for (const t of trades) {
+      if (!t || t.status !== 'CLOSED') continue;
+      const iso = parseDateToIso(t.date);
+      if (iso === null) continue;
+      if (iso < cycleStart || iso > cycleEnd) continue;
+      inWindow.push(t);
+    }
+  }
+
+  const totalTrades = inWindow.length;
+  if (totalTrades === 0) {
+    return {
+      avgMEP: null,
+      avgMEN: null,
+      coverage: 0,
+      coverageBelowThreshold: false,
+      totalTrades: 0,
+      tradesWithData: 0,
+      insufficientReason: 'no_trades',
+    };
+  }
+
+  let sumMep = 0;
+  let sumMen = 0;
+  let tradesWithData = 0;
+  for (const t of inWindow) {
+    const pct = excursionPctForTrade(t);
+    if (pct === null) continue;
+    sumMep += pct.mepPct;
+    sumMen += pct.menPct;
+    tradesWithData += 1;
+  }
+
+  if (tradesWithData === 0) {
+    return {
+      avgMEP: null,
+      avgMEN: null,
+      coverage: 0,
+      coverageBelowThreshold: true,
+      coverageLabel: `⚠ MEP/MEN em 0 de ${totalTrades} trades`,
+      totalTrades,
+      tradesWithData: 0,
+      insufficientReason: 'no_excursion_data',
+    };
+  }
+
+  const coverage = tradesWithData / totalTrades;
+  const coverageBelowThreshold = coverage < coverageThreshold;
+  const result = {
+    avgMEP: sumMep / tradesWithData,
+    avgMEN: sumMen / tradesWithData,
+    coverage,
+    coverageBelowThreshold,
+    totalTrades,
+    tradesWithData,
+  };
+  if (coverageBelowThreshold) {
+    result.coverageLabel = `⚠ MEP/MEN em ${tradesWithData} de ${totalTrades} trades`;
+  }
+  return result;
+}
+
+module.exports = computeAvgExcursion;
+module.exports.computeAvgExcursion = computeAvgExcursion;
+module.exports.excursionPctForTrade = excursionPctForTrade;

--- a/functions/cycleConsistency/computeCVNormalized.js
+++ b/functions/cycleConsistency/computeCVNormalized.js
@@ -16,7 +16,7 @@
 //   cv_obs   = std_obs / |mean_obs|                          (null se mean_obs ≈ 0)
 //
 //   ── CV esperado pelo plano (analítico) ──
-//   p        = WR efetiva no ciclo (fallback plan.expectedWinRate)
+//   p        = WR efetiva no ciclo (fallback breakeven 1/(1+RR) quando insuficiente)
 //   RR       = plan.targetRR
 //   mean_exp = p × RR − (1 − p)                              [unidades de R]
 //   var_exp  = p × (RR − mean_exp)² + (1 − p) × (−1 − mean_exp)²
@@ -106,11 +106,12 @@ function computeCvExpected(p, RR) {
   return { cv: std / Math.abs(mean), mean, std };
 }
 
-function resolveWinRate(trades, plan) {
+function resolveWinRate(trades, rrTarget) {
   const fromTrades = effectiveWinRate(trades);
   if (fromTrades !== null) return fromTrades;
-  const fallback = plan && plan.expectedWinRate;
-  if (typeof fallback === 'number' && Number.isFinite(fallback)) return fallback;
+  if (typeof rrTarget === 'number' && Number.isFinite(rrTarget) && rrTarget > 0) {
+    return 1 / (1 + rrTarget);
+  }
   return null;
 }
 
@@ -118,7 +119,7 @@ function resolveWinRate(trades, plan) {
  * CV normalizado per-ciclo. Pure function — zero Firestore.
  *
  * @param {Array<{date:string,result:number,status:string}>} trades
- * @param {{targetRR:number, expectedWinRate?:number}} plan
+ * @param {{rrTarget:number}} plan — campo canônico é `rrTarget` (ver PlanManagementModal)
  * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
  * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
  * @param {Object} [opts]
@@ -141,8 +142,8 @@ function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {}) {
     };
   }
 
-  const targetRR = plan && plan.targetRR;
-  if (typeof targetRR !== 'number' || !Number.isFinite(targetRR) || targetRR <= 0) {
+  const rrTarget = plan && plan.rrTarget;
+  if (typeof rrTarget !== 'number' || !Number.isFinite(rrTarget) || rrTarget <= 0) {
     return {
       value: null,
       cvObs: null,
@@ -163,7 +164,7 @@ function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {}) {
     inWindowTrades.push(t);
   }
 
-  const p = resolveWinRate(inWindowTrades, plan);
+  const p = resolveWinRate(inWindowTrades, rrTarget);
   if (p === null) {
     return {
       value: null,
@@ -175,7 +176,7 @@ function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {}) {
     };
   }
 
-  const exp = computeCvExpected(p, targetRR);
+  const exp = computeCvExpected(p, rrTarget);
   if (exp.cv === null) {
     return {
       value: null,

--- a/functions/cycleConsistency/computeCVNormalized.js
+++ b/functions/cycleConsistency/computeCVNormalized.js
@@ -17,7 +17,7 @@
 //
 //   ── CV esperado pelo plano (analítico) ──
 //   p        = WR efetiva no ciclo (fallback breakeven 1/(1+RR) quando insuficiente)
-//   RR       = plan.targetRR
+//   RR       = plan.rrTarget
 //   mean_exp = p × RR − (1 − p)                              [unidades de R]
 //   var_exp  = p × (RR − mean_exp)² + (1 − p) × (−1 − mean_exp)²
 //   std_exp  = sqrt(var_exp)

--- a/functions/cycleConsistency/computeCVNormalized.js
+++ b/functions/cycleConsistency/computeCVNormalized.js
@@ -1,0 +1,217 @@
+// ============================================
+// CYCLE CONSISTENCY — Cloud Functions copy
+// ============================================
+//
+// ⚠️ ESPELHO de src/utils/cycleConsistency/computeCVNormalized.js — MANTER SINCRONIZADO ⚠️
+// Qualquer alteração aqui replica em src/, e vice-versa (#119/#191).
+//
+// CV normalizado per-ciclo: razão entre variabilidade observada do P&L
+// diário e variabilidade teórica esperada pelo plano (RR + WR).
+//
+// Algoritmo (memória de cálculo, body do issue #235 §2):
+//
+//   ── CV observado (sobre P&L diário do ciclo) ──
+//   mean_obs = Σ pl_dia / N
+//   std_obs  = sqrt( Σ (pl_dia - mean_obs)² / (N - 1) )      [amostral, Bessel]
+//   cv_obs   = std_obs / |mean_obs|                          (null se mean_obs ≈ 0)
+//
+//   ── CV esperado pelo plano (analítico) ──
+//   p        = WR efetiva no ciclo (fallback plan.expectedWinRate)
+//   RR       = plan.targetRR
+//   mean_exp = p × RR − (1 − p)                              [unidades de R]
+//   var_exp  = p × (RR − mean_exp)² + (1 − p) × (−1 − mean_exp)²
+//   std_exp  = sqrt(var_exp)
+//   cv_exp   = std_exp / |mean_exp|                          (null se mean_exp ≈ 0)
+//
+//   ── Normalizado ──
+//   cv_normalized = cv_obs / cv_exp                          (ratio adimensional)
+//
+// Função pura: zero Firestore, zero I/O.
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+const NEAR_ZERO = 1e-9;
+
+function parseDateToIso(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  const m = BR_DATE_RE.exec(value);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return null;
+}
+
+/**
+ * Agrupa trades por dia (ISO `YYYY-MM-DD`), filtrando por janela
+ * `[cycleStart, cycleEnd]` (inclusive) e `status === 'CLOSED'`.
+ * Mesmo contrato do helper homônimo em computeCycleSharpe.js (DEC-AUTO-235-T06-A:
+ * duplicação intencional para preservar mirror discipline F1.1).
+ */
+function groupTradesByDay(trades, cycleStart, cycleEnd) {
+  const map = new Map();
+  if (!Array.isArray(trades) || trades.length === 0) return map;
+
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    const iso = parseDateToIso(t.date);
+    if (iso === null) continue;
+    if (iso < cycleStart || iso > cycleEnd) continue;
+    const pl = typeof t.result === 'number' && Number.isFinite(t.result) ? t.result : null;
+    if (pl === null) continue;
+    map.set(iso, (map.get(iso) ?? 0) + pl);
+  }
+  return map;
+}
+
+function effectiveWinRate(trades) {
+  if (!Array.isArray(trades) || trades.length === 0) return null;
+  let wins = 0;
+  let total = 0;
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    if (typeof t.result !== 'number' || !Number.isFinite(t.result)) continue;
+    total += 1;
+    if (t.result > 0) wins += 1;
+  }
+  if (total === 0) return null;
+  return wins / total;
+}
+
+function computeCvObserved(dailyPLs) {
+  if (!Array.isArray(dailyPLs) || dailyPLs.length === 0) {
+    return { cv: null, mean: 0, std: 0 };
+  }
+  const N = dailyPLs.length;
+  let sum = 0;
+  for (const v of dailyPLs) sum += v;
+  const mean = sum / N;
+
+  if (N < 2) {
+    if (Math.abs(mean) < NEAR_ZERO) return { cv: null, mean, std: 0 };
+    return { cv: 0, mean, std: 0 };
+  }
+
+  let sumSq = 0;
+  for (const v of dailyPLs) sumSq += (v - mean) ** 2;
+  const std = Math.sqrt(sumSq / (N - 1));
+
+  if (Math.abs(mean) < NEAR_ZERO) return { cv: null, mean, std };
+  return { cv: std / Math.abs(mean), mean, std };
+}
+
+function computeCvExpected(p, RR) {
+  const mean = p * RR - (1 - p);
+  const variance = p * (RR - mean) ** 2 + (1 - p) * (-1 - mean) ** 2;
+  const std = Math.sqrt(variance);
+  if (Math.abs(mean) < NEAR_ZERO) return { cv: null, mean, std };
+  return { cv: std / Math.abs(mean), mean, std };
+}
+
+function resolveWinRate(trades, plan) {
+  const fromTrades = effectiveWinRate(trades);
+  if (fromTrades !== null) return fromTrades;
+  const fallback = plan && plan.expectedWinRate;
+  if (typeof fallback === 'number' && Number.isFinite(fallback)) return fallback;
+  return null;
+}
+
+/**
+ * CV normalizado per-ciclo. Pure function — zero Firestore.
+ *
+ * @param {Array<{date:string,result:number,status:string}>} trades
+ * @param {{targetRR:number, expectedWinRate?:number}} plan
+ * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
+ * @param {Object} [opts]
+ * @param {number} [opts.minDays=5]
+ */
+function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {}) {
+  const minDays = typeof opts.minDays === 'number' ? opts.minDays : 5;
+
+  const groups = groupTradesByDay(trades, cycleStart, cycleEnd);
+  const daysWithTrade = groups.size;
+
+  if (daysWithTrade < minDays) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'min_days',
+      label: `Insuficiente · ≥${minDays} dias`,
+    };
+  }
+
+  const targetRR = plan && plan.targetRR;
+  if (typeof targetRR !== 'number' || !Number.isFinite(targetRR) || targetRR <= 0) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'no_target_rr',
+      label: 'Plano sem RR alvo definido — definir para ativar métrica',
+    };
+  }
+
+  const inWindowTrades = [];
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    const iso = parseDateToIso(t.date);
+    if (iso === null) continue;
+    if (iso < cycleStart || iso > cycleEnd) continue;
+    if (typeof t.result !== 'number' || !Number.isFinite(t.result)) continue;
+    inWindowTrades.push(t);
+  }
+
+  const p = resolveWinRate(inWindowTrades, plan);
+  if (p === null) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'no_target_rr',
+      label: 'Plano sem RR alvo definido — definir para ativar métrica',
+    };
+  }
+
+  const exp = computeCvExpected(p, targetRR);
+  if (exp.cv === null) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'breakeven_plan',
+      label: 'Plano com expectância nula — métrica indefinida',
+    };
+  }
+
+  const dailyPLs = Array.from(groups.values());
+  const obs = computeCvObserved(dailyPLs);
+  if (obs.cv === null) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: exp.cv,
+      daysWithTrade,
+      insufficientReason: 'zero_obs_mean',
+      label: 'P&L médio diário próximo de zero — CV indefinido',
+    };
+  }
+
+  return {
+    value: obs.cv / exp.cv,
+    cvObs: obs.cv,
+    cvExp: exp.cv,
+    daysWithTrade,
+  };
+}
+
+module.exports = computeCVNormalized;
+module.exports.computeCVNormalized = computeCVNormalized;
+module.exports.groupTradesByDay = groupTradesByDay;
+module.exports.effectiveWinRate = effectiveWinRate;
+module.exports.computeCvObserved = computeCvObserved;
+module.exports.computeCvExpected = computeCvExpected;
+module.exports.resolveWinRate = resolveWinRate;

--- a/functions/cycleConsistency/computeCycleSharpe.js
+++ b/functions/cycleConsistency/computeCycleSharpe.js
@@ -1,0 +1,175 @@
+// ============================================
+// CYCLE CONSISTENCY — Cloud Functions copy
+// ============================================
+//
+// ⚠️ ESPELHO de src/utils/cycleConsistency/computeCycleSharpe.js — MANTER SINCRONIZADO ⚠️
+// Qualquer alteração aqui replica em src/, e vice-versa (#119/#191).
+//
+// Sharpe ratio per-ciclo com Selic histórica descontada apenas em dias com
+// trade. Anualiza pelo factor √252 (DEC-AUTO-235-03).
+//
+// Algoritmo (memória de cálculo, body do issue #235):
+//   returns_d   = Σ result_dia(d) / plStart                    [d ∈ dias com trade]
+//   rfr_d       = getSelicForDate(d).rateDaily                 [um lookup por dia distinto]
+//   excess_d    = returns_d - rfr_d
+//   mean        = Σ excess_d / N
+//   std         = sqrt( Σ (excess_d - mean)² / (N - 1) )       [amostral, Bessel]
+//   sharpe      = (mean / std) * √252                          [annual]
+//
+// Consistência declarada: Selic é descontada APENAS para dias com trade —
+// nem dias sem trade entram em returns_d nem em rfr_d.
+
+const SQRT_252 = Math.sqrt(252);
+const SQRT_21 = Math.sqrt(21);
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+function parseDateToIso(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  const m = BR_DATE_RE.exec(value);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return null;
+}
+
+/**
+ * Agrupa trades por dia (ISO `YYYY-MM-DD`), filtrando por janela
+ * `[cycleStart, cycleEnd]` (inclusive) e `status === 'CLOSED'`.
+ */
+function groupTradesByDay(trades, cycleStart, cycleEnd) {
+  const map = new Map();
+  if (!Array.isArray(trades) || trades.length === 0) return map;
+
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    const iso = parseDateToIso(t.date);
+    if (iso === null) continue;
+    if (iso < cycleStart || iso > cycleEnd) continue;
+    const pl = typeof t.result === 'number' && Number.isFinite(t.result) ? t.result : null;
+    if (pl === null) continue;
+    map.set(iso, (map.get(iso) ?? 0) + pl);
+  }
+  return map;
+}
+
+function dailyReturnsFromGroups(groups, plStart) {
+  if (!(groups instanceof Map) || groups.size === 0) return [];
+  if (typeof plStart !== 'number' || !Number.isFinite(plStart) || plStart === 0) return [];
+
+  const dates = Array.from(groups.keys()).sort();
+  return dates.map((dateIso) => ({
+    dateIso,
+    dailyReturn: groups.get(dateIso) / plStart,
+  }));
+}
+
+function meanStdSample(arr) {
+  if (!Array.isArray(arr) || arr.length === 0) return { mean: 0, std: 0 };
+  const N = arr.length;
+  let sum = 0;
+  for (const v of arr) sum += v;
+  const mean = sum / N;
+  if (N < 2) return { mean, std: 0 };
+
+  let sumSq = 0;
+  for (const v of arr) sumSq += (v - mean) ** 2;
+  const std = Math.sqrt(sumSq / (N - 1));
+  return { mean, std };
+}
+
+function aggregateSource(daySources) {
+  let bcbCount = 0;
+  let fallbackCount = 0;
+  for (const s of daySources) {
+    if (s.isFallback) fallbackCount += 1;
+    else bcbCount += 1;
+  }
+  const fallbackUsed = fallbackCount > 0;
+  let source;
+  if (fallbackCount === 0) source = 'BCB';
+  else if (bcbCount === 0) source = 'FALLBACK';
+  else source = 'MIXED';
+  return { source, fallbackUsed };
+}
+
+function resolveGetSelicFn(opts) {
+  if (typeof opts.getSelicForDateFn === 'function') return opts.getSelicForDateFn;
+  return require('../marketData/getSelicForDate').getSelicForDate;
+}
+
+/**
+ * Sharpe per-ciclo anualizado, com Selic histórica descontada por dia operado.
+ *
+ * @param {Array<{date:string,result:number,status:string}>} trades
+ * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
+ * @param {number} plStart    — balance no início do ciclo (R$)
+ * @param {Object} [opts]
+ * @param {number} [opts.minDays=5]
+ * @param {('annual'|'monthly')} [opts.periodicity='annual']
+ * @param {Function} [opts.getSelicForDateFn]
+ * @returns {Promise<{value:(number|null), daysWithTrade:number, source:('BCB'|'FALLBACK'|'MIXED'), insufficientReason?:string, fallbackUsed:boolean}>}
+ */
+async function computeCycleSharpe(trades, cycleStart, cycleEnd, plStart, opts = {}) {
+  const minDays = typeof opts.minDays === 'number' ? opts.minDays : 5;
+  const periodicity = opts.periodicity ?? 'annual';
+  const multiplier = periodicity === 'monthly' ? SQRT_21 : SQRT_252;
+
+  const groups = groupTradesByDay(trades, cycleStart, cycleEnd);
+  const daysWithTrade = groups.size;
+
+  if (daysWithTrade < minDays) {
+    return {
+      value: null,
+      daysWithTrade,
+      source: 'BCB',
+      insufficientReason: 'min_days',
+      fallbackUsed: false,
+    };
+  }
+
+  const dailyReturns = dailyReturnsFromGroups(groups, plStart);
+  const getSelicFn = resolveGetSelicFn(opts);
+
+  const lookups = await Promise.all(
+    dailyReturns.map((d) => Promise.resolve(getSelicFn(d.dateIso)))
+  );
+
+  const excess = [];
+  const daySources = [];
+  for (let i = 0; i < dailyReturns.length; i += 1) {
+    const r = lookups[i] ?? {};
+    const rateDaily = typeof r.rateDaily === 'number' && Number.isFinite(r.rateDaily) ? r.rateDaily : 0;
+    const isFallback = r.isFallback === true || r.source === 'FALLBACK';
+    daySources.push({ isFallback });
+    excess.push(dailyReturns[i].dailyReturn - rateDaily);
+  }
+
+  const { source, fallbackUsed } = aggregateSource(daySources);
+  const { mean, std } = meanStdSample(excess);
+
+  if (std === 0) {
+    return {
+      value: null,
+      daysWithTrade,
+      source,
+      insufficientReason: 'zero_variance',
+      fallbackUsed,
+    };
+  }
+
+  const value = (mean / std) * multiplier;
+  return {
+    value,
+    daysWithTrade,
+    source,
+    fallbackUsed,
+  };
+}
+
+module.exports = computeCycleSharpe;
+module.exports.computeCycleSharpe = computeCycleSharpe;
+module.exports.groupTradesByDay = groupTradesByDay;
+module.exports.dailyReturnsFromGroups = dailyReturnsFromGroups;
+module.exports.meanStdSample = meanStdSample;

--- a/functions/index.js
+++ b/functions/index.js
@@ -1499,3 +1499,8 @@ exports.generateWeeklySwot = require("./reviews/generateWeeklySwot");
 // ============================================
 exports.enrichTradeWithExcursions = require("./marketData/enrichTradeWithExcursions");
 exports.onTradeCreatedAutoEnrich = require("./marketData/onTradeCreatedAutoEnrich");
+
+// ============================================
+// MARKET DATA — Selic diária BCB SGS-11 (issue #235 F0.1)
+// ============================================
+exports.fetchSelicDaily = require("./marketData/fetchSelicDaily");

--- a/functions/marketData/fetchSelicDaily.js
+++ b/functions/marketData/fetchSelicDaily.js
@@ -1,0 +1,268 @@
+/**
+ * fetchSelicDaily.js — issue #235 Fase F0.1
+ *
+ * Cloud Function (onSchedule v2) que busca a taxa Selic diária no BCB SGS-11
+ * todo dia útil às 09h BRT e grava em `systemConfig/selic` (doc + subcollection
+ * `history`). Insumo do helper `getSelicForDate` (F0.3) usado por
+ * `computeCycleSharpe` (F1.1).
+ *
+ * Endpoint BCB SGS-11 (público, sem auth):
+ *   https://api.bcb.gov.br/dados/serie/bcdata.sgs.11/dados
+ *     ?formato=json&dataInicial=DD/MM/YYYY&dataFinal=DD/MM/YYYY
+ *
+ * Payload sucesso (1 dia):
+ *   [{ "data": "DD/MM/YYYY", "valor": "0.04953" }]   // valor = taxa diária em %
+ *
+ * Payload em fim de semana / feriado: `[]` (BCB não publica). Não é erro.
+ *
+ * Política de erro: NUNCA throw. Falha após N retries grava
+ * `systemConfig/selic.lastError` e retorna — evita o scheduler do Cloud
+ * Functions empilhar retry em cima do nosso retry.
+ *
+ * Schema gravado:
+ *   systemConfig/selic                       { lastDate, lastRate, lastFetchedAt, source, lastError }
+ *   systemConfig/selic/history/<YYYY-MM-DD>  { date, rateDaily, source, fetchedAt }
+ *
+ * INV-15: namespace aprovado em #issuecomment-4364111738.
+ */
+
+const BCB_URL = 'https://api.bcb.gov.br/dados/serie/bcdata.sgs.11/dados';
+const SOURCE = 'BCB-SGS-11';
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_BASE_MS = 1000;
+const DEFAULT_TIMEOUT_MS = 8000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Converte Date para `DD/MM/YYYY` no fuso America/Sao_Paulo.
+ */
+function formatBrDate(date) {
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'America/Sao_Paulo',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  return fmt.format(date).replace(/-/g, '/');
+}
+
+/**
+ * Converte `DD/MM/YYYY` → `YYYY-MM-DD` (ISO). Não valida calendário.
+ */
+function brToIso(brDate) {
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(brDate);
+  if (!m) return null;
+  return `${m[3]}-${m[2]}-${m[1]}`;
+}
+
+/**
+ * Calcula D-1 do horário atual em America/Sao_Paulo. BCB publica a taxa
+ * referente ao dia útil anterior; D-0 às 09h BRT geralmente ainda não saiu.
+ */
+function previousBrDate(now) {
+  const brNow = new Date(now.getTime());
+  brNow.setUTCDate(brNow.getUTCDate() - 1);
+  return formatBrDate(brNow);
+}
+
+async function fetchOnce(url, fetchFn, timeoutMs) {
+  const ac = new AbortController();
+  const tid = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(url, { signal: ac.signal });
+    if (!res.ok) {
+      const err = new Error(`HTTP ${res.status}`);
+      err.code = `http_${res.status}`;
+      throw err;
+    }
+    return await res.json();
+  } finally {
+    clearTimeout(tid);
+  }
+}
+
+/**
+ * Tenta buscar até `attempts` vezes com backoff exponencial
+ * (base, base*2, base*4, ...). Lança o último erro se todas falharem.
+ */
+async function fetchWithRetry(url, { fetchFn, attempts, backoffBase, timeoutMs, sleepFn }) {
+  let lastErr = null;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fetchOnce(url, fetchFn, timeoutMs);
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) {
+        await sleepFn(backoffBase * Math.pow(2, i));
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Parse defensivo do payload BCB. Aceita campos extras, valida apenas
+ * `data` (string DD/MM/YYYY) e `valor` (string numérica).
+ */
+function parsePayload(json) {
+  if (!Array.isArray(json)) return null;
+  const out = [];
+  for (const item of json) {
+    if (!item || typeof item.data !== 'string' || typeof item.valor !== 'string') return null;
+    const iso = brToIso(item.data);
+    if (!iso) return null;
+    const num = Number(item.valor);
+    if (!Number.isFinite(num)) return null;
+    out.push({ date: iso, rateDaily: num / 100 });
+  }
+  return out;
+}
+
+/**
+ * Helper puro: orquestra fetch + parse + escrita Firestore.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.db                 — admin.firestore() instance (ou stub)
+ * @param {Function} deps.fetchFn          — fetch (default: global fetch)
+ * @param {Function} [deps.now]            — () => Date (default: () => new Date())
+ * @param {number} [deps.attempts]         — default 3
+ * @param {number} [deps.backoffBase]      — ms, default 1000
+ * @param {number} [deps.timeoutMs]        — default 8000
+ * @param {Function} [deps.sleepFn]        — injetável para testes
+ * @param {Object} [deps.timestamp]        — { now: () => any } para FieldValue.serverTimestamp simulado
+ * @returns {Promise<{ok: boolean, status: 'written'|'skipped_idempotent'|'no_data'|'error', date?: string, rateDaily?: number, reason?: string}>}
+ */
+async function runFetchSelicDaily(deps = {}) {
+  const fetchFn = deps.fetchFn ?? (typeof fetch !== 'undefined' ? fetch : null);
+  if (!deps.db) throw new Error('deps.db obrigatório');
+  if (!fetchFn) throw new Error('fetch indisponível');
+
+  const now = deps.now ? deps.now() : new Date();
+  const attempts = deps.attempts ?? DEFAULT_ATTEMPTS;
+  const backoffBase = deps.backoffBase ?? DEFAULT_BACKOFF_BASE_MS;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const sleepFn = deps.sleepFn ?? sleep;
+  const ts = deps.timestamp ?? { now: () => new Date() };
+
+  const targetBr = previousBrDate(now);
+  const url = `${BCB_URL}?formato=json&dataInicial=${encodeURIComponent(targetBr)}&dataFinal=${encodeURIComponent(targetBr)}`;
+
+  const selicRef = deps.db.collection('systemConfig').doc('selic');
+
+  let payload;
+  try {
+    payload = await fetchWithRetry(url, { fetchFn, attempts, backoffBase, timeoutMs, sleepFn });
+  } catch (err) {
+    const code = err.code || 'fetch_failed';
+    const message = err.message || String(err);
+    console.error(`[fetchSelicDaily] falha após ${attempts} tentativas: ${code} ${message}`);
+    await selicRef.set(
+      {
+        lastError: { code, message, attemptedAt: ts.now() },
+      },
+      { merge: true }
+    );
+    return { ok: false, status: 'error', reason: `${code}: ${message}` };
+  }
+
+  const parsed = parsePayload(payload);
+  if (parsed == null) {
+    const message = 'payload com schema inválido';
+    console.error(`[fetchSelicDaily] ${message}`);
+    await selicRef.set(
+      {
+        lastError: { code: 'bad_schema', message, attemptedAt: ts.now() },
+      },
+      { merge: true }
+    );
+    return { ok: false, status: 'error', reason: message };
+  }
+
+  // Atualiza metadata mesmo em payload vazio (saber que rodamos hoje).
+  if (parsed.length === 0) {
+    console.info(`[fetchSelicDaily] no data for ${targetBr} (fim de semana / feriado)`);
+    await selicRef.set(
+      {
+        lastFetchedAt: ts.now(),
+        source: SOURCE,
+        lastError: null,
+      },
+      { merge: true }
+    );
+    return { ok: true, status: 'no_data' };
+  }
+
+  // BCB devolve a janela inteira; pegamos a entrada cuja data bate com o alvo,
+  // ou a última disponível como fallback (defensivo).
+  const targetIso = brToIso(targetBr);
+  const entry = parsed.find((p) => p.date === targetIso) ?? parsed[parsed.length - 1];
+
+  // Idempotência: se history/<date> já existe com source BCB-SGS-11, pula.
+  const historyRef = selicRef.collection('history').doc(entry.date);
+  const existing = await historyRef.get();
+  if (existing.exists && existing.data()?.source === SOURCE) {
+    console.info(`[fetchSelicDaily] already fetched for ${entry.date}`);
+    await selicRef.set(
+      {
+        lastFetchedAt: ts.now(),
+        lastError: null,
+      },
+      { merge: true }
+    );
+    return { ok: true, status: 'skipped_idempotent', date: entry.date, rateDaily: entry.rateDaily };
+  }
+
+  const batch = deps.db.batch();
+  batch.set(historyRef, {
+    date: entry.date,
+    rateDaily: entry.rateDaily,
+    source: SOURCE,
+    fetchedAt: ts.now(),
+  });
+  batch.set(
+    selicRef,
+    {
+      lastDate: entry.date,
+      lastRate: entry.rateDaily,
+      lastFetchedAt: ts.now(),
+      source: SOURCE,
+      lastError: null,
+    },
+    { merge: true }
+  );
+  await batch.commit();
+
+  console.info(`[fetchSelicDaily] ok ${entry.date} rateDaily=${entry.rateDaily}`);
+  return { ok: true, status: 'written', date: entry.date, rateDaily: entry.rateDaily };
+}
+
+const { onSchedule } = (() => {
+  try {
+    return require('firebase-functions/v2/scheduler');
+  } catch (_e) {
+    return { onSchedule: (_opts, fn) => fn };
+  }
+})();
+
+const fetchSelicDaily = onSchedule(
+  {
+    schedule: 'every day 09:00',
+    timeZone: 'America/Sao_Paulo',
+    region: 'us-central1',
+    retryCount: 0,
+  },
+  async () => {
+    const admin = require('firebase-admin');
+    const db = admin.firestore();
+    const ts = { now: () => admin.firestore.FieldValue.serverTimestamp() };
+    return runFetchSelicDaily({ db, timestamp: ts });
+  }
+);
+
+module.exports = fetchSelicDaily;
+module.exports.runFetchSelicDaily = runFetchSelicDaily;
+module.exports.parsePayload = parsePayload;
+module.exports.formatBrDate = formatBrDate;
+module.exports.brToIso = brToIso;
+module.exports.previousBrDate = previousBrDate;

--- a/functions/marketData/getSelicForDate.js
+++ b/functions/marketData/getSelicForDate.js
@@ -1,0 +1,115 @@
+// ============================================
+// MARKET DATA — Cloud Functions copy
+// ============================================
+//
+// ⚠️ ESPELHO de src/utils/marketData/getSelicForDate.js — MANTER SINCRONIZADO ⚠️
+// Qualquer alteração aqui deve replicar em src/, e vice-versa (#119/#191).
+//
+// Resolve a taxa Selic diária (`rateDaily`, fração) para uma data ISO,
+// lendo `systemConfig/selic/history/<YYYY-MM-DD>` (gravado pela CF F0.1
+// `fetchSelicDaily` e backfill F0.2). Carry-forward para fim-de-semana /
+// feriado; fallback hardcoded para gap longo ou erro de Firestore.
+// NUNCA throw.
+//
+// Schema esperado (lock INV-10 com fetchSelicDaily.js):
+//   { date: 'YYYY-MM-DD', rateDaily: number, source: string, fetchedAt: Timestamp }
+//
+// INV-15: leitura apenas, namespace já aprovado em F0.1.
+
+const SELIC_FALLBACK_DAILY = 14.75 / 252 / 100;
+const SELIC_HISTORY_PARENT = 'systemConfig';
+const SELIC_DOC = 'selic';
+const SELIC_HISTORY_SUB = 'history';
+const FALLBACK_SOURCE = 'FALLBACK';
+const DEFAULT_MAX_CARRY_FORWARD_DAYS = 7;
+
+function daysDiffIso(isoA, isoB) {
+  const a = Date.parse(`${isoA}T00:00:00Z`);
+  const b = Date.parse(`${isoB}T00:00:00Z`);
+  return Math.round((a - b) / 86400000);
+}
+
+function makeFallback(rateDaily) {
+  return {
+    rateDaily,
+    source: FALLBACK_SOURCE,
+    dateUsed: null,
+    isCarryForward: false,
+    isFallback: true,
+  };
+}
+
+function getDefaultDb() {
+  const admin = require('firebase-admin');
+  return admin.firestore();
+}
+
+/**
+ * Resolve `rateDaily` para `dateIso`.
+ *
+ * @param {string} dateIso                                    — `YYYY-MM-DD`
+ * @param {Object} [opts]
+ * @param {Object} [opts.db]                                  — admin.firestore() instance
+ * @param {number} [opts.maxCarryForwardDays=7]
+ * @param {number} [opts.fallbackRateDaily=SELIC_FALLBACK_DAILY]
+ * @returns {Promise<{rateDaily:number, source:string, dateUsed:string|null, isCarryForward:boolean, isFallback:boolean}>}
+ */
+async function getSelicForDate(dateIso, opts = {}) {
+  const db = opts.db ?? getDefaultDb();
+  const maxCarryForwardDays = opts.maxCarryForwardDays ?? DEFAULT_MAX_CARRY_FORWARD_DAYS;
+  const fallbackRateDaily = opts.fallbackRateDaily ?? SELIC_FALLBACK_DAILY;
+
+  try {
+    const historyCol = db
+      .collection(SELIC_HISTORY_PARENT)
+      .doc(SELIC_DOC)
+      .collection(SELIC_HISTORY_SUB);
+
+    const exactSnap = await historyCol.doc(dateIso).get();
+    if (exactSnap.exists) {
+      const data = exactSnap.data();
+      return {
+        rateDaily: data.rateDaily,
+        source: data.source,
+        dateUsed: dateIso,
+        isCarryForward: false,
+        isFallback: false,
+      };
+    }
+
+    const querySnap = await historyCol
+      .where('date', '<=', dateIso)
+      .orderBy('date', 'desc')
+      .limit(1)
+      .get();
+
+    if (querySnap.empty || !querySnap.docs?.length) {
+      return makeFallback(fallbackRateDaily);
+    }
+
+    const data = querySnap.docs[0].data();
+    const foundDate = data.date;
+    const daysBack = daysDiffIso(dateIso, foundDate);
+    if (daysBack >= 0 && daysBack <= maxCarryForwardDays) {
+      return {
+        rateDaily: data.rateDaily,
+        source: data.source,
+        dateUsed: foundDate,
+        isCarryForward: daysBack > 0,
+        isFallback: false,
+      };
+    }
+    return makeFallback(fallbackRateDaily);
+  } catch (err) {
+    const code = err?.code ?? 'firestore_error';
+    const message = err?.message ?? String(err);
+    console.error(`[getSelicForDate] ${code}: ${message} (date=${dateIso})`);
+    return makeFallback(fallbackRateDaily);
+  }
+}
+
+module.exports = getSelicForDate;
+module.exports.getSelicForDate = getSelicForDate;
+module.exports.daysDiffIso = daysDiffIso;
+module.exports.SELIC_FALLBACK_DAILY = SELIC_FALLBACK_DAILY;
+module.exports.SELIC_HISTORY_PATH = `${SELIC_HISTORY_PARENT}/${SELIC_DOC}/${SELIC_HISTORY_SUB}`;

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -12,6 +12,9 @@
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^5.1.0"
       },
+      "devDependencies": {
+        "vitest": "^4.1.5"
+      },
       "engines": {
         "node": "22"
       }
@@ -45,6 +48,40 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@fastify/busboy": {
       "version": "3.2.0",
@@ -277,6 +314,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
@@ -288,6 +332,25 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -296,6 +359,16 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -362,6 +435,277 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -370,6 +714,17 @@
       "optional": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -389,6 +744,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -406,6 +772,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.3",
@@ -545,6 +925,119 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -632,6 +1125,16 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-retry": {
@@ -749,6 +1252,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -817,6 +1330,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -884,6 +1404,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -972,6 +1502,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1015,6 +1552,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1031,6 +1578,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1131,6 +1688,24 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/finalhandler": {
@@ -1265,6 +1840,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1808,6 +2398,267 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -1896,6 +2747,16 @@
         "lru-cache": "6.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1971,6 +2832,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2061,6 +2941,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -2113,6 +3004,62 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -2251,6 +3198,40 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/safe-buffer": {
@@ -2426,6 +3407,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2434,6 +3439,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -2593,6 +3605,50 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2680,6 +3736,174 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -2726,6 +3950,23 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "serve": "firebase emulators:start --only functions",
     "deploy": "firebase deploy --only functions",
-    "migrate": "node migrate-trade-status.js"
+    "migrate": "node migrate-trade-status.js",
+    "test": "vitest"
   },
   "engines": {
     "node": "22"
@@ -15,5 +16,8 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^5.1.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.5"
   }
 }

--- a/functions/vitest.config.js
+++ b/functions/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['__tests__/**/*.test.js'],
+    exclude: ['node_modules'],
+  },
+});

--- a/scripts/issue-235-bootstrap-selic-history.mjs
+++ b/scripts/issue-235-bootstrap-selic-history.mjs
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+/**
+ * issue-235-bootstrap-selic-history.mjs — backfill diário Selic SGS-11
+ *
+ * CONTEXTO (issue #235, F0.2):
+ *   Task 01 (commit e8286e08) entregou a CF `fetchSelicDaily`, que mantém
+ *   `systemConfig/selic` atualizado a partir de hoje. Para alimentar o helper
+ *   `getSelicForDate` (F0.3) e `computeCycleSharpe` (F1.1) com Sharpe per-ciclo
+ *   desde o início do tracking (jan/2024), precisamos popular retroativamente
+ *   `systemConfig/selic/history/<YYYY-MM-DD>` com o histórico oficial BCB SGS-11.
+ *
+ * ESTRATÉGIA:
+ *   - Fetch BCB SGS-11 em janelas de até 365 dias entre `--from` e `--to`.
+ *   - Parse defensivo + filtragem por idempotência (history/<date> com
+ *     source=BCB-SGS-11 → pula).
+ *   - Enfileira escrita em batches de 500 (limite Firestore).
+ *   - Schema gravado idêntico ao da CF F0.1: {date, rateDaily, source,
+ *     fetchedAt} no history; metadata em `systemConfig/selic` só avança se
+ *     houve gravação E a maior data nova for superior à `lastDate` corrente
+ *     (não regride janela atual).
+ *
+ * MODO DRY-RUN (default — sem credenciais necessárias se fetchFn for mock):
+ *   node scripts/issue-235-bootstrap-selic-history.mjs
+ *
+ * MODO EXECUTE (requer dupla confirmação):
+ *   node scripts/issue-235-bootstrap-selic-history.mjs --execute --confirm=SIM
+ *
+ * Args opcionais:
+ *   --from=YYYY-MM-DD   default 2024-01-01
+ *   --to=YYYY-MM-DD     default D-1 BRT
+ *
+ * PRÉ-REQUISITOS (modo execute):
+ *   gcloud auth application-default login
+ *
+ * LOG:
+ *   scripts/logs/issue-235-{dryrun|execute}-<ISO8601>.json
+ *
+ * INV-15: namespace systemConfig/selic + history aprovado em
+ *         #issuecomment-4364111738.
+ * INV-10: schema 1:1 com `functions/marketData/fetchSelicDaily.js`.
+ */
+
+import { createRequire } from 'node:module';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..');
+const LOGS_DIR = join(PROJECT_ROOT, 'scripts', 'logs');
+
+export const PROJECT_ID = 'acompanhamento-20';
+export const BATCH_SIZE = 500;
+export const SOURCE = 'BCB-SGS-11';
+export const BCB_URL = 'https://api.bcb.gov.br/dados/serie/bcdata.sgs.11/dados';
+export const DEFAULT_FROM = '2024-01-01';
+export const RANGE_CHUNK_DAYS = 365;
+
+// ── Pure helpers (exportadas para teste) ────────────────────
+
+export function brToIso(brDate) {
+  const m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(brDate);
+  if (!m) return null;
+  return `${m[3]}-${m[2]}-${m[1]}`;
+}
+
+export function isoToBr(isoDate) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate);
+  if (!m) return null;
+  return `${m[3]}/${m[2]}/${m[1]}`;
+}
+
+export function formatBrDate(date) {
+  const fmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'America/Sao_Paulo',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  return fmt.format(date).replace(/-/g, '/');
+}
+
+export function previousBrDate(now) {
+  const d = new Date(now.getTime());
+  d.setUTCDate(d.getUTCDate() - 1);
+  return formatBrDate(d);
+}
+
+export function defaultToIso(now) {
+  return brToIso(previousBrDate(now));
+}
+
+/**
+ * Parse defensivo do payload BCB SGS-11. Aceita campo extra; valida apenas
+ * `data` (DD/MM/YYYY) e `valor` numérico. Retorna null no schema inválido.
+ * Schema mantido 1:1 com `functions/marketData/fetchSelicDaily.parsePayload`.
+ */
+export function parsePayload(json) {
+  if (!Array.isArray(json)) return null;
+  const out = [];
+  for (const item of json) {
+    if (!item || typeof item.data !== 'string' || typeof item.valor !== 'string') return null;
+    const iso = brToIso(item.data);
+    if (!iso) return null;
+    const num = Number(item.valor);
+    if (!Number.isFinite(num)) return null;
+    out.push({ date: iso, rateDaily: num / 100 });
+  }
+  return out;
+}
+
+/**
+ * Quebra array em chunks de tamanho `size`. Último chunk pode ser menor.
+ */
+export function chunkBatch(arr, size) {
+  if (!Array.isArray(arr)) throw new TypeError('chunkBatch: arr deve ser Array');
+  if (!Number.isInteger(size) || size <= 0) throw new RangeError('chunkBatch: size deve ser inteiro positivo');
+  const out = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Lista YYYY-MM-DD inclusiva de fromIso até toIso (UTC). [] se from > to.
+ */
+export function iterateDateRange(fromIso, toIso) {
+  const fm = /^(\d{4})-(\d{2})-(\d{2})$/.exec(fromIso);
+  const tm = /^(\d{4})-(\d{2})-(\d{2})$/.exec(toIso);
+  if (!fm || !tm) throw new RangeError('iterateDateRange: ISO date inválido');
+  const start = Date.UTC(+fm[1], +fm[2] - 1, +fm[3]);
+  const end = Date.UTC(+tm[1], +tm[2] - 1, +tm[3]);
+  if (start > end) return [];
+  const out = [];
+  for (let t = start; t <= end; t += 86400000) {
+    const d = new Date(t);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const dd = String(d.getUTCDate()).padStart(2, '0');
+    out.push(`${y}-${m}-${dd}`);
+  }
+  return out;
+}
+
+/**
+ * Quebra um range [from, to] em janelas inclusivas de até `chunkDays` dias.
+ */
+export function chunkDateRange(fromIso, toIso, chunkDays = RANGE_CHUNK_DAYS) {
+  const all = iterateDateRange(fromIso, toIso);
+  if (all.length === 0) return [];
+  const chunks = [];
+  for (let i = 0; i < all.length; i += chunkDays) {
+    const slice = all.slice(i, i + chunkDays);
+    chunks.push({ from: slice[0], to: slice[slice.length - 1] });
+  }
+  return chunks;
+}
+
+// ── Orchestration (testável via injeção de dependências) ────
+
+/**
+ * @param {Object} deps
+ * @param {Object}   deps.db          — admin.firestore() ou stub
+ * @param {Function} deps.fetchFn     — fetch (global ou mock)
+ * @param {string}   [deps.from]      — YYYY-MM-DD (default DEFAULT_FROM)
+ * @param {string}   [deps.to]        — YYYY-MM-DD (default D-1 BRT)
+ * @param {'dryrun'|'execute'} [deps.mode]
+ * @param {number}   [deps.batchSize] — default BATCH_SIZE
+ * @param {Object}   [deps.timestamp] — { now: () => any }
+ * @param {Function} [deps.now]       — () => Date
+ * @param {Function} [deps.log]       — (line: string) => void
+ * @returns {Promise<Object>} summary { mode, from, to, fetched_count, would_write|wrote, skipped, errors, started_at, finished_at, duration_ms }
+ */
+export async function runBootstrap(deps) {
+  if (!deps?.db) throw new Error('deps.db obrigatório');
+  if (!deps?.fetchFn) throw new Error('deps.fetchFn obrigatório');
+
+  const mode = deps.mode === 'execute' ? 'execute' : 'dryrun';
+  const now = deps.now ? deps.now() : new Date();
+  const from = deps.from ?? DEFAULT_FROM;
+  const to = deps.to ?? defaultToIso(now);
+  const batchSize = deps.batchSize ?? BATCH_SIZE;
+  const ts = deps.timestamp ?? { now: () => new Date() };
+  const log = deps.log ?? (() => {});
+
+  const startedAt = new Date().toISOString();
+  const startedMs = Date.now();
+
+  log(`[bootstrap] mode=${mode} from=${from} to=${to} batchSize=${batchSize}`);
+
+  const ranges = chunkDateRange(from, to);
+  const errors = [];
+  const fetched = [];
+
+  for (const r of ranges) {
+    const url = `${BCB_URL}?formato=json&dataInicial=${encodeURIComponent(isoToBr(r.from))}&dataFinal=${encodeURIComponent(isoToBr(r.to))}`;
+    try {
+      const res = await deps.fetchFn(url);
+      if (!res.ok) {
+        errors.push({
+          phase: 'fetch',
+          range: r,
+          code: `http_${res.status}`,
+          message: `HTTP ${res.status}`,
+        });
+        continue;
+      }
+      const json = await res.json();
+      const parsed = parsePayload(json);
+      if (parsed == null) {
+        errors.push({
+          phase: 'parse',
+          range: r,
+          code: 'bad_schema',
+          message: 'payload com schema inválido',
+        });
+        continue;
+      }
+      fetched.push(...parsed);
+      log(`[bootstrap] ${r.from}..${r.to}: ${parsed.length} item(s)`);
+    } catch (err) {
+      errors.push({
+        phase: 'fetch',
+        range: r,
+        code: err.code || 'fetch_error',
+        message: err.message || String(err),
+      });
+    }
+  }
+
+  // Idempotência: filtrar dias já presentes em history com source=BCB-SGS-11.
+  const selicRef = deps.db.collection('systemConfig').doc('selic');
+  const historyCol = selicRef.collection('history');
+  const toWrite = [];
+  let skipped = 0;
+  for (const item of fetched) {
+    const existing = await historyCol.doc(item.date).get();
+    if (existing.exists && existing.data()?.source === SOURCE) {
+      skipped += 1;
+      continue;
+    }
+    toWrite.push(item);
+  }
+
+  const wouldWrite = toWrite.length;
+  let wrote = 0;
+  const writtenDates = [];
+
+  if (mode === 'execute' && toWrite.length > 0) {
+    const batches = chunkBatch(toWrite, batchSize);
+    for (let bi = 0; bi < batches.length; bi++) {
+      const slice = batches[bi];
+      const batch = deps.db.batch();
+      for (const item of slice) {
+        batch.set(historyCol.doc(item.date), {
+          date: item.date,
+          rateDaily: item.rateDaily,
+          source: SOURCE,
+          fetchedAt: ts.now(),
+        });
+      }
+      try {
+        await batch.commit();
+        wrote += slice.length;
+        for (const item of slice) writtenDates.push(item.date);
+        log(`[bootstrap] batch ${bi + 1}/${batches.length}: ${slice.length} docs gravados (total ${wrote})`);
+      } catch (err) {
+        errors.push({
+          phase: 'commit',
+          batch: bi + 1,
+          size: slice.length,
+          code: err.code || 'batch_error',
+          message: err.message || String(err),
+        });
+      }
+    }
+
+    if (writtenDates.length > 0) {
+      const maxNewDate = writtenDates.slice().sort().slice(-1)[0];
+      const winningItem = toWrite.find((i) => i.date === maxNewDate);
+      const cur = await selicRef.get();
+      const curData = cur.exists ? cur.data() : null;
+      if (!curData || !curData.lastDate || maxNewDate > curData.lastDate) {
+        await selicRef.set(
+          {
+            lastDate: maxNewDate,
+            lastRate: winningItem.rateDaily,
+            lastFetchedAt: ts.now(),
+            source: SOURCE,
+            lastError: null,
+          },
+          { merge: true }
+        );
+        log(`[bootstrap] systemConfig/selic atualizado: lastDate=${maxNewDate} lastRate=${winningItem.rateDaily}`);
+      } else {
+        log(`[bootstrap] systemConfig/selic preservado (lastDate=${curData.lastDate} >= ${maxNewDate})`);
+      }
+    }
+  }
+
+  const finishedAt = new Date().toISOString();
+  const summary = {
+    mode,
+    from,
+    to,
+    fetched_count: fetched.length,
+    skipped,
+    errors,
+    started_at: startedAt,
+    finished_at: finishedAt,
+    duration_ms: Date.now() - startedMs,
+  };
+  if (mode === 'execute') {
+    summary.wrote = wrote;
+  } else {
+    summary.would_write = wouldWrite;
+  }
+  return summary;
+}
+
+// ── Runner (CLI) ────────────────────────────────────────────
+
+function ts() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function writeLog(mode, payload) {
+  if (!existsSync(LOGS_DIR)) mkdirSync(LOGS_DIR, { recursive: true });
+  const path = join(LOGS_DIR, `issue-235-${mode}-${ts()}.json`);
+  writeFileSync(path, JSON.stringify(payload, null, 2));
+  return path;
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = { execute: false, confirmed: false, from: null, to: null };
+  for (const a of args) {
+    if (a === '--execute') out.execute = true;
+    else if (a === '--confirm=SIM') out.confirmed = true;
+    else if (a.startsWith('--from=')) out.from = a.slice('--from='.length);
+    else if (a.startsWith('--to=')) out.to = a.slice('--to='.length);
+  }
+  return out;
+}
+
+function initAdmin() {
+  const require = createRequire(import.meta.url);
+  const admin = require(join(PROJECT_ROOT, 'functions', 'node_modules', 'firebase-admin'));
+  if (!admin.apps.length) {
+    admin.initializeApp({ projectId: PROJECT_ID });
+  }
+  return admin;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+
+  if (opts.execute && !opts.confirmed) {
+    console.error('\n❌ --execute requer --confirm=SIM (dupla confirmação obrigatória).\n');
+    process.exit(1);
+  }
+
+  const mode = opts.execute ? 'execute' : 'dryrun';
+  const now = new Date();
+  const from = opts.from ?? DEFAULT_FROM;
+  const to = opts.to ?? defaultToIso(now);
+
+  console.log(`\n🔧 issue-235 — bootstrap Selic history [${mode.toUpperCase()}]`);
+  console.log(`   Projeto: ${PROJECT_ID}`);
+  console.log(`   Janela: ${from} → ${to}`);
+  console.log(`   Fonte:  ${BCB_URL}\n`);
+
+  const admin = initAdmin();
+  const db = admin.firestore();
+  const timestamp = { now: () => admin.firestore.FieldValue.serverTimestamp() };
+
+  const summary = await runBootstrap({
+    db,
+    fetchFn: globalThis.fetch,
+    from,
+    to,
+    mode,
+    batchSize: BATCH_SIZE,
+    timestamp,
+    now: () => now,
+    log: (line) => console.log(`   ${line}`),
+  });
+
+  console.log('\n── Resumo ──────────────────────────────────────');
+  console.log(`   modo:           ${summary.mode}`);
+  console.log(`   janela:         ${summary.from} → ${summary.to}`);
+  console.log(`   fetched_count:  ${summary.fetched_count}`);
+  console.log(`   skipped:        ${summary.skipped}`);
+  if (summary.mode === 'execute') {
+    console.log(`   wrote:          ${summary.wrote}`);
+  } else {
+    console.log(`   would_write:    ${summary.would_write}`);
+  }
+  console.log(`   errors:         ${summary.errors.length}`);
+  console.log(`   duration_ms:    ${summary.duration_ms}\n`);
+
+  if (summary.errors.length > 0) {
+    console.log('   Erros (primeiros 5):');
+    for (const e of summary.errors.slice(0, 5)) {
+      console.log(`     [${e.phase}] ${e.code}: ${e.message}`);
+    }
+    console.log();
+  }
+
+  const logPath = writeLog(mode, summary);
+  console.log(`📝 Log: ${logPath}\n`);
+
+  if (mode === 'dryrun') {
+    console.log('🟡 DRY-RUN — nada gravado. Para executar:');
+    console.log('     node scripts/issue-235-bootstrap-selic-history.mjs --execute --confirm=SIM\n');
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('\n💥 erro:', err);
+    process.exit(1);
+  });
+}

--- a/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
+++ b/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
@@ -57,17 +57,18 @@ describe('CycleConsistencyCard', () => {
 
     // Header
     expect(screen.getByText(/Consistencia Operacional/i)).toBeTruthy();
-    expect(screen.getByText('(FEV/2026)')).toBeTruthy();
+    expect(screen.getByText(/FEV\/2026/)).toBeTruthy();
 
     // 4 valores
     expect(screen.getByText('1.42')).toBeTruthy();
     expect(screen.getByText('1.05')).toBeTruthy();
     expect(screen.getByText('+1.8%')).toBeTruthy();
     expect(screen.getByText('-0.6%')).toBeTruthy();
-    expect(screen.getByText(/MEP \/ MEN médio/)).toBeTruthy();
+    expect(screen.getByText(/MEP médio/)).toBeTruthy();
+    expect(screen.getByText(/MEN médio/)).toBeTruthy();
 
     // Sharpe row label inclui o ciclo
-    expect(screen.getByText(/Sharpe \(FEV\/2026\)/)).toBeTruthy();
+    // Tile label é só "Sharpe" agora; cycleLabel ficou no header (já checado acima)
 
     // Badge Selic atual presente (BCB), sem coverage warning
     expect(screen.getByText(/Selic atual/)).toBeTruthy();

--- a/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
+++ b/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
@@ -62,8 +62,9 @@ describe('CycleConsistencyCard', () => {
     // 4 valores
     expect(screen.getByText('1.42')).toBeTruthy();
     expect(screen.getByText('1.05')).toBeTruthy();
-    expect(screen.getByText('+1.8% / entry')).toBeTruthy();
-    expect(screen.getByText('-0.6% / entry')).toBeTruthy();
+    expect(screen.getByText('+1.8%')).toBeTruthy();
+    expect(screen.getByText('-0.6%')).toBeTruthy();
+    expect(screen.getByText(/MEP \/ MEN médio/)).toBeTruthy();
 
     // Sharpe row label inclui o ciclo
     expect(screen.getByText(/Sharpe \(FEV\/2026\)/)).toBeTruthy();

--- a/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
+++ b/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
@@ -1,0 +1,177 @@
+/**
+ * CycleConsistencyCard.test.jsx — issue #235 F2.2
+ *
+ * Cobre:
+ *  C1 — happy path: 4 métricas + badge BCB + sem coverage warning
+ *  C2 — loading=true → skeleton visível
+ *  C3 — error → mensagem amigável
+ *  C4 — Sharpe insufficientReason='min_days' → label "Insuficiente · ≥X dias", sem badge BCB
+ *  C5 — CV insufficientReason='no_target_rr' → label do plano sem RR
+ *  C6 — coverage abaixo do threshold → badge "MEP/MEN em N de M trades"
+ *  C7 — DebugBadge com component="CycleConsistencyCard"
+ *
+ * Mocka useCycleConsistency para isolar UI da pipeline async (Selic via Firestore).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../../hooks/useCycleConsistency', () => ({
+  useCycleConsistency: vi.fn(),
+}));
+
+import CycleConsistencyCard from '../../../components/dashboard/CycleConsistencyCard';
+import { useCycleConsistency } from '../../../hooks/useCycleConsistency';
+
+const baseProps = {
+  trades: [],
+  plan: { pl: 10000, targetRR: 2, expectedWinRate: 0.5 },
+  cycleStart: '2026-02-01',
+  cycleEnd: '2026-02-28',
+};
+
+const happyState = {
+  sharpe: { value: 1.42, daysWithTrade: 12, source: 'BCB', fallbackUsed: false },
+  cvNormalized: { value: 1.05, cvObs: 9.66, cvExp: 9.20, daysWithTrade: 12 },
+  avgExcursion: {
+    avgMEP: 1.8,
+    avgMEN: -0.6,
+    coverage: 1,
+    coverageBelowThreshold: false,
+    totalTrades: 12,
+    tradesWithData: 12,
+  },
+  loading: false,
+  error: null,
+};
+
+describe('CycleConsistencyCard', () => {
+  beforeEach(() => {
+    vi.mocked(useCycleConsistency).mockReset();
+  });
+
+  it('C1 — happy path renderiza 4 métricas, badge BCB e header com cycleLabel derivado', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue(happyState);
+
+    render(<CycleConsistencyCard {...baseProps} />);
+
+    // Header
+    expect(screen.getByText(/Consistencia Operacional/i)).toBeTruthy();
+    expect(screen.getByText('(FEV/2026)')).toBeTruthy();
+
+    // 4 valores
+    expect(screen.getByText('1.42')).toBeTruthy();
+    expect(screen.getByText('1.05')).toBeTruthy();
+    expect(screen.getByText('+1.8% / entry')).toBeTruthy();
+    expect(screen.getByText('-0.6% / entry')).toBeTruthy();
+
+    // Sharpe row label inclui o ciclo
+    expect(screen.getByText(/Sharpe \(FEV\/2026\)/)).toBeTruthy();
+
+    // Badge BCB presente, sem coverage warning
+    expect(screen.getByText(/BCB/)).toBeTruthy();
+    expect(screen.queryByText(/MEP\/MEN em/)).toBeNull();
+  });
+
+  it('C2 — loading=true exibe skeleton', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue({
+      sharpe: null,
+      cvNormalized: null,
+      avgExcursion: null,
+      loading: true,
+      error: null,
+    });
+
+    render(<CycleConsistencyCard {...baseProps} />);
+
+    expect(screen.getByTestId('cycle-consistency-skeleton')).toBeTruthy();
+    expect(screen.queryByText('1.42')).toBeNull();
+  });
+
+  it('C3 — error exibe mensagem amigável', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue({
+      sharpe: null,
+      cvNormalized: null,
+      avgExcursion: null,
+      loading: false,
+      error: new Error('selic boom'),
+    });
+
+    render(<CycleConsistencyCard {...baseProps} />);
+
+    expect(screen.getByText(/Não foi possível carregar métricas do ciclo/i)).toBeTruthy();
+    expect(screen.queryByTestId('cycle-consistency-skeleton')).toBeNull();
+  });
+
+  it('C4 — Sharpe insufficientReason=min_days mostra label e oculta badge BCB', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue({
+      sharpe: { value: null, daysWithTrade: 2, source: 'BCB', insufficientReason: 'min_days', fallbackUsed: false },
+      cvNormalized: { value: 1.05, cvObs: 9.66, cvExp: 9.20, daysWithTrade: 2 },
+      avgExcursion: {
+        avgMEP: 1.0, avgMEN: -0.5,
+        coverage: 1, coverageBelowThreshold: false,
+        totalTrades: 2, tradesWithData: 2,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(<CycleConsistencyCard {...baseProps} opts={{ minDays: 5 }} />);
+
+    expect(screen.getByText(/Insuficiente · ≥5 dias/)).toBeTruthy();
+    expect(screen.queryByText(/BCB/)).toBeNull();
+  });
+
+  it('C5 — CV insufficientReason=no_target_rr mostra label de plano sem RR', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue({
+      sharpe: { value: 1.42, daysWithTrade: 12, source: 'BCB', fallbackUsed: false },
+      cvNormalized: {
+        value: null,
+        cvObs: null,
+        cvExp: null,
+        daysWithTrade: 12,
+        insufficientReason: 'no_target_rr',
+        label: 'Plano sem RR alvo definido — definir para ativar métrica',
+      },
+      avgExcursion: {
+        avgMEP: 1.0, avgMEN: -0.5,
+        coverage: 1, coverageBelowThreshold: false,
+        totalTrades: 12, tradesWithData: 12,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(<CycleConsistencyCard {...baseProps} />);
+
+    expect(screen.getByText(/Plano sem RR alvo definido/i)).toBeTruthy();
+  });
+
+  it('C6 — coverage abaixo do threshold exibe label de cobertura', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue({
+      sharpe: { value: 1.42, daysWithTrade: 12, source: 'BCB', fallbackUsed: false },
+      cvNormalized: { value: 1.05, cvObs: 9.66, cvExp: 9.20, daysWithTrade: 12 },
+      avgExcursion: {
+        avgMEP: 1.8, avgMEN: -0.6,
+        coverage: 0.5, coverageBelowThreshold: true,
+        coverageLabel: '⚠ MEP/MEN em 6 de 12 trades',
+        totalTrades: 12, tradesWithData: 6,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(<CycleConsistencyCard {...baseProps} />);
+
+    expect(screen.getByText(/MEP\/MEN em 6 de 12 trades/)).toBeTruthy();
+  });
+
+  it('C7 — DebugBadge presente com component="CycleConsistencyCard"', () => {
+    vi.mocked(useCycleConsistency).mockReturnValue(happyState);
+
+    render(<CycleConsistencyCard {...baseProps} />);
+
+    // DebugBadge default render: "{component} • {VERSION.display}"
+    expect(screen.getByText(/CycleConsistencyCard/)).toBeTruthy();
+  });
+});

--- a/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
+++ b/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
@@ -25,7 +25,7 @@ import { useCycleConsistency } from '../../../hooks/useCycleConsistency';
 
 const baseProps = {
   trades: [],
-  plan: { pl: 10000, targetRR: 2, expectedWinRate: 0.5 },
+  plan: { pl: 10000, rrTarget: 2 },
   cycleStart: '2026-02-01',
   cycleEnd: '2026-02-28',
 };

--- a/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
+++ b/src/__tests__/components/dashboard/CycleConsistencyCard.test.jsx
@@ -69,8 +69,8 @@ describe('CycleConsistencyCard', () => {
     // Sharpe row label inclui o ciclo
     expect(screen.getByText(/Sharpe \(FEV\/2026\)/)).toBeTruthy();
 
-    // Badge BCB presente, sem coverage warning
-    expect(screen.getByText(/BCB/)).toBeTruthy();
+    // Badge Selic atual presente (BCB), sem coverage warning
+    expect(screen.getByText(/Selic atual/)).toBeTruthy();
     expect(screen.queryByText(/MEP\/MEN em/)).toBeNull();
   });
 
@@ -120,7 +120,7 @@ describe('CycleConsistencyCard', () => {
     render(<CycleConsistencyCard {...baseProps} opts={{ minDays: 5 }} />);
 
     expect(screen.getByText(/Insuficiente · ≥5 dias/)).toBeTruthy();
-    expect(screen.queryByText(/BCB/)).toBeNull();
+    expect(screen.queryByText(/Selic atual/)).toBeNull();
   });
 
   it('C5 — CV insufficientReason=no_target_rr mostra label de plano sem RR', () => {

--- a/src/__tests__/hooks/useCycleConsistency.test.js
+++ b/src/__tests__/hooks/useCycleConsistency.test.js
@@ -1,0 +1,328 @@
+/**
+ * useCycleConsistency — issue #235 F2.1
+ *
+ * Cobertura:
+ *  C1 — sem trades / inputs ausentes → metrics null, loading=false
+ *  C2 — happy path: trades + plan + cycle válidos com Selic mockada
+ *  C3 — plan sem targetRR → cvNormalized.insufficientReason='no_target_rr'
+ *  C4 — plan sem pl inicial → sharpe.insufficientReason='no_pl_start'
+ *  C5 — getSelicForDateFn rejeita → error capturado, loading=false
+ *  C6 — re-render com trades atualizados → recomputa
+ *  C7 — unmount durante async → não setState pós-unmount (sem warning)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useCycleConsistency } from '../../hooks/useCycleConsistency';
+
+// --- Fixtures ----------------------------------------------------------------
+
+const CYCLE_START = '2026-02-01';
+const CYCLE_END = '2026-02-28';
+
+const mkTrade = (date, result, overrides = {}) => ({
+  date,
+  status: 'CLOSED',
+  result,
+  side: 'LONG',
+  entry: 100,
+  mepPrice: 102,
+  menPrice: 99,
+  ...overrides,
+});
+
+// 6 dias distintos com trade — supera default minDays=5 dos helpers
+const happyTrades = [
+  mkTrade('2026-02-02', 100),
+  mkTrade('2026-02-05', -50),
+  mkTrade('2026-02-09', 200),
+  mkTrade('2026-02-13', -80),
+  mkTrade('2026-02-17', 150),
+  mkTrade('2026-02-21', -30),
+];
+
+const happyPlan = {
+  pl: 10000,
+  targetRR: 2,
+  expectedWinRate: 0.5,
+};
+
+// Refs estáveis para evitar loop em useEffect (deps por referência)
+const EMPTY_TRADES = [];
+const PLAN_NO_RR = { pl: 10000 };
+const PLAN_NO_PL = { targetRR: 2, expectedWinRate: 0.5 };
+
+const mockSelicFn = vi.fn(async () => ({
+  rateDaily: 0.0006,
+  source: 'BCB',
+  dateUsed: '2026-02-02',
+  isCarryForward: false,
+  isFallback: false,
+}));
+
+// --- Tests -------------------------------------------------------------------
+
+describe('useCycleConsistency', () => {
+  beforeEach(() => {
+    mockSelicFn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // C1 ------------------------------------------------------------------------
+  it('C1 — sem trades retorna metrics null e loading=false', async () => {
+    const opts = { getSelicForDateFn: mockSelicFn };
+    const { result } = renderHook(() =>
+      useCycleConsistency({
+        trades: EMPTY_TRADES,
+        plan: happyPlan,
+        cycleStart: CYCLE_START,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.sharpe).not.toBeNull();
+    expect(result.current.sharpe.insufficientReason).toBe('min_days');
+    expect(result.current.cvNormalized).not.toBeNull();
+    expect(result.current.cvNormalized.insufficientReason).toBe('min_days');
+    expect(result.current.avgExcursion).not.toBeNull();
+    expect(result.current.avgExcursion.insufficientReason).toBe('no_trades');
+  });
+
+  it('C1b — inputs ausentes (sem cycleStart) retorna shape null/null/null', () => {
+    const opts = { getSelicForDateFn: mockSelicFn };
+    const { result } = renderHook(() =>
+      useCycleConsistency({
+        trades: happyTrades,
+        plan: happyPlan,
+        cycleStart: null,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.sharpe).toBeNull();
+    expect(result.current.cvNormalized).toBeNull();
+    expect(result.current.avgExcursion).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(mockSelicFn).not.toHaveBeenCalled();
+  });
+
+  // C2 ------------------------------------------------------------------------
+  it('C2 — happy path: 3 métricas populadas, loading=false, error=null', async () => {
+    const opts = { getSelicForDateFn: mockSelicFn };
+    const { result } = renderHook(() =>
+      useCycleConsistency({
+        trades: happyTrades,
+        plan: happyPlan,
+        cycleStart: CYCLE_START,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+
+    expect(result.current.sharpe).toMatchObject({
+      source: 'BCB',
+      fallbackUsed: false,
+      daysWithTrade: 6,
+    });
+    expect(typeof result.current.sharpe.value).toBe('number');
+    expect(Number.isFinite(result.current.sharpe.value)).toBe(true);
+
+    expect(result.current.cvNormalized).toMatchObject({ daysWithTrade: 6 });
+    expect(typeof result.current.cvNormalized.value).toBe('number');
+    expect(typeof result.current.cvNormalized.cvObs).toBe('number');
+    expect(typeof result.current.cvNormalized.cvExp).toBe('number');
+
+    expect(result.current.avgExcursion).toMatchObject({
+      totalTrades: 6,
+      tradesWithData: 6,
+      coverage: 1,
+      coverageBelowThreshold: false,
+    });
+    expect(result.current.avgExcursion.avgMEP).toBeCloseTo(2, 5);
+    expect(result.current.avgExcursion.avgMEN).toBeCloseTo(-1, 5);
+
+    expect(mockSelicFn).toHaveBeenCalledTimes(6);
+  });
+
+  // C3 ------------------------------------------------------------------------
+  it('C3 — plan sem targetRR: cvNormalized=no_target_rr, sharpe e avgExcursion ok', async () => {
+    const opts = { getSelicForDateFn: mockSelicFn };
+    const { result } = renderHook(() =>
+      useCycleConsistency({
+        trades: happyTrades,
+        plan: PLAN_NO_RR,
+        cycleStart: CYCLE_START,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.cvNormalized.insufficientReason).toBe('no_target_rr');
+    expect(result.current.cvNormalized.value).toBeNull();
+    expect(typeof result.current.sharpe.value).toBe('number');
+    expect(result.current.avgExcursion.tradesWithData).toBe(6);
+  });
+
+  // C4 ------------------------------------------------------------------------
+  it('C4 — plan sem pl inicial: sharpe.insufficientReason=no_pl_start, demais ok', async () => {
+    const opts = { getSelicForDateFn: mockSelicFn };
+    const { result } = renderHook(() =>
+      useCycleConsistency({
+        trades: happyTrades,
+        plan: PLAN_NO_PL,
+        cycleStart: CYCLE_START,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.sharpe.value).toBeNull();
+    expect(result.current.sharpe.insufficientReason).toBe('no_pl_start');
+    expect(typeof result.current.cvNormalized.value).toBe('number');
+    expect(result.current.avgExcursion.tradesWithData).toBe(6);
+    // Sharpe nem chamou Selic (curto-circuito no_pl_start)
+    expect(mockSelicFn).not.toHaveBeenCalled();
+  });
+
+  // C5 ------------------------------------------------------------------------
+  it('C5 — getSelicForDateFn rejeita: error capturado, loading=false', async () => {
+    const errFn = vi.fn(async () => {
+      throw new Error('selic boom');
+    });
+    const opts = { getSelicForDateFn: errFn };
+
+    const { result } = renderHook(() =>
+      useCycleConsistency({
+        trades: happyTrades,
+        plan: happyPlan,
+        cycleStart: CYCLE_START,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error.message).toBe('selic boom');
+    expect(result.current.sharpe).toBeNull();
+    expect(result.current.cvNormalized).toBeNull();
+    expect(result.current.avgExcursion).toBeNull();
+  });
+
+  // C6 ------------------------------------------------------------------------
+  it('C6 — re-render com trades atualizados recomputa', async () => {
+    const opts = { getSelicForDateFn: mockSelicFn };
+    const { result, rerender } = renderHook(
+      (props) => useCycleConsistency(props),
+      {
+        initialProps: {
+          trades: happyTrades,
+          plan: happyPlan,
+          cycleStart: CYCLE_START,
+          cycleEnd: CYCLE_END,
+          opts,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.avgExcursion.totalTrades).toBe(6);
+
+    const moreTrades = [...happyTrades, mkTrade('2026-02-25', 50)];
+    rerender({
+      trades: moreTrades,
+      plan: happyPlan,
+      cycleStart: CYCLE_START,
+      cycleEnd: CYCLE_END,
+      opts,
+    });
+
+    await waitFor(() => {
+      expect(result.current.avgExcursion?.totalTrades).toBe(7);
+    });
+    expect(result.current.cvNormalized.daysWithTrade).toBe(7);
+  });
+
+  // C7 ------------------------------------------------------------------------
+  it('C7 — unmount durante async não dispara setState pós-unmount', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    let resolveSelic;
+    const slowSelicFn = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSelic = resolve;
+        })
+    );
+
+    const opts = { getSelicForDateFn: slowSelicFn };
+    const { unmount } = renderHook(() =>
+      useCycleConsistency({
+        trades: happyTrades,
+        plan: happyPlan,
+        cycleStart: CYCLE_START,
+        cycleEnd: CYCLE_END,
+        opts,
+      })
+    );
+
+    // Aguarda a promessa lenta começar (helper computeCycleSharpe chama getSelicFn)
+    await waitFor(() => {
+      expect(slowSelicFn).toHaveBeenCalled();
+    });
+
+    unmount();
+
+    // Resolve depois do unmount — não deve disparar setState
+    await act(async () => {
+      resolveSelic({
+        rateDaily: 0.0006,
+        source: 'BCB',
+        dateUsed: '2026-02-02',
+        isCarryForward: false,
+        isFallback: false,
+      });
+      await Promise.resolve();
+    });
+
+    // Nenhum erro/warning de "setState on unmounted component" deve ter sido logado
+    const setStateWarning = consoleErrorSpy.mock.calls.find((call) =>
+      String(call[0] ?? '').includes('unmounted')
+    );
+    expect(setStateWarning).toBeUndefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/__tests__/hooks/useCycleConsistency.test.js
+++ b/src/__tests__/hooks/useCycleConsistency.test.js
@@ -4,7 +4,7 @@
  * Cobertura:
  *  C1 — sem trades / inputs ausentes → metrics null, loading=false
  *  C2 — happy path: trades + plan + cycle válidos com Selic mockada
- *  C3 — plan sem targetRR → cvNormalized.insufficientReason='no_target_rr'
+ *  C3 — plan sem rrTarget → cvNormalized.insufficientReason='no_target_rr'
  *  C4 — plan sem pl inicial → sharpe.insufficientReason='no_pl_start'
  *  C5 — getSelicForDateFn rejeita → error capturado, loading=false
  *  C6 — re-render com trades atualizados → recomputa
@@ -43,14 +43,13 @@ const happyTrades = [
 
 const happyPlan = {
   pl: 10000,
-  targetRR: 2,
-  expectedWinRate: 0.5,
+  rrTarget: 2,
 };
 
 // Refs estáveis para evitar loop em useEffect (deps por referência)
 const EMPTY_TRADES = [];
 const PLAN_NO_RR = { pl: 10000 };
-const PLAN_NO_PL = { targetRR: 2, expectedWinRate: 0.5 };
+const PLAN_NO_PL = { rrTarget: 2 };
 
 const mockSelicFn = vi.fn(async () => ({
   rateDaily: 0.0006,
@@ -162,7 +161,7 @@ describe('useCycleConsistency', () => {
   });
 
   // C3 ------------------------------------------------------------------------
-  it('C3 — plan sem targetRR: cvNormalized=no_target_rr, sharpe e avgExcursion ok', async () => {
+  it('C3 — plan sem rrTarget: cvNormalized=no_target_rr, sharpe e avgExcursion ok', async () => {
     const opts = { getSelicForDateFn: mockSelicFn };
     const { result } = renderHook(() =>
       useCycleConsistency({

--- a/src/__tests__/utils/clientSnapshotBuilder.test.js
+++ b/src/__tests__/utils/clientSnapshotBuilder.test.js
@@ -326,4 +326,74 @@ describe('buildClientSnapshot', () => {
       expect(buildClientSnapshot({ plan, trades: [], maturity: [] }).maturitySnapshot).toBeNull();
     });
   });
+
+  // === Issue #235 F3.1 — kpis.cvNormalized (CV normalizado per-ciclo) ===
+
+  describe('kpis.cvNormalized — CV normalizado per-ciclo (issue #235)', () => {
+    // Plano com targetRR para ativar fórmula analítica de cv_exp.
+    // Note: o helper lê `plan.targetRR` (não `plan.rrTarget`).
+    const planCycle = { id: 'plan1', adjustmentCycle: 'Mensal', pl: 10000, targetRR: 3, expectedWinRate: 0.5 };
+
+    it('C1 — sem cycleStart/cycleEnd → cvNormalized é null (campo presente, valor null)', () => {
+      const snap = buildClientSnapshot({ plan: planCycle, trades: [mkTrade({ id: 't1', result: 50 })] });
+      expect(snap.kpis).toHaveProperty('cvNormalized');
+      expect(snap.kpis.cvNormalized).toBeNull();
+    });
+
+    it('C2 — com cycleStart/cycleEnd válidos + trades em ≥5 dias + targetRR → value populado', () => {
+      // 5 dias com trade (mínimo do helper) com magnitudes variando para ter std/mean computáveis.
+      const trades = [
+        mkTrade({ id: 'd1', result: 100, date: '2026-04-01', status: 'CLOSED' }),
+        mkTrade({ id: 'd2', result: -50, date: '2026-04-02', status: 'CLOSED' }),
+        mkTrade({ id: 'd3', result: 200, date: '2026-04-03', status: 'CLOSED' }),
+        mkTrade({ id: 'd4', result: -80, date: '2026-04-04', status: 'CLOSED' }),
+        mkTrade({ id: 'd5', result: 300, date: '2026-04-05', status: 'CLOSED' }),
+      ];
+      const snap = buildClientSnapshot({
+        plan: planCycle,
+        trades,
+        cycleStart: '2026-04-01',
+        cycleEnd: '2026-04-30',
+      });
+      expect(snap.kpis.cvNormalized).not.toBeNull();
+      expect(typeof snap.kpis.cvNormalized.value).toBe('number');
+      expect(Number.isFinite(snap.kpis.cvNormalized.value)).toBe(true);
+      expect(snap.kpis.cvNormalized.daysWithTrade).toBe(5);
+      expect(snap.kpis.cvNormalized.insufficientReason).toBeNull();
+      expect(typeof snap.kpis.cvNormalized.cvObs).toBe('number');
+      expect(typeof snap.kpis.cvNormalized.cvExp).toBe('number');
+    });
+
+    it('C3 — com cycleStart/cycleEnd, plan sem targetRR → value null + insufficientReason="no_target_rr"', () => {
+      const trades = [
+        mkTrade({ id: 'd1', result: 100, date: '2026-04-01', status: 'CLOSED' }),
+        mkTrade({ id: 'd2', result: -50, date: '2026-04-02', status: 'CLOSED' }),
+        mkTrade({ id: 'd3', result: 200, date: '2026-04-03', status: 'CLOSED' }),
+        mkTrade({ id: 'd4', result: -80, date: '2026-04-04', status: 'CLOSED' }),
+        mkTrade({ id: 'd5', result: 300, date: '2026-04-05', status: 'CLOSED' }),
+      ];
+      // Plan sem targetRR — herda de `plan` base (que tem rrTarget mas NÃO targetRR).
+      const snap = buildClientSnapshot({
+        plan,
+        trades,
+        cycleStart: '2026-04-01',
+        cycleEnd: '2026-04-30',
+      });
+      expect(snap.kpis.cvNormalized).not.toBeNull();
+      expect(snap.kpis.cvNormalized.value).toBeNull();
+      expect(snap.kpis.cvNormalized.insufficientReason).toBe('no_target_rr');
+    });
+
+    it('coefVariation (CV puro) permanece presente — compat reversa', () => {
+      const trades = [100, 102, 98].map((r, i) => mkTrade({ id: `h${i}`, result: r }));
+      const snap = buildClientSnapshot({
+        plan: planCycle,
+        trades,
+        cycleStart: '2026-04-01',
+        cycleEnd: '2026-04-30',
+      });
+      expect(snap.kpis).toHaveProperty('coefVariation');
+      expect(typeof snap.kpis.coefVariation).toBe('number');
+    });
+  });
 });

--- a/src/__tests__/utils/clientSnapshotBuilder.test.js
+++ b/src/__tests__/utils/clientSnapshotBuilder.test.js
@@ -330,9 +330,8 @@ describe('buildClientSnapshot', () => {
   // === Issue #235 F3.1 — kpis.cvNormalized (CV normalizado per-ciclo) ===
 
   describe('kpis.cvNormalized — CV normalizado per-ciclo (issue #235)', () => {
-    // Plano com targetRR para ativar fórmula analítica de cv_exp.
-    // Note: o helper lê `plan.targetRR` (não `plan.rrTarget`).
-    const planCycle = { id: 'plan1', adjustmentCycle: 'Mensal', pl: 10000, targetRR: 3, expectedWinRate: 0.5 };
+    // Plano com rrTarget (campo canônico) para ativar fórmula analítica de cv_exp.
+    const planCycle = { id: 'plan1', adjustmentCycle: 'Mensal', pl: 10000, rrTarget: 3 };
 
     it('C1 — sem cycleStart/cycleEnd → cvNormalized é null (campo presente, valor null)', () => {
       const snap = buildClientSnapshot({ plan: planCycle, trades: [mkTrade({ id: 't1', result: 50 })] });
@@ -340,7 +339,7 @@ describe('buildClientSnapshot', () => {
       expect(snap.kpis.cvNormalized).toBeNull();
     });
 
-    it('C2 — com cycleStart/cycleEnd válidos + trades em ≥5 dias + targetRR → value populado', () => {
+    it('C2 — com cycleStart/cycleEnd válidos + trades em ≥5 dias + rrTarget → value populado', () => {
       // 5 dias com trade (mínimo do helper) com magnitudes variando para ter std/mean computáveis.
       const trades = [
         mkTrade({ id: 'd1', result: 100, date: '2026-04-01', status: 'CLOSED' }),
@@ -364,7 +363,7 @@ describe('buildClientSnapshot', () => {
       expect(typeof snap.kpis.cvNormalized.cvExp).toBe('number');
     });
 
-    it('C3 — com cycleStart/cycleEnd, plan sem targetRR → value null + insufficientReason="no_target_rr"', () => {
+    it('C3 — com cycleStart/cycleEnd, plan sem rrTarget → value null + insufficientReason="no_target_rr"', () => {
       const trades = [
         mkTrade({ id: 'd1', result: 100, date: '2026-04-01', status: 'CLOSED' }),
         mkTrade({ id: 'd2', result: -50, date: '2026-04-02', status: 'CLOSED' }),
@@ -372,9 +371,10 @@ describe('buildClientSnapshot', () => {
         mkTrade({ id: 'd4', result: -80, date: '2026-04-04', status: 'CLOSED' }),
         mkTrade({ id: 'd5', result: 300, date: '2026-04-05', status: 'CLOSED' }),
       ];
-      // Plan sem targetRR — herda de `plan` base (que tem rrTarget mas NÃO targetRR).
+      // Plan sem rrTarget definido (campo ausente).
+      const planNoRR = { id: 'plan1', adjustmentCycle: 'Mensal', pl: 10000 };
       const snap = buildClientSnapshot({
-        plan,
+        plan: planNoRR,
         trades,
         cycleStart: '2026-04-01',
         cycleEnd: '2026-04-30',

--- a/src/__tests__/utils/cycleConsistency/computeAvgExcursion.test.js
+++ b/src/__tests__/utils/cycleConsistency/computeAvgExcursion.test.js
@@ -1,0 +1,202 @@
+/**
+ * computeAvgExcursion.test.js — issue #235 F1.3 (ESM)
+ *
+ * Cobre 9 cenários (C1..C9) conforme critérios de aceitação no body do issue:
+ *   C1 — janela vazia → insufficientReason 'no_trades'
+ *   C2 — todos sem mepPrice/menPrice → insufficientReason 'no_excursion_data'
+ *   C3 — LONG happy path: avgMEP=+2.0, avgMEN=-1.0, coverage=1.0
+ *   C4 — SHORT happy path: sinais invertidos pela fórmula
+ *   C5 — coverage abaixo do threshold (4/10 < 0.7) → label avisando
+ *   C6 — mix LONG+SHORT no ciclo, médias agregadas corretamente
+ *   C7 — side inválido ('BUY') pulado, não conta em tradesWithData
+ *   C8 — entry=0 pulado (evita divisão por zero)
+ *   C9 — excursionPctForTrade puro: LONG/SHORT/inválido/sem dado
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeAvgExcursion,
+  excursionPctForTrade,
+} from '../../../utils/cycleConsistency/computeAvgExcursion.js';
+
+describe('computeAvgExcursion (ESM)', () => {
+  it('C1 — janela vazia retorna null com insufficientReason no_trades', () => {
+    const result = computeAvgExcursion([], '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeNull();
+    expect(result.avgMEN).toBeNull();
+    expect(result.coverage).toBe(0);
+    expect(result.coverageBelowThreshold).toBe(false);
+    expect(result.totalTrades).toBe(0);
+    expect(result.tradesWithData).toBe(0);
+    expect(result.insufficientReason).toBe('no_trades');
+    expect(result.coverageLabel).toBeUndefined();
+  });
+
+  it('C2 — trades só com mepPrice/menPrice null retorna no_excursion_data', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: null, menPrice: null },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: null, menPrice: null },
+      { date: '04/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: null, menPrice: null },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeNull();
+    expect(result.avgMEN).toBeNull();
+    expect(result.coverage).toBe(0);
+    expect(result.totalTrades).toBe(3);
+    expect(result.tradesWithData).toBe(0);
+    expect(result.insufficientReason).toBe('no_excursion_data');
+  });
+
+  it('C3 — LONG happy path: 5 trades entry=100 mep=102 men=99 → +2.0% / -1.0% coverage 1.0', () => {
+    const trades = Array.from({ length: 5 }, (_, i) => ({
+      date: `0${i + 2}/02/2026`,
+      status: 'CLOSED',
+      side: 'LONG',
+      entry: 100,
+      mepPrice: 102,
+      menPrice: 99,
+    }));
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+    expect(result.coverage).toBe(1.0);
+    expect(result.coverageBelowThreshold).toBe(false);
+    expect(result.coverageLabel).toBeUndefined();
+    expect(result.totalTrades).toBe(5);
+    expect(result.tradesWithData).toBe(5);
+    expect(result.insufficientReason).toBeUndefined();
+  });
+
+  it('C4 — SHORT happy path: entry=100 mep=98 men=101 → +2.0% / -1.0% (sinais invertidos)', () => {
+    const trades = Array.from({ length: 4 }, (_, i) => ({
+      date: `0${i + 2}/02/2026`,
+      status: 'CLOSED',
+      side: 'SHORT',
+      entry: 100,
+      mepPrice: 98,
+      menPrice: 101,
+    }));
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+    expect(result.coverage).toBe(1.0);
+    expect(result.coverageBelowThreshold).toBe(false);
+    expect(result.tradesWithData).toBe(4);
+  });
+
+  it('C5 — coverage 4/10 < 0.7 → coverageBelowThreshold true + label apropriado', () => {
+    const withData = Array.from({ length: 4 }, (_, i) => ({
+      date: `0${i + 2}/02/2026`,
+      status: 'CLOSED',
+      side: 'LONG',
+      entry: 100,
+      mepPrice: 102,
+      menPrice: 99,
+    }));
+    const withoutData = Array.from({ length: 6 }, (_, i) => ({
+      date: `${(i + 6).toString().padStart(2, '0')}/02/2026`,
+      status: 'CLOSED',
+      side: 'LONG',
+      entry: 100,
+      mepPrice: null,
+      menPrice: null,
+    }));
+    const result = computeAvgExcursion([...withData, ...withoutData], '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(10);
+    expect(result.tradesWithData).toBe(4);
+    expect(result.coverage).toBeCloseTo(0.4, 10);
+    expect(result.coverageBelowThreshold).toBe(true);
+    expect(result.coverageLabel).toBe('⚠ MEP/MEN em 4 de 10 trades');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+  });
+
+  it('C6 — mix LONG+SHORT no ciclo, médias agregadas corretamente', () => {
+    // 2 LONG (entry=100, mep=104, men=98) → mepPct=+4, menPct=-2
+    // 2 SHORT (entry=200, mep=196, men=202) → mepPct=+2, menPct=-1
+    // avgMEP = mean([+4,+4,+2,+2]) = +3.0
+    // avgMEN = mean([-2,-2,-1,-1]) = -1.5
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG',  entry: 100, mepPrice: 104, menPrice: 98 },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG',  entry: 100, mepPrice: 104, menPrice: 98 },
+      { date: '04/02/2026', status: 'CLOSED', side: 'SHORT', entry: 200, mepPrice: 196, menPrice: 202 },
+      { date: '05/02/2026', status: 'CLOSED', side: 'SHORT', entry: 200, mepPrice: 196, menPrice: 202 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.tradesWithData).toBe(4);
+    expect(result.avgMEP).toBeCloseTo(3.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.5, 10);
+    expect(result.coverage).toBe(1.0);
+  });
+
+  it('C7 — side inválido (BUY) é pulado, não conta em tradesWithData', () => {
+    // 3 LONG válidos + 2 com side='BUY' (inválido).
+    // totalTrades=5, tradesWithData=3, coverage=3/5=0.6 (< 0.7 → label).
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '04/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '05/02/2026', status: 'CLOSED', side: 'BUY',  entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '06/02/2026', status: 'CLOSED', side: 'BUY',  entry: 100, mepPrice: 102, menPrice: 99 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(5);
+    expect(result.tradesWithData).toBe(3);
+    expect(result.coverage).toBeCloseTo(0.6, 10);
+    expect(result.coverageBelowThreshold).toBe(true);
+    expect(result.coverageLabel).toBe('⚠ MEP/MEN em 3 de 5 trades');
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+  });
+
+  it('C8 — entry=0 (e entry inválido) é pulado para evitar divisão por zero', () => {
+    const trades = [
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      { date: '03/02/2026', status: 'CLOSED', side: 'LONG', entry: 0,   mepPrice: 102, menPrice: 99 },
+      { date: '04/02/2026', status: 'CLOSED', side: 'LONG', entry: -10, mepPrice: 102, menPrice: 99 },
+      { date: '05/02/2026', status: 'CLOSED', side: 'LONG', entry: NaN, mepPrice: 102, menPrice: 99 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(4);
+    expect(result.tradesWithData).toBe(1);
+    expect(result.coverage).toBeCloseTo(0.25, 10);
+    expect(result.avgMEP).toBeCloseTo(2.0, 10);
+    expect(result.avgMEN).toBeCloseTo(-1.0, 10);
+  });
+
+  it('C9 — excursionPctForTrade puro: LONG, SHORT, inválido, sem dado', () => {
+    // LONG válido
+    expect(excursionPctForTrade({ side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 }))
+      .toEqual({ mepPct: 2.0, menPct: -1.0 });
+    // SHORT válido
+    expect(excursionPctForTrade({ side: 'SHORT', entry: 100, mepPrice: 98, menPrice: 101 }))
+      .toEqual({ mepPct: 2.0, menPct: -1.0 });
+    // side inválido
+    expect(excursionPctForTrade({ side: 'BUY', entry: 100, mepPrice: 102, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: undefined, entry: 100, mepPrice: 102, menPrice: 99 })).toBeNull();
+    // mepPrice/menPrice ausentes
+    expect(excursionPctForTrade({ side: 'LONG', entry: 100, mepPrice: null, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: 'LONG', entry: 100, mepPrice: 102, menPrice: undefined })).toBeNull();
+    // entry inválido
+    expect(excursionPctForTrade({ side: 'LONG', entry: 0, mepPrice: 102, menPrice: 99 })).toBeNull();
+    expect(excursionPctForTrade({ side: 'LONG', entry: NaN, mepPrice: 102, menPrice: 99 })).toBeNull();
+    // trade null
+    expect(excursionPctForTrade(null)).toBeNull();
+  });
+
+  it('helper — filtra fora-janela e status != CLOSED', () => {
+    const trades = [
+      // dentro janela, CLOSED, com dado
+      { date: '02/02/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      // dentro janela, mas OPEN → ignorado
+      { date: '03/02/2026', status: 'OPEN',   side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      // fora janela (antes), CLOSED → ignorado
+      { date: '01/01/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+      // fora janela (depois), CLOSED → ignorado
+      { date: '01/03/2026', status: 'CLOSED', side: 'LONG', entry: 100, mepPrice: 102, menPrice: 99 },
+    ];
+    const result = computeAvgExcursion(trades, '2026-02-01', '2026-02-28');
+    expect(result.totalTrades).toBe(1);
+    expect(result.tradesWithData).toBe(1);
+  });
+});

--- a/src/__tests__/utils/cycleConsistency/computeCVNormalized.test.js
+++ b/src/__tests__/utils/cycleConsistency/computeCVNormalized.test.js
@@ -1,0 +1,224 @@
+/**
+ * computeCVNormalized.test.js — issue #235 F1.2 (ESM)
+ *
+ * Cobre 10 cenários:
+ *  C1 — janela vazia → null, min_days
+ *  C2 — 4 dias com trade (< minDays=5) → null, min_days
+ *  C3 — plan sem targetRR → null, no_target_rr
+ *  C4 — calibração spec issue body: 7L+3G@3R em 10 dias → cv_normalized ≈ 1.05 ±0.05
+ *  C5 — plano breakeven (WR efetiva 0.25 / RR 3) → null, breakeven_plan
+ *  C6 — mean_obs ≈ 0 (P&L diário simétrico) → null, zero_obs_mean
+ *  C7 — happy path: WR efetiva difere de plan.expectedWinRate, usa efetiva
+ *  C8 — fallback plan.expectedWinRate quando WR efetiva indefinida (helper)
+ *  C9 — effectiveWinRate puro: 7L+3G → 0.3
+ *  C10 — computeCvExpected(0.3, 3): mean=0.20, std≈1.833, cv≈9.17
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeCVNormalized,
+  groupTradesByDay,
+  effectiveWinRate,
+  computeCvObserved,
+  computeCvExpected,
+  resolveWinRate,
+} from '../../../utils/cycleConsistency/computeCVNormalized.js';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+// Calibração C4: 10 trades em 10 dias úteis distintos, 7L (-100) + 3G (+300).
+// Pattern alternado para aproximar distribuição "realista":
+//   PL/dia = [-100,-100,-100,+300,-100,-100,+300,-100,-100,+300]
+//   mean_obs = (3·300 + 7·-100) / 10 = 200/10 = 20
+//   var_sample = (7·14400 + 3·78400) / 9 = 336000/9 = 37333.33
+//   std_obs = 193.218 → cv_obs = 9.66
+// Plano {targetRR: 3} → mean_exp = 0.20, var_exp = 3.36, cv_exp = 9.165
+// cv_normalized = 9.66 / 9.165 ≈ 1.054
+const CALIB_TRADES = [
+  { date: '02/02/2026', result: -100, status: 'CLOSED' },
+  { date: '03/02/2026', result: -100, status: 'CLOSED' },
+  { date: '04/02/2026', result: -100, status: 'CLOSED' },
+  { date: '05/02/2026', result: +300, status: 'CLOSED' },
+  { date: '06/02/2026', result: -100, status: 'CLOSED' },
+  { date: '09/02/2026', result: -100, status: 'CLOSED' },
+  { date: '10/02/2026', result: +300, status: 'CLOSED' },
+  { date: '11/02/2026', result: -100, status: 'CLOSED' },
+  { date: '12/02/2026', result: -100, status: 'CLOSED' },
+  { date: '13/02/2026', result: +300, status: 'CLOSED' },
+];
+
+describe('computeCVNormalized (ESM)', () => {
+  it('C1 — janela vazia retorna null com insufficientReason min_days', () => {
+    const result = computeCVNormalized([], { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.cvObs).toBeNull();
+    expect(result.cvExp).toBeNull();
+    expect(result.daysWithTrade).toBe(0);
+    expect(result.insufficientReason).toBe('min_days');
+    expect(result.label).toBe('Insuficiente · ≥5 dias');
+  });
+
+  it('C2 — 4 dias com trade (< minDays=5) retorna null min_days', () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '05/02/2026', result: 75, status: 'CLOSED' },
+    ];
+    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(4);
+    expect(result.insufficientReason).toBe('min_days');
+  });
+
+  it('C3 — plan sem targetRR retorna null no_target_rr com label apropriado', () => {
+    const result = computeCVNormalized(CALIB_TRADES, {}, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(10);
+    expect(result.insufficientReason).toBe('no_target_rr');
+    expect(result.label).toBe('Plano sem RR alvo definido — definir para ativar métrica');
+  });
+
+  it('C4 — calibração spec issue body (7L+3G@3R, 10 dias) → cv_normalized ≈ 1.05 ± 0.05', () => {
+    const result = computeCVNormalized(
+      CALIB_TRADES,
+      { targetRR: 3 },
+      '2026-02-01',
+      '2026-02-28'
+    );
+    expect(result.daysWithTrade).toBe(10);
+    expect(result.value).not.toBeNull();
+    expect(result.cvObs).toBeCloseTo(9.66, 1);
+    expect(result.cvExp).toBeCloseTo(9.165, 2);
+    expect(result.value).toBeGreaterThan(1.00);
+    expect(result.value).toBeLessThan(1.10);
+  });
+
+  it('C5 — plano breakeven (WR efetiva 0.25 / RR 3 → mean_exp 0) retorna null breakeven_plan', () => {
+    // 8 trades em 5 dias, 2 wins + 6 losses, WR=2/8=0.25.
+    // Magnitudes diferentes para evitar mean_obs=0 (queremos breakeven_plan, não zero_obs_mean):
+    //   wins=+500 cada, losses=-50 cada.
+    //   PL/dia = [+1000, -100, -100, -50, -50] (sum=700, mean=140)
+    const trades = [
+      { date: '02/02/2026', result: +500, status: 'CLOSED' },
+      { date: '02/02/2026', result: +500, status: 'CLOSED' },
+      { date: '03/02/2026', result: -50, status: 'CLOSED' },
+      { date: '03/02/2026', result: -50, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '05/02/2026', result: -50, status: 'CLOSED' },
+      { date: '06/02/2026', result: -50, status: 'CLOSED' },
+    ];
+    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(5);
+    expect(result.insufficientReason).toBe('breakeven_plan');
+    expect(result.label).toBe('Plano com expectância nula — métrica indefinida');
+  });
+
+  it('C6 — mean_obs ≈ 0 (P&L diário simétrico) retorna null zero_obs_mean', () => {
+    // 6 dias alternando +1000/-1000 → soma 0 → mean_obs 0.
+    // WR=3/6=0.5, RR=2 → mean_exp = 0.5·2 - 0.5 = +0.5 (válido, não breakeven).
+    const trades = [
+      { date: '02/02/2026', result: +1000, status: 'CLOSED' },
+      { date: '03/02/2026', result: -1000, status: 'CLOSED' },
+      { date: '04/02/2026', result: +1000, status: 'CLOSED' },
+      { date: '05/02/2026', result: -1000, status: 'CLOSED' },
+      { date: '06/02/2026', result: +1000, status: 'CLOSED' },
+      { date: '09/02/2026', result: -1000, status: 'CLOSED' },
+    ];
+    const result = computeCVNormalized(trades, { targetRR: 2 }, '2026-02-01', '2026-02-28');
+    expect(result.value).toBeNull();
+    expect(result.daysWithTrade).toBe(6);
+    expect(result.insufficientReason).toBe('zero_obs_mean');
+    expect(result.cvExp).not.toBeNull();
+    expect(result.label).toBe('P&L médio diário próximo de zero — CV indefinido');
+  });
+
+  it('C7 — happy path: WR efetiva difere de plan.expectedWinRate, helper usa a efetiva', () => {
+    // CALIB_TRADES: WR efetiva = 3/10 = 0.30 (igual ao spec).
+    // Plan: targetRR=3, expectedWinRate=0.50 (sintético, deveria ser ignorado).
+    // Se efetiva for usada (0.30): cv_exp = 9.165 → cv_normalized ≈ 1.054.
+    // Se fallback fosse usado (0.50): mean_exp = 1.0, cv_exp ≈ 2.0 → cv_normalized ≈ 4.83.
+    const result = computeCVNormalized(
+      CALIB_TRADES,
+      { targetRR: 3, expectedWinRate: 0.50 },
+      '2026-02-01',
+      '2026-02-28'
+    );
+    expect(result.value).not.toBeNull();
+    expect(result.cvExp).toBeCloseTo(9.165, 2);
+    expect(result.value).toBeGreaterThan(1.00);
+    expect(result.value).toBeLessThan(1.10);
+  });
+
+  it('C8 — fallback plan.expectedWinRate quando WR efetiva indefinida (resolveWinRate)', () => {
+    // resolveWinRate sem trades → fallback para plan.expectedWinRate.
+    expect(resolveWinRate([], { expectedWinRate: 0.42 })).toBe(0.42);
+    expect(resolveWinRate([], {})).toBeNull();
+    expect(resolveWinRate([], null)).toBeNull();
+
+    // Precedência: trades disponíveis sempre vencem fallback.
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '02/02/2026', result: -50, status: 'CLOSED' },
+      { date: '02/02/2026', result: -50, status: 'CLOSED' },
+    ];
+    expect(resolveWinRate(trades, { expectedWinRate: 0.99 })).toBe(0.5);
+  });
+
+  it('C9 — effectiveWinRate puro: 7L+3G → 0.3', () => {
+    expect(effectiveWinRate(CALIB_TRADES)).toBeCloseTo(0.3, 10);
+    expect(effectiveWinRate([])).toBeNull();
+    expect(effectiveWinRate([{ result: 100, status: 'CLOSED' }])).toBe(1);
+    expect(effectiveWinRate([{ result: -100, status: 'CLOSED' }])).toBe(0);
+    // Trades não-CLOSED ou result não-numérico são ignorados no denominador.
+    const mixed = [
+      { result: 100, status: 'OPEN' },
+      { result: 100, status: 'CLOSED' },
+      { result: 'NaN', status: 'CLOSED' },
+      { result: -50, status: 'CLOSED' },
+    ];
+    expect(effectiveWinRate(mixed)).toBeCloseTo(0.5, 10);
+  });
+
+  it('C10 — computeCvExpected(0.3, 3): mean=0.20, std≈1.833, cv≈9.165', () => {
+    const out = computeCvExpected(0.3, 3);
+    expect(out.mean).toBeCloseTo(0.20, 10);
+    expect(out.std).toBeCloseTo(Math.sqrt(3.36), 6);
+    expect(out.cv).toBeCloseTo(9.165, 2);
+
+    // Plano breakeven: WR=0.25, RR=3 → mean_exp = 0 → cv null.
+    const breakeven = computeCvExpected(0.25, 3);
+    expect(breakeven.cv).toBeNull();
+    expect(Math.abs(breakeven.mean)).toBeLessThan(1e-9);
+  });
+
+  it('helper — computeCvObserved sample N-1, edge cases', () => {
+    expect(computeCvObserved([])).toEqual({ cv: null, mean: 0, std: 0 });
+    // 1 ponto: std=0, mean=valor, cv=0 quando |mean|>0.
+    const single = computeCvObserved([100]);
+    expect(single.mean).toBe(100);
+    expect(single.std).toBe(0);
+    expect(single.cv).toBe(0);
+    // 1 ponto em zero: cv null (CV indefinido).
+    expect(computeCvObserved([0]).cv).toBeNull();
+    // P&L diário simétrico → mean ≈ 0 → cv null.
+    expect(computeCvObserved([100, -100, 100, -100]).cv).toBeNull();
+  });
+
+  it('helper — groupTradesByDay filtra fora-janela e status != CLOSED', () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'OPEN' },
+      { date: '01/01/2026', result: 999, status: 'CLOSED' },
+      { date: '05/02/2026', result: 150, status: 'CLOSED' },
+      { date: '05/02/2026', result: 50, status: 'CLOSED' },
+    ];
+    const map = groupTradesByDay(trades, '2026-02-01', '2026-02-28');
+    expect(map.size).toBe(2);
+    expect(map.get('2026-02-02')).toBe(100);
+    expect(map.get('2026-02-05')).toBe(200);
+  });
+});

--- a/src/__tests__/utils/cycleConsistency/computeCVNormalized.test.js
+++ b/src/__tests__/utils/cycleConsistency/computeCVNormalized.test.js
@@ -4,12 +4,12 @@
  * Cobre 10 cenários:
  *  C1 — janela vazia → null, min_days
  *  C2 — 4 dias com trade (< minDays=5) → null, min_days
- *  C3 — plan sem targetRR → null, no_target_rr
+ *  C3 — plan sem rrTarget → null, no_target_rr
  *  C4 — calibração spec issue body: 7L+3G@3R em 10 dias → cv_normalized ≈ 1.05 ±0.05
  *  C5 — plano breakeven (WR efetiva 0.25 / RR 3) → null, breakeven_plan
  *  C6 — mean_obs ≈ 0 (P&L diário simétrico) → null, zero_obs_mean
- *  C7 — happy path: WR efetiva difere de plan.expectedWinRate, usa efetiva
- *  C8 — fallback plan.expectedWinRate quando WR efetiva indefinida (helper)
+ *  C7 — happy path: usa WR efetiva quando trades suficientes (ignora fallback)
+ *  C8 — fallback breakeven 1/(1+RR) quando WR efetiva indefinida (helper)
  *  C9 — effectiveWinRate puro: 7L+3G → 0.3
  *  C10 — computeCvExpected(0.3, 3): mean=0.20, std≈1.833, cv≈9.17
  */
@@ -32,7 +32,7 @@ import {
 //   mean_obs = (3·300 + 7·-100) / 10 = 200/10 = 20
 //   var_sample = (7·14400 + 3·78400) / 9 = 336000/9 = 37333.33
 //   std_obs = 193.218 → cv_obs = 9.66
-// Plano {targetRR: 3} → mean_exp = 0.20, var_exp = 3.36, cv_exp = 9.165
+// Plano {rrTarget: 3} → mean_exp = 0.20, var_exp = 3.36, cv_exp = 9.165
 // cv_normalized = 9.66 / 9.165 ≈ 1.054
 const CALIB_TRADES = [
   { date: '02/02/2026', result: -100, status: 'CLOSED' },
@@ -49,7 +49,7 @@ const CALIB_TRADES = [
 
 describe('computeCVNormalized (ESM)', () => {
   it('C1 — janela vazia retorna null com insufficientReason min_days', () => {
-    const result = computeCVNormalized([], { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized([], { rrTarget: 3 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.cvObs).toBeNull();
     expect(result.cvExp).toBeNull();
@@ -65,13 +65,13 @@ describe('computeCVNormalized (ESM)', () => {
       { date: '04/02/2026', result: -50, status: 'CLOSED' },
       { date: '05/02/2026', result: 75, status: 'CLOSED' },
     ];
-    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized(trades, { rrTarget: 3 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(4);
     expect(result.insufficientReason).toBe('min_days');
   });
 
-  it('C3 — plan sem targetRR retorna null no_target_rr com label apropriado', () => {
+  it('C3 — plan sem rrTarget retorna null no_target_rr com label apropriado', () => {
     const result = computeCVNormalized(CALIB_TRADES, {}, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(10);
@@ -82,7 +82,7 @@ describe('computeCVNormalized (ESM)', () => {
   it('C4 — calibração spec issue body (7L+3G@3R, 10 dias) → cv_normalized ≈ 1.05 ± 0.05', () => {
     const result = computeCVNormalized(
       CALIB_TRADES,
-      { targetRR: 3 },
+      { rrTarget: 3 },
       '2026-02-01',
       '2026-02-28'
     );
@@ -109,7 +109,7 @@ describe('computeCVNormalized (ESM)', () => {
       { date: '05/02/2026', result: -50, status: 'CLOSED' },
       { date: '06/02/2026', result: -50, status: 'CLOSED' },
     ];
-    const result = computeCVNormalized(trades, { targetRR: 3 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized(trades, { rrTarget: 3 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(5);
     expect(result.insufficientReason).toBe('breakeven_plan');
@@ -127,7 +127,7 @@ describe('computeCVNormalized (ESM)', () => {
       { date: '06/02/2026', result: +1000, status: 'CLOSED' },
       { date: '09/02/2026', result: -1000, status: 'CLOSED' },
     ];
-    const result = computeCVNormalized(trades, { targetRR: 2 }, '2026-02-01', '2026-02-28');
+    const result = computeCVNormalized(trades, { rrTarget: 2 }, '2026-02-01', '2026-02-28');
     expect(result.value).toBeNull();
     expect(result.daysWithTrade).toBe(6);
     expect(result.insufficientReason).toBe('zero_obs_mean');
@@ -135,14 +135,13 @@ describe('computeCVNormalized (ESM)', () => {
     expect(result.label).toBe('P&L médio diário próximo de zero — CV indefinido');
   });
 
-  it('C7 — happy path: WR efetiva difere de plan.expectedWinRate, helper usa a efetiva', () => {
+  it('C7 — happy path: helper usa WR efetiva quando trades suficientes (ignora fallback breakeven)', () => {
     // CALIB_TRADES: WR efetiva = 3/10 = 0.30 (igual ao spec).
-    // Plan: targetRR=3, expectedWinRate=0.50 (sintético, deveria ser ignorado).
-    // Se efetiva for usada (0.30): cv_exp = 9.165 → cv_normalized ≈ 1.054.
-    // Se fallback fosse usado (0.50): mean_exp = 1.0, cv_exp ≈ 2.0 → cv_normalized ≈ 4.83.
+    // Plan: rrTarget=3. Se efetiva for usada (0.30): cv_exp = 9.165 → cv_normalized ≈ 1.054.
+    // Se fallback breakeven (1/(1+3) = 0.25) fosse usado: cv_exp diferente → resultado diferente.
     const result = computeCVNormalized(
       CALIB_TRADES,
-      { targetRR: 3, expectedWinRate: 0.50 },
+      { rrTarget: 3 },
       '2026-02-01',
       '2026-02-28'
     );
@@ -152,20 +151,22 @@ describe('computeCVNormalized (ESM)', () => {
     expect(result.value).toBeLessThan(1.10);
   });
 
-  it('C8 — fallback plan.expectedWinRate quando WR efetiva indefinida (resolveWinRate)', () => {
-    // resolveWinRate sem trades → fallback para plan.expectedWinRate.
-    expect(resolveWinRate([], { expectedWinRate: 0.42 })).toBe(0.42);
-    expect(resolveWinRate([], {})).toBeNull();
+  it('C8 — fallback breakeven 1/(1+RR) quando WR efetiva indefinida (resolveWinRate)', () => {
+    // resolveWinRate sem trades + rrTarget=2 → 1/(1+2) = 0.333…
+    expect(resolveWinRate([], 2)).toBeCloseTo(1 / 3, 10);
+    expect(resolveWinRate([], 1)).toBeCloseTo(0.5, 10);
+    expect(resolveWinRate([], 0)).toBeNull();
     expect(resolveWinRate([], null)).toBeNull();
+    expect(resolveWinRate([], undefined)).toBeNull();
 
-    // Precedência: trades disponíveis sempre vencem fallback.
+    // Precedência: trades disponíveis sempre vencem o fallback breakeven.
     const trades = [
       { date: '02/02/2026', result: 100, status: 'CLOSED' },
       { date: '02/02/2026', result: 100, status: 'CLOSED' },
       { date: '02/02/2026', result: -50, status: 'CLOSED' },
       { date: '02/02/2026', result: -50, status: 'CLOSED' },
     ];
-    expect(resolveWinRate(trades, { expectedWinRate: 0.99 })).toBe(0.5);
+    expect(resolveWinRate(trades, 99)).toBe(0.5);
   });
 
   it('C9 — effectiveWinRate puro: 7L+3G → 0.3', () => {

--- a/src/__tests__/utils/cycleConsistency/computeCycleSharpe.test.js
+++ b/src/__tests__/utils/cycleConsistency/computeCycleSharpe.test.js
@@ -1,0 +1,193 @@
+/**
+ * computeCycleSharpe.test.js — issue #235 F1.1 (ESM)
+ *
+ * Cobre 8 cenários:
+ *  C1 — janela vazia → null, min_days
+ *  C2 — 4 dias com trade (< minDays=5) → null, min_days
+ *  C3 — happy path FEV/2026 com Selic descontada → ~5.86 ± 0.5
+ *  C4 — mesmo dataset com rfr=0 → ~6.80 ± 0.5
+ *  C5 — variância zero (P&L diário constante) → null, zero_variance
+ *  C6 — multi-day fallback parcial → source 'MIXED', fallbackUsed true
+ *  C7 — groupTradesByDay filtra fora-janela e status != 'CLOSED'
+ *  C8 — meanStdSample edge: 1 item → std=0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeCycleSharpe,
+  groupTradesByDay,
+  dailyReturnsFromGroups,
+  meanStdSample,
+} from '../../../utils/cycleConsistency/computeCycleSharpe.js';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+// Dataset FEV/2026: 13 trades em 8 dias úteis distintos, plStart 100k.
+// PL por dia: [600, -800, 2000, 200, -500, 1400, 800, -400] (sum=3300, mean=412.5).
+// Daily returns: [0.006, -0.008, 0.020, 0.002, -0.005, 0.014, 0.008, -0.004]
+// Mean=0.004125 · Std (sample N-1)=0.009775 · Sharpe sem rfr=6.699 · com Selic=5.749.
+// Ambos dentro de ±0.5 dos targets do issue body (6.80 / 5.86).
+const FEV_2026_TRADES = [
+  { date: '02/02/2026', result: 400, status: 'CLOSED' },
+  { date: '02/02/2026', result: 200, status: 'CLOSED' },
+  { date: '03/02/2026', result: -300, status: 'CLOSED' },
+  { date: '03/02/2026', result: -500, status: 'CLOSED' },
+  { date: '04/02/2026', result: 800, status: 'CLOSED' },
+  { date: '04/02/2026', result: 700, status: 'CLOSED' },
+  { date: '04/02/2026', result: 500, status: 'CLOSED' },
+  { date: '05/02/2026', result: 200, status: 'CLOSED' },
+  { date: '06/02/2026', result: -500, status: 'CLOSED' },
+  { date: '09/02/2026', result: 600, status: 'CLOSED' },
+  { date: '09/02/2026', result: 800, status: 'CLOSED' },
+  { date: '10/02/2026', result: 400, status: 'CLOSED' },
+  { date: '10/02/2026', result: 400, status: 'CLOSED' },
+  { date: '11/02/2026', result: -400, status: 'CLOSED' },
+];
+
+// Selic 14.75% a.a. ÷ 252 d.u. ÷ 100 = 0.0005853174603174603
+const SELIC_FEV_2026 = 14.75 / 252 / 100;
+
+const fakeSelic = (rate, source = 'BCB-SGS-11') =>
+  async () => ({ rateDaily: rate, source, isFallback: source === 'FALLBACK' });
+
+describe('computeCycleSharpe (ESM)', () => {
+  it('C1 — janela vazia retorna null com insufficientReason min_days', async () => {
+    const result = await computeCycleSharpe([], '2026-02-01', '2026-02-28', 100000, {
+      getSelicForDateFn: fakeSelic(SELIC_FEV_2026),
+    });
+    expect(result).toEqual({
+      value: null,
+      daysWithTrade: 0,
+      source: 'BCB',
+      insufficientReason: 'min_days',
+      fallbackUsed: false,
+    });
+  });
+
+  it('C2 — 4 dias com trade (< minDays=5) retorna null min_days', async () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },
+      { date: '03/02/2026', result: 200, status: 'CLOSED' },
+      { date: '04/02/2026', result: -50, status: 'CLOSED' },
+      { date: '05/02/2026', result: 75, status: 'CLOSED' },
+    ];
+    const result = await computeCycleSharpe(trades, '2026-02-01', '2026-02-28', 100000, {
+      getSelicForDateFn: fakeSelic(SELIC_FEV_2026),
+    });
+    expect(result.value).toBeNull();
+    expect(result.insufficientReason).toBe('min_days');
+    expect(result.daysWithTrade).toBe(4);
+    expect(result.fallbackUsed).toBe(false);
+  });
+
+  it('C3 — FEV/2026 com Selic descontada → Sharpe ~5.75 (target 5.86 ± 0.5)', async () => {
+    const result = await computeCycleSharpe(
+      FEV_2026_TRADES,
+      '2026-02-01',
+      '2026-02-28',
+      100000,
+      { getSelicForDateFn: fakeSelic(SELIC_FEV_2026) }
+    );
+    expect(result.daysWithTrade).toBe(8);
+    expect(result.source).toBe('BCB');
+    expect(result.fallbackUsed).toBe(false);
+    expect(result.value).not.toBeNull();
+    // Target spec: 5.86 ± 0.5 → [5.36, 6.36]. Calculado 5.749.
+    expect(result.value).toBeGreaterThan(5.36);
+    expect(result.value).toBeLessThan(6.36);
+  });
+
+  it('C4 — FEV/2026 com rfr=0 → Sharpe ~6.70 (target 6.80 ± 0.5), maior que C3', async () => {
+    const result = await computeCycleSharpe(
+      FEV_2026_TRADES,
+      '2026-02-01',
+      '2026-02-28',
+      100000,
+      { getSelicForDateFn: fakeSelic(0, 'BCB-SGS-11') }
+    );
+    expect(result.value).not.toBeNull();
+    // Target spec: 6.80 ± 0.5 → [6.30, 7.30]. Calculado 6.699.
+    expect(result.value).toBeGreaterThan(6.30);
+    expect(result.value).toBeLessThan(7.30);
+  });
+
+  it('C5 — variância zero (mesmo PL todo dia) retorna null zero_variance', async () => {
+    // 5 dias com PL idêntico → returns idênticos → std=0.
+    const trades = [
+      { date: '02/02/2026', result: 500, status: 'CLOSED' },
+      { date: '03/02/2026', result: 500, status: 'CLOSED' },
+      { date: '04/02/2026', result: 500, status: 'CLOSED' },
+      { date: '05/02/2026', result: 500, status: 'CLOSED' },
+      { date: '06/02/2026', result: 500, status: 'CLOSED' },
+    ];
+    const result = await computeCycleSharpe(trades, '2026-02-01', '2026-02-28', 100000, {
+      getSelicForDateFn: fakeSelic(SELIC_FEV_2026),
+    });
+    expect(result.value).toBeNull();
+    expect(result.insufficientReason).toBe('zero_variance');
+    expect(result.daysWithTrade).toBe(5);
+  });
+
+  it('C6 — multi-day fallback parcial → source MIXED, fallbackUsed true', async () => {
+    // Mock retorna FALLBACK só em '06/02' e '09/02', BCB nos demais.
+    const mixedFn = async (dateIso) => {
+      const isFallback = dateIso === '2026-02-06' || dateIso === '2026-02-09';
+      return {
+        rateDaily: SELIC_FEV_2026,
+        source: isFallback ? 'FALLBACK' : 'BCB-SGS-11',
+        isFallback,
+      };
+    };
+    const result = await computeCycleSharpe(
+      FEV_2026_TRADES,
+      '2026-02-01',
+      '2026-02-28',
+      100000,
+      { getSelicForDateFn: mixedFn }
+    );
+    expect(result.source).toBe('MIXED');
+    expect(result.fallbackUsed).toBe(true);
+    expect(result.daysWithTrade).toBe(8);
+  });
+
+  it('C7 — groupTradesByDay filtra fora-janela e status != CLOSED', () => {
+    const trades = [
+      { date: '02/02/2026', result: 100, status: 'CLOSED' },           // dentro
+      { date: '03/02/2026', result: 200, status: 'OPEN' },             // status errado
+      { date: '04/02/2026', result: 300, status: 'REVIEWED' },         // status errado
+      { date: '01/01/2026', result: 999, status: 'CLOSED' },           // fora-janela (antes)
+      { date: '01/03/2026', result: 999, status: 'CLOSED' },           // fora-janela (depois)
+      { date: '05/02/2026', result: 150, status: 'CLOSED' },           // dentro
+      { date: '05/02/2026', result: 50,  status: 'CLOSED' },           // dentro (mesmo dia, agrega)
+      { date: 'lixo',       result: 100, status: 'CLOSED' },           // date inválida
+      { date: '06/02/2026', result: 'NaN', status: 'CLOSED' },         // result não-numérico
+    ];
+    const map = groupTradesByDay(trades, '2026-02-01', '2026-02-28');
+    expect(map.size).toBe(2);
+    expect(map.get('2026-02-02')).toBe(100);
+    expect(map.get('2026-02-05')).toBe(200); // 150 + 50
+  });
+
+  it('C8 — meanStdSample com 1 item retorna std=0; agregações puras', () => {
+    expect(meanStdSample([])).toEqual({ mean: 0, std: 0 });
+    expect(meanStdSample([5])).toEqual({ mean: 5, std: 0 });
+    const r = meanStdSample([1, 2, 3, 4, 5]);
+    expect(r.mean).toBeCloseTo(3, 10);
+    // std amostral de 1..5 = sqrt(2.5) ≈ 1.5811
+    expect(r.std).toBeCloseTo(Math.sqrt(2.5), 10);
+  });
+
+  it('helper — dailyReturnsFromGroups produz ordenação asc e divide por plStart', () => {
+    const map = new Map([
+      ['2026-02-05', 200],
+      ['2026-02-02', 600],
+      ['2026-02-03', -800],
+    ]);
+    const out = dailyReturnsFromGroups(map, 100000);
+    expect(out).toEqual([
+      { dateIso: '2026-02-02', dailyReturn: 0.006 },
+      { dateIso: '2026-02-03', dailyReturn: -0.008 },
+      { dateIso: '2026-02-05', dailyReturn: 0.002 },
+    ]);
+  });
+});

--- a/src/__tests__/utils/marketData/getSelicForDate.test.js
+++ b/src/__tests__/utils/marketData/getSelicForDate.test.js
@@ -1,0 +1,224 @@
+/**
+ * getSelicForDate.test.js — issue #235 F0.3
+ *
+ * Cobre 7 cenários:
+ *  C1 — exact hit
+ *  C2 — carry-forward 1 dia (sábado → sexta)
+ *  C3 — carry-forward dentro do limite (5 dias)
+ *  C4 — gap > maxCarryForwardDays → fallback
+ *  C5 — coleção vazia → fallback
+ *  C6 — erro Firestore → fallback + log
+ *  C7 — daysDiffIso atravessa virada de mês sem drift
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Mocks de Firestore ──────────────────────────────────────
+
+const mockGetDoc = vi.fn();
+const mockGetDocs = vi.fn();
+const mockDoc = vi.fn((db, path) => ({ __doc: path }));
+const mockCollection = vi.fn((db, path) => ({ __col: path }));
+const mockQuery = vi.fn((col, ...constraints) => ({ __q: { col, constraints } }));
+const mockWhere = vi.fn((field, op, value) => ({ __w: [field, op, value] }));
+const mockOrderBy = vi.fn((field, dir) => ({ __o: [field, dir] }));
+const mockLimit = vi.fn((n) => ({ __l: n }));
+
+vi.mock('firebase/firestore', () => ({
+  getDoc: (...args) => mockGetDoc(...args),
+  getDocs: (...args) => mockGetDocs(...args),
+  doc: (...args) => mockDoc(...args),
+  collection: (...args) => mockCollection(...args),
+  query: (...args) => mockQuery(...args),
+  where: (...args) => mockWhere(...args),
+  orderBy: (...args) => mockOrderBy(...args),
+  limit: (...args) => mockLimit(...args),
+}));
+
+vi.mock('../../../firebase', () => ({
+  db: { __mock: 'firestore-client' },
+}));
+
+import {
+  getSelicForDate,
+  daysDiffIso,
+  SELIC_FALLBACK_DAILY,
+  SELIC_HISTORY_PATH,
+} from '../../../utils/marketData/getSelicForDate';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+const docSnap = (data) =>
+  data === null
+    ? { exists: () => false, data: () => undefined }
+    : { exists: () => true, data: () => data };
+
+const querySnap = (rows) => ({
+  empty: rows.length === 0,
+  docs: rows.map((r) => ({ data: () => r })),
+});
+
+beforeEach(() => {
+  mockGetDoc.mockReset();
+  mockGetDocs.mockReset();
+  mockDoc.mockClear();
+  mockCollection.mockClear();
+  mockQuery.mockClear();
+  mockWhere.mockClear();
+  mockOrderBy.mockClear();
+  mockLimit.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getSelicForDate (ESM)', () => {
+  it('C1 — exact hit retorna doc do dia sem carry-forward nem fallback', async () => {
+    mockGetDoc.mockResolvedValueOnce(
+      docSnap({ date: '2026-05-02', rateDaily: 0.00052531, source: 'BCB-SGS-11' })
+    );
+
+    const result = await getSelicForDate('2026-05-02');
+
+    expect(result).toEqual({
+      rateDaily: 0.00052531,
+      source: 'BCB-SGS-11',
+      dateUsed: '2026-05-02',
+      isCarryForward: false,
+      isFallback: false,
+    });
+    expect(mockGetDoc).toHaveBeenCalledTimes(1);
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(mockDoc).toHaveBeenCalledWith(
+      { __mock: 'firestore-client' },
+      `${SELIC_HISTORY_PATH}/2026-05-02`
+    );
+  });
+
+  it('C2 — sábado faz carry-forward para sexta (1 dia)', async () => {
+    // sábado: doc do dia não existe → query devolve sexta
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    mockGetDocs.mockResolvedValueOnce(
+      querySnap([{ date: '2026-05-01', rateDaily: 0.00052531, source: 'BCB-SGS-11' }])
+    );
+
+    const result = await getSelicForDate('2026-05-02'); // sábado fictício
+
+    expect(result).toEqual({
+      rateDaily: 0.00052531,
+      source: 'BCB-SGS-11',
+      dateUsed: '2026-05-01',
+      isCarryForward: true,
+      isFallback: false,
+    });
+    // confirma uso da query com where/orderBy/limit
+    expect(mockWhere).toHaveBeenCalledWith('date', '<=', '2026-05-02');
+    expect(mockOrderBy).toHaveBeenCalledWith('date', 'desc');
+    expect(mockLimit).toHaveBeenCalledWith(1);
+  });
+
+  it('C3 — gap de 5 dias dentro do maxCarryForwardDays default (7) → carry-forward', async () => {
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    mockGetDocs.mockResolvedValueOnce(
+      querySnap([{ date: '2026-04-25', rateDaily: 0.00052531, source: 'BCB-SGS-11' }])
+    );
+
+    const result = await getSelicForDate('2026-04-30');
+
+    expect(result.isCarryForward).toBe(true);
+    expect(result.isFallback).toBe(false);
+    expect(result.dateUsed).toBe('2026-04-25');
+    expect(result.rateDaily).toBe(0.00052531);
+  });
+
+  it('C4 — gap > maxCarryForwardDays cai em fallback', async () => {
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    mockGetDocs.mockResolvedValueOnce(
+      querySnap([{ date: '2026-04-01', rateDaily: 0.00052531, source: 'BCB-SGS-11' }])
+    );
+
+    const result = await getSelicForDate('2026-04-30'); // 29 dias > 7
+
+    expect(result).toEqual({
+      rateDaily: SELIC_FALLBACK_DAILY,
+      source: 'FALLBACK',
+      dateUsed: null,
+      isCarryForward: false,
+      isFallback: true,
+    });
+  });
+
+  it('C4b — limite customizado: maxCarryForwardDays=2 com gap=3 → fallback', async () => {
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    mockGetDocs.mockResolvedValueOnce(
+      querySnap([{ date: '2026-04-27', rateDaily: 0.00052531, source: 'BCB-SGS-11' }])
+    );
+
+    const result = await getSelicForDate('2026-04-30', { maxCarryForwardDays: 2 });
+
+    expect(result.isFallback).toBe(true);
+    expect(result.source).toBe('FALLBACK');
+  });
+
+  it('C5 — coleção vazia → fallback', async () => {
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    mockGetDocs.mockResolvedValueOnce(querySnap([]));
+
+    const result = await getSelicForDate('2026-05-02');
+
+    expect(result).toEqual({
+      rateDaily: SELIC_FALLBACK_DAILY,
+      source: 'FALLBACK',
+      dateUsed: null,
+      isCarryForward: false,
+      isFallback: true,
+    });
+  });
+
+  it('C6 — getDocs throw → fallback + log estruturado, NUNCA throw', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    const fsErr = Object.assign(new Error('UNAVAILABLE'), { code: 'unavailable' });
+    mockGetDocs.mockRejectedValueOnce(fsErr);
+
+    const result = await getSelicForDate('2026-05-02');
+
+    expect(result.isFallback).toBe(true);
+    expect(result.source).toBe('FALLBACK');
+    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy.mock.calls[0][0]).toMatch(/getSelicForDate/);
+    expect(errSpy.mock.calls[0][0]).toMatch(/unavailable/);
+    errSpy.mockRestore();
+  });
+
+  it('C6b — fallbackRateDaily customizado é respeitado', async () => {
+    mockGetDoc.mockResolvedValueOnce(docSnap(null));
+    mockGetDocs.mockResolvedValueOnce(querySnap([]));
+
+    const result = await getSelicForDate('2026-05-02', { fallbackRateDaily: 0.0009 });
+
+    expect(result.rateDaily).toBe(0.0009);
+    expect(result.isFallback).toBe(true);
+  });
+
+  it('C7 — daysDiffIso sem timezone drift (atravessa mês e ano)', () => {
+    expect(daysDiffIso('2026-03-01', '2026-02-28')).toBe(1);
+    expect(daysDiffIso('2024-03-01', '2024-02-28')).toBe(2); // ano bissexto
+    expect(daysDiffIso('2026-01-01', '2025-12-31')).toBe(1);
+    expect(daysDiffIso('2026-05-02', '2026-05-01')).toBe(1);
+    expect(daysDiffIso('2026-05-02', '2026-05-02')).toBe(0);
+    expect(daysDiffIso('2026-04-01', '2026-04-30')).toBe(-29);
+  });
+
+  it('C8 — db injetável via opts.db substitui o default', async () => {
+    const customDb = { __custom: true };
+    mockGetDoc.mockResolvedValueOnce(
+      docSnap({ date: '2026-05-02', rateDaily: 0.00052531, source: 'BCB-SGS-11' })
+    );
+
+    await getSelicForDate('2026-05-02', { db: customDb });
+
+    expect(mockDoc).toHaveBeenCalledWith(customDb, `${SELIC_HISTORY_PATH}/2026-05-02`);
+  });
+});

--- a/src/components/dashboard/CycleConsistencyCard.jsx
+++ b/src/components/dashboard/CycleConsistencyCard.jsx
@@ -294,7 +294,27 @@ function classifyDuration(minutes) {
   return { label: 'Swing', color: 'text-emerald-400' };
 }
 
-const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, opts, avgTradeDuration }) => {
+function deltaTTheme(level) {
+  if (level === 'winners-run') return { text: 'text-emerald-400', dot: 'bg-emerald-400', label: 'Winners run' };
+  if (level === 'neutral') return { text: 'text-amber-400', dot: 'bg-amber-400', label: 'Equilibrado' };
+  if (level === 'holding-losses') return { text: 'text-red-400', dot: 'bg-red-400', label: 'Segura loss' };
+  return { text: 'text-slate-500', dot: 'bg-slate-500', label: '-' };
+}
+
+function deltaTTooltip(level, deltaPercent) {
+  if (level === 'winners-run') {
+    return `Você segura ganhos e corta perdas (W ${Math.abs(deltaPercent).toFixed(0)}% mais longos que L) — comportamento saudável.`;
+  }
+  if (level === 'neutral') {
+    return `Tempos de W e L similares (delta ${deltaPercent.toFixed(0)}%). Sem padrão claro de gestão em posição.`;
+  }
+  if (level === 'holding-losses') {
+    return `Você segura losses (W ${Math.abs(deltaPercent).toFixed(0)}% mais curtos que L) — corta ganho cedo, espera loss virar. Padrão clássico de aversão à perda.`;
+  }
+  return 'Precisa de wins e losses com duração registrada.';
+}
+
+const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, opts, avgTradeDuration, durationDelta }) => {
   const state = useCycleConsistency({ trades, plan, cycleStart, cycleEnd, opts });
   const { sharpe, cvNormalized, avgExcursion, loading, error } = state;
 
@@ -349,6 +369,28 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
             left={{ caption: 'MEP', view: mepView, tooltip: MEP_TOOLTIP }}
             right={{ caption: 'MEN', view: menView, tooltip: MEN_TOOLTIP }}
           />
+          {(() => {
+            if (!durationDelta) return null;
+            const t = deltaTTheme(durationDelta.level);
+            const dPct = durationDelta.deltaPercent;
+            const sign = dPct >= 0 ? '+' : '';
+            return (
+              <div className="py-2.5" title={deltaTTooltip(durationDelta.level, dPct)}>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-slate-500">Tempo W vs L</span>
+                  <div className="flex items-center gap-2">
+                    <span className={`text-sm font-bold font-mono ${t.text}`}>{sign}{dPct.toFixed(0)}%</span>
+                    <span className={`text-[10px] font-bold ${t.text}`}>{t.label}</span>
+                    <span className={`w-2 h-2 rounded-full ${t.dot}`} aria-hidden="true" />
+                  </div>
+                </div>
+                <div className="flex items-center gap-3 mt-1 text-[11px] text-slate-500">
+                  <span>W: <span className="font-mono text-emerald-400/80">{formatDuration(durationDelta.durationWin)}</span></span>
+                  <span>L: <span className="font-mono text-red-400/80">{formatDuration(durationDelta.durationLoss)}</span></span>
+                </div>
+              </div>
+            );
+          })()}
 
           {avgExcursion?.coverageBelowThreshold && avgExcursion.coverageLabel && (
             <p className="text-[10px] text-amber-400/80 mt-2 pt-2 border-0">

--- a/src/components/dashboard/CycleConsistencyCard.jsx
+++ b/src/components/dashboard/CycleConsistencyCard.jsx
@@ -40,12 +40,12 @@ function sharpeTheme(value) {
 }
 
 function cvTheme(value) {
-  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500' };
-  if (value < 0.5) return { text: 'text-amber-400', dot: 'bg-amber-400' };
-  if (value <= 1.2) return { text: 'text-emerald-400', dot: 'bg-emerald-400' };
-  if (value <= 1.5) return { text: 'text-amber-400', dot: 'bg-amber-400' };
-  if (value <= 2.0) return { text: 'text-orange-400', dot: 'bg-orange-400' };
-  return { text: 'text-red-400', dot: 'bg-red-400' };
+  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500', bandLabel: '' };
+  if (value < 0.5) return { text: 'text-amber-400', dot: 'bg-amber-400', bandLabel: 'Suspeito' };
+  if (value <= 1.2) return { text: 'text-emerald-400', dot: 'bg-emerald-400', bandLabel: 'No plano' };
+  if (value <= 1.5) return { text: 'text-amber-400', dot: 'bg-amber-400', bandLabel: 'Levemente errático' };
+  if (value <= 2.0) return { text: 'text-orange-400', dot: 'bg-orange-400', bandLabel: 'Errático' };
+  return { text: 'text-red-400', dot: 'bg-red-400', bandLabel: 'Muito errático' };
 }
 
 function mepTheme(value) {
@@ -109,57 +109,25 @@ function selicBadge(source) {
   return null;
 }
 
-function MetricRow({ label, value, extra, theme, badge, tooltip, valueClassName }) {
+function MetricTile({ label, value, theme, bandLabel, badge, caption, tooltip, isInsufficient }) {
   return (
-    <div className="flex items-center justify-between py-2.5" title={tooltip}>
-      <span className="text-xs text-slate-500">{label}</span>
-      <div className="flex items-center gap-2">
-        <span className={`text-sm font-bold font-mono ${valueClassName ?? theme.text}`}>{value}</span>
-        {extra && <span className={`text-[10px] font-bold ${theme.text}`}>{extra}</span>}
-        {badge}
-        <span className={`w-2 h-2 rounded-full ${theme.dot}`} aria-hidden="true" />
-      </div>
-    </div>
-  );
-}
-
-function DualMetricRow({ label, left, right }) {
-  // Quando ambos lados estão em estado "insuficiente" (mesma mensagem), colapsa
-  // para uma linha só com a mensagem — evita duplicação visual.
-  const sameInsufficient =
-    left.view.valueClassName && right.view.valueClassName && left.view.value === right.view.value;
-  if (sameInsufficient) {
-    return (
-      <div className="flex items-center justify-between py-2.5">
-        <span className="text-xs text-slate-500">{label}</span>
-        <span className={`text-xs font-medium ${left.view.valueClassName}`}>{left.view.value}</span>
-      </div>
-    );
-  }
-  return (
-    <div className="flex items-center justify-between py-2.5">
-      <span className="text-xs text-slate-500">{label}</span>
-      <div className="flex items-center gap-3">
-        <span className="flex items-center gap-1.5" title={left.tooltip}>
-          <span className="text-[10px] text-slate-600 font-mono">{left.caption}</span>
-          <span
-            className={`text-sm font-bold font-mono ${left.view.valueClassName ?? left.view.theme.text}`}
-          >
-            {left.view.value}
-          </span>
-          <span className={`w-2 h-2 rounded-full ${left.view.theme.dot}`} aria-hidden="true" />
-        </span>
-        <span className="text-slate-700">·</span>
-        <span className="flex items-center gap-1.5" title={right.tooltip}>
-          <span className="text-[10px] text-slate-600 font-mono">{right.caption}</span>
-          <span
-            className={`text-sm font-bold font-mono ${right.view.valueClassName ?? right.view.theme.text}`}
-          >
-            {right.view.value}
-          </span>
-          <span className={`w-2 h-2 rounded-full ${right.view.theme.dot}`} aria-hidden="true" />
-        </span>
-      </div>
+    <div className="flex flex-col gap-1.5" title={tooltip}>
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 font-medium">{label}</p>
+      {isInsufficient ? (
+        <p className="text-xs text-slate-500 leading-snug min-h-[2.5rem]">{value}</p>
+      ) : (
+        <div className="flex items-baseline gap-2">
+          <span className={`text-2xl font-bold font-mono leading-none ${theme.text}`}>{value}</span>
+          <span className={`w-2 h-2 rounded-full ${theme.dot} self-center`} aria-hidden="true" />
+        </div>
+      )}
+      {!isInsufficient && bandLabel && (
+        <p className={`text-[10px] font-bold ${theme.text}`}>{bandLabel}</p>
+      )}
+      {!isInsufficient && caption && (
+        <p className="text-[10px] text-slate-600">{caption}</p>
+      )}
+      {badge && <div className="flex">{badge}</div>}
     </div>
   );
 }
@@ -204,18 +172,21 @@ function sharpeContent(sharpe, opts) {
 }
 
 function cvContent(cv) {
-  if (!cv) return { value: '-', theme: cvTheme(null) };
+  if (!cv) return { value: '-', theme: cvTheme(null), bandLabel: '' };
   if (cv.value == null) {
     const label = cv.label ?? '-';
     return {
       value: label,
       theme: cvTheme(null),
+      bandLabel: '',
       valueClassName: 'text-xs font-medium text-slate-500',
     };
   }
+  const theme = cvTheme(cv.value);
   return {
     value: cv.value.toFixed(2),
-    theme: cvTheme(cv.value),
+    theme,
+    bandLabel: theme.bandLabel,
   };
 }
 
@@ -348,14 +319,14 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
 
   return (
     <div className="glass-card p-5 relative h-full flex flex-col">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-5">
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-cyan-400" />
           <span className="text-xs text-slate-500 uppercase tracking-wider font-medium">
             Consistencia Operacional
           </span>
           {label && (
-            <span className="text-[11px] text-slate-500 normal-case">({label})</span>
+            <span className="text-[11px] text-slate-600 normal-case">· {label}</span>
           )}
         </div>
       </div>
@@ -363,51 +334,70 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
       {error ? (
         <p className="text-sm text-amber-400/80">Não foi possível carregar métricas do ciclo</p>
       ) : loading ? (
-        <div className="flex-1 space-y-3" data-testid="cycle-consistency-skeleton">
+        <div className="flex-1 grid grid-cols-2 md:grid-cols-4 gap-4" data-testid="cycle-consistency-skeleton">
           {[0, 1, 2, 3].map((i) => (
-            <div key={i} className="h-6 bg-slate-700/30 rounded animate-pulse" />
+            <div key={i} className="space-y-2">
+              <div className="h-3 bg-slate-700/30 rounded animate-pulse" />
+              <div className="h-7 bg-slate-700/30 rounded animate-pulse" />
+              <div className="h-3 bg-slate-700/30 rounded animate-pulse w-2/3" />
+            </div>
           ))}
         </div>
       ) : (
-        <div className="flex-1 flex flex-col divide-y divide-slate-700/30">
-          <MetricRow
-            label={`Sharpe${label ? ` (${label})` : ''}`}
-            value={sharpeView.value}
-            extra={sharpeView.bandLabel}
-            theme={sharpeView.theme}
-            badge={sharpeView.badge}
-            tooltip={buildSharpeTooltip(sharpe, label)}
-            valueClassName={sharpeView.valueClassName}
-          />
-          <MetricRow
-            label="CV normalizado"
-            value={cvView.value}
-            theme={cvView.theme}
-            tooltip={buildCvTooltip(cvNormalized, plan)}
-            valueClassName={cvView.valueClassName}
-          />
-          <DualMetricRow
-            label="MEP / MEN médio (% / entry)"
-            left={{ caption: 'MEP', view: mepView, tooltip: MEP_TOOLTIP }}
-            right={{ caption: 'MEN', view: menView, tooltip: MEN_TOOLTIP }}
-          />
-          {(() => {
-            if (!durationDelta) return null;
+        <div className="flex-1 flex flex-col">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <MetricTile
+              label="Sharpe"
+              value={sharpeView.value}
+              theme={sharpeView.theme}
+              bandLabel={sharpeView.bandLabel}
+              badge={sharpeView.badge}
+              tooltip={buildSharpeTooltip(sharpe, label)}
+              isInsufficient={!!sharpeView.valueClassName}
+            />
+            <MetricTile
+              label="CV norm."
+              value={cvView.value}
+              theme={cvView.theme}
+              bandLabel={cvView.bandLabel}
+              tooltip={buildCvTooltip(cvNormalized, plan)}
+              isInsufficient={!!cvView.valueClassName}
+            />
+            <MetricTile
+              label="MEP médio"
+              value={mepView.value}
+              theme={mepView.theme}
+              caption="por entry"
+              tooltip={MEP_TOOLTIP}
+              isInsufficient={!!mepView.valueClassName}
+            />
+            <MetricTile
+              label="MEN médio"
+              value={menView.value}
+              theme={menView.theme}
+              caption="por entry"
+              tooltip={MEN_TOOLTIP}
+              isInsufficient={!!menView.valueClassName}
+            />
+          </div>
+
+          {durationDelta && (() => {
             const t = deltaTTheme(durationDelta.level);
             const dPct = durationDelta.deltaPercent;
             const sign = dPct >= 0 ? '+' : '';
             return (
-              <div className="py-2.5" title={deltaTTooltip(durationDelta.level, dPct)}>
+              <div className="border-t border-slate-700/30 mt-4 pt-3" title={deltaTTooltip(durationDelta.level, dPct)}>
                 <div className="flex items-center justify-between">
-                  <span className="text-xs text-slate-500">Tempo W vs L</span>
+                  <span className="text-[10px] uppercase tracking-wider text-slate-500 font-medium">Tempo W vs L</span>
                   <div className="flex items-center gap-2">
-                    <span className={`text-sm font-bold font-mono ${t.text}`}>{sign}{dPct.toFixed(0)}%</span>
+                    <span className={`text-base font-bold font-mono ${t.text}`}>{sign}{dPct.toFixed(0)}%</span>
                     <span className={`text-[10px] font-bold ${t.text}`}>{t.label}</span>
                     <span className={`w-2 h-2 rounded-full ${t.dot}`} aria-hidden="true" />
                   </div>
                 </div>
                 <div className="flex items-center gap-3 mt-1 text-[11px] text-slate-500">
                   <span>W: <span className="font-mono text-emerald-400/80">{formatDuration(durationDelta.durationWin)}</span></span>
+                  <span className="text-slate-700">·</span>
                   <span>L: <span className="font-mono text-red-400/80">{formatDuration(durationDelta.durationLoss)}</span></span>
                 </div>
               </div>
@@ -415,7 +405,7 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
           })()}
 
           {avgExcursion?.coverageBelowThreshold && avgExcursion.coverageLabel && (
-            <p className="text-[10px] text-amber-400/80 mt-2 pt-2 border-0">
+            <p className="text-[10px] text-amber-400/80 mt-3">
               {avgExcursion.coverageLabel}
             </p>
           )}

--- a/src/components/dashboard/CycleConsistencyCard.jsx
+++ b/src/components/dashboard/CycleConsistencyCard.jsx
@@ -1,0 +1,304 @@
+/**
+ * CycleConsistencyCard
+ * @version 1.0.0 (v1.54.0 — issue #235 F2.2)
+ * @description Card "Consistência Operacional" do StudentDashboard. Substitui
+ *   CV puro + ΔT W/L (que confundiam concentração/estabilidade/aderência) por
+ *   4 métricas científicas: Sharpe per-ciclo (Selic descontada), CV normalizado
+ *   (cv_obs / cv_exp(plan.targetRR, WR)), MEP médio e MEN médio em % por entry.
+ *
+ *   Spec / mockup: docs/dev/issues/issue-235-cycle-consistency-redesign.md
+ *   Hook orquestrador: src/hooks/useCycleConsistency.js (commit 10b941ec)
+ *
+ *   ΔT W/L e tempo médio geral foram removidos do card (DEC-AUTO-235-T09-B —
+ *   se voltarem, será em outro card / outro issue, conforme spec do issue).
+ */
+/* eslint-disable react/prop-types */
+
+import { Activity } from 'lucide-react';
+import { useCycleConsistency } from '../../hooks/useCycleConsistency';
+import DebugBadge from '../DebugBadge';
+
+const MONTH_PT_BR = ['JAN', 'FEV', 'MAR', 'ABR', 'MAI', 'JUN', 'JUL', 'AGO', 'SET', 'OUT', 'NOV', 'DEZ'];
+
+function deriveCycleLabel(cycleStart) {
+  if (typeof cycleStart !== 'string' || cycleStart.length < 7) return null;
+  const m = /^(\d{4})-(\d{2})/.exec(cycleStart);
+  if (!m) return null;
+  const monthIdx = Number(m[2]) - 1;
+  if (monthIdx < 0 || monthIdx > 11) return null;
+  return `${MONTH_PT_BR[monthIdx]}/${m[1]}`;
+}
+
+function sharpeTheme(value) {
+  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500' };
+  if (value >= 1.5) return { text: 'text-emerald-400', dot: 'bg-emerald-400' };
+  if (value >= 1.2) return { text: 'text-amber-400', dot: 'bg-amber-400' };
+  if (value >= 0) return { text: 'text-orange-400', dot: 'bg-orange-400' };
+  return { text: 'text-red-400', dot: 'bg-red-400' };
+}
+
+function cvTheme(value) {
+  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500' };
+  if (value < 0.5) return { text: 'text-amber-400', dot: 'bg-amber-400' };
+  if (value <= 1.2) return { text: 'text-emerald-400', dot: 'bg-emerald-400' };
+  if (value <= 1.5) return { text: 'text-amber-400', dot: 'bg-amber-400' };
+  if (value <= 2.0) return { text: 'text-orange-400', dot: 'bg-orange-400' };
+  return { text: 'text-red-400', dot: 'bg-red-400' };
+}
+
+function mepTheme(value) {
+  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500' };
+  if (value < 0) return { text: 'text-red-400', dot: 'bg-red-400' };
+  if (value >= 1.0) return { text: 'text-emerald-400', dot: 'bg-emerald-400' };
+  if (value >= 0.5) return { text: 'text-amber-400', dot: 'bg-amber-400' };
+  return { text: 'text-orange-400', dot: 'bg-orange-400' };
+}
+
+function menTheme(value) {
+  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500' };
+  if (value >= -0.5) return { text: 'text-emerald-400', dot: 'bg-emerald-400' };
+  if (value >= -1.0) return { text: 'text-amber-400', dot: 'bg-amber-400' };
+  if (value >= -2.0) return { text: 'text-orange-400', dot: 'bg-orange-400' };
+  return { text: 'text-red-400', dot: 'bg-red-400' };
+}
+
+function selicBadge(source) {
+  if (source === 'BCB') {
+    return (
+      <span className="text-[10px] font-mono text-emerald-400/80 bg-emerald-500/10 border border-emerald-500/20 rounded px-1.5 py-0.5">
+        📊 BCB
+      </span>
+    );
+  }
+  if (source === 'FALLBACK') {
+    return (
+      <span className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+        ⚠ fallback
+      </span>
+    );
+  }
+  if (source === 'MIXED') {
+    return (
+      <span className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+        ⚠ misto
+      </span>
+    );
+  }
+  return null;
+}
+
+function MetricRow({ label, value, theme, badge, tooltip, valueClassName }) {
+  return (
+    <div className="flex items-center justify-between py-2.5" title={tooltip}>
+      <span className="text-xs text-slate-500">{label}</span>
+      <div className="flex items-center gap-2">
+        <span className={`text-sm font-bold font-mono ${valueClassName ?? theme.text}`}>{value}</span>
+        {badge}
+        <span className={`w-2 h-2 rounded-full ${theme.dot}`} aria-hidden="true" />
+      </div>
+    </div>
+  );
+}
+
+function sharpeContent(sharpe, opts) {
+  if (!sharpe) return { value: '-', theme: sharpeTheme(null), badge: null };
+  if (sharpe.value == null) {
+    if (sharpe.insufficientReason === 'min_days') {
+      const min = opts.minDays ?? 5;
+      return {
+        value: `Insuficiente · ≥${min} dias`,
+        theme: sharpeTheme(null),
+        badge: null,
+        valueClassName: 'text-xs font-medium text-slate-500',
+      };
+    }
+    if (sharpe.insufficientReason === 'no_pl_start') {
+      return {
+        value: 'Plano sem saldo inicial registrado',
+        theme: sharpeTheme(null),
+        badge: null,
+        valueClassName: 'text-xs font-medium text-slate-500',
+      };
+    }
+    if (sharpe.insufficientReason === 'zero_variance') {
+      return {
+        value: 'Variância zero — operações idênticas',
+        theme: sharpeTheme(null),
+        badge: null,
+        valueClassName: 'text-xs font-medium text-slate-500',
+      };
+    }
+    return { value: '-', theme: sharpeTheme(null), badge: null };
+  }
+  return {
+    value: sharpe.value.toFixed(2),
+    theme: sharpeTheme(sharpe.value),
+    badge: selicBadge(sharpe.source),
+  };
+}
+
+function cvContent(cv) {
+  if (!cv) return { value: '-', theme: cvTheme(null) };
+  if (cv.value == null) {
+    const label = cv.label ?? '-';
+    return {
+      value: label,
+      theme: cvTheme(null),
+      valueClassName: 'text-xs font-medium text-slate-500',
+    };
+  }
+  return {
+    value: cv.value.toFixed(2),
+    theme: cvTheme(cv.value),
+  };
+}
+
+function mepContent(avg) {
+  if (!avg || avg.avgMEP == null) {
+    const label = avg?.insufficientReason === 'no_excursion_data'
+      ? 'Sem dado MEP/MEN nos trades do ciclo'
+      : avg?.insufficientReason === 'no_trades'
+        ? 'Sem trades no ciclo'
+        : '-';
+    return {
+      value: label,
+      theme: mepTheme(null),
+      valueClassName: 'text-xs font-medium text-slate-500',
+    };
+  }
+  const v = avg.avgMEP;
+  return {
+    value: `${v >= 0 ? '+' : ''}${v.toFixed(1)}% / entry`,
+    theme: mepTheme(v),
+  };
+}
+
+function menContent(avg) {
+  if (!avg || avg.avgMEN == null) {
+    const label = avg?.insufficientReason === 'no_excursion_data'
+      ? 'Sem dado MEP/MEN nos trades do ciclo'
+      : avg?.insufficientReason === 'no_trades'
+        ? 'Sem trades no ciclo'
+        : '-';
+    return {
+      value: label,
+      theme: menTheme(null),
+      valueClassName: 'text-xs font-medium text-slate-500',
+    };
+  }
+  const v = avg.avgMEN;
+  return {
+    value: `${v >= 0 ? '+' : ''}${v.toFixed(1)}% / entry`,
+    theme: menTheme(v),
+  };
+}
+
+function buildSharpeTooltip(sharpe, cycleLabel) {
+  const days = sharpe?.daysWithTrade ?? 0;
+  return (
+    'Sharpe = (retorno médio diário − Selic do dia) ÷ desvio padrão dos retornos × √252. ' +
+    'Mede o quanto seu retorno compensa o risco descontando a oportunidade de ganhar Selic ' +
+    `sem risco. Anualizado √252. Selic descontada apenas em dias com trade. Janela: ${cycleLabel ?? '—'} ` +
+    `(${days} dias operados).`
+  );
+}
+
+function buildCvTooltip(cv, plan) {
+  const rrText = plan && typeof plan.targetRR === 'number' ? plan.targetRR.toFixed(1) : '?';
+  const wrText = cv && typeof cv.cvObs === 'number' && plan && typeof plan.expectedWinRate === 'number'
+    ? `${(plan.expectedWinRate * 100).toFixed(0)}%`
+    : '—';
+  return (
+    `CV normalizado compara a variabilidade do seu P&L com a esperada pelo seu plano (RR ${rrText}, ` +
+    `WR ${wrText}). 1.0 = executando exatamente o plano · >1.5 = mais errático · <0.8 = mais estável ` +
+    '(verificar amostra ou overfitting).'
+  );
+}
+
+const MEP_TOOLTIP =
+  'MEP médio (Máxima Excursão Positiva): em média seus trades chegaram a +X% durante a vida do ' +
+  'trade. Comparado com o resultado final, mostra quanto você deixou na mesa.';
+
+const MEN_TOOLTIP =
+  'MEN médio (Máxima Excursão Negativa): em média seus trades chegaram a −X% antes de fechar. ' +
+  'Mostra quanto risco você aceitou correr antes do desfecho.';
+
+const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, opts }) => {
+  const state = useCycleConsistency({ trades, plan, cycleStart, cycleEnd, opts });
+  const { sharpe, cvNormalized, avgExcursion, loading, error } = state;
+
+  const label = cycleLabel ?? deriveCycleLabel(cycleStart);
+
+  const sharpeView = sharpeContent(sharpe, opts ?? {});
+  const cvView = cvContent(cvNormalized);
+  const mepView = mepContent(avgExcursion);
+  const menView = menContent(avgExcursion);
+
+  return (
+    <div className="glass-card p-5 relative h-full flex flex-col">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Activity className="w-4 h-4 text-cyan-400" />
+          <span className="text-xs text-slate-500 uppercase tracking-wider font-medium">
+            Consistencia Operacional
+          </span>
+          {label && (
+            <span className="text-[11px] text-slate-500 normal-case">({label})</span>
+          )}
+        </div>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-amber-400/80">Não foi possível carregar métricas do ciclo</p>
+      ) : loading ? (
+        <div className="flex-1 space-y-3" data-testid="cycle-consistency-skeleton">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="h-6 bg-slate-700/30 rounded animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <div className="flex-1 flex flex-col divide-y divide-slate-700/30">
+          <MetricRow
+            label={`Sharpe${label ? ` (${label})` : ''}`}
+            value={sharpeView.value}
+            theme={sharpeView.theme}
+            badge={sharpeView.badge}
+            tooltip={buildSharpeTooltip(sharpe, label)}
+            valueClassName={sharpeView.valueClassName}
+          />
+          <MetricRow
+            label="CV normalizado"
+            value={cvView.value}
+            theme={cvView.theme}
+            tooltip={buildCvTooltip(cvNormalized, plan)}
+            valueClassName={cvView.valueClassName}
+          />
+          <MetricRow
+            label="MEP médio"
+            value={mepView.value}
+            theme={mepView.theme}
+            tooltip={MEP_TOOLTIP}
+            valueClassName={mepView.valueClassName}
+          />
+          <MetricRow
+            label="MEN médio"
+            value={menView.value}
+            theme={menView.theme}
+            tooltip={MEN_TOOLTIP}
+            valueClassName={menView.valueClassName}
+          />
+
+          {avgExcursion?.coverageBelowThreshold && avgExcursion.coverageLabel && (
+            <p className="text-[10px] text-amber-400/80 mt-2 pt-2 border-0">
+              {avgExcursion.coverageLabel}
+            </p>
+          )}
+        </div>
+      )}
+
+      <DebugBadge component="CycleConsistencyCard" embedded />
+    </div>
+  );
+};
+
+export default CycleConsistencyCard;

--- a/src/components/dashboard/CycleConsistencyCard.jsx
+++ b/src/components/dashboard/CycleConsistencyCard.jsx
@@ -4,17 +4,18 @@
  * @description Card "Consistência Operacional" do StudentDashboard. Substitui
  *   CV puro + ΔT W/L (que confundiam concentração/estabilidade/aderência) por
  *   4 métricas científicas: Sharpe per-ciclo (Selic descontada), CV normalizado
- *   (cv_obs / cv_exp(plan.targetRR, WR)), MEP médio e MEN médio em % por entry.
+ *   (cv_obs / cv_exp(plan.rrTarget, WR)), MEP médio e MEN médio em % por entry.
  *
  *   Spec / mockup: docs/dev/issues/issue-235-cycle-consistency-redesign.md
  *   Hook orquestrador: src/hooks/useCycleConsistency.js (commit 10b941ec)
  *
- *   ΔT W/L e tempo médio geral foram removidos do card (DEC-AUTO-235-T09-B —
- *   se voltarem, será em outro card / outro issue, conforme spec do issue).
+ *   ΔT W/L removido (sem substituto direto no novo modelo). Tempo medio geral
+ *   preservado como sub-linha (info universal, sem indicadores de tempo
+ *   ainda assertivos pro aluno — DEC-AUTO-235-T09-B revisada em review).
  */
 /* eslint-disable react/prop-types */
 
-import { Activity } from 'lucide-react';
+import { Activity, Clock } from 'lucide-react';
 import { useCycleConsistency } from '../../hooks/useCycleConsistency';
 import DebugBadge from '../DebugBadge';
 
@@ -62,24 +63,43 @@ function menTheme(value) {
   return { text: 'text-red-400', dot: 'bg-red-400' };
 }
 
+const SELIC_BADGE_TOOLTIP_BCB =
+  'Selic histórica diária via BCB SGS-11 sendo descontada no Sharpe (taxa livre de risco real do dia).';
+const SELIC_BADGE_TOOLTIP_FALLBACK =
+  'Selic do BCB indisponível no período — Sharpe calculado com taxa anual constante hardcoded (~14.75% a.a.). ' +
+  'Após CF agendada `fetchSelicDaily` rodar (próximo 09h BRT) e bootstrap histórico ser executado, ' +
+  'o badge fica verde com a Selic real do dia.';
+const SELIC_BADGE_TOOLTIP_MIXED =
+  'Parte do período usa Selic do BCB e parte usa fallback hardcoded (gap em dias específicos). ' +
+  'Sharpe ainda é confiável; badge alerta para a mistura.';
+
 function selicBadge(source) {
   if (source === 'BCB') {
     return (
-      <span className="text-[10px] font-mono text-emerald-400/80 bg-emerald-500/10 border border-emerald-500/20 rounded px-1.5 py-0.5">
+      <span
+        title={SELIC_BADGE_TOOLTIP_BCB}
+        className="text-[10px] font-mono text-emerald-400/80 bg-emerald-500/10 border border-emerald-500/20 rounded px-1.5 py-0.5"
+      >
         📊 BCB
       </span>
     );
   }
   if (source === 'FALLBACK') {
     return (
-      <span className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+      <span
+        title={SELIC_BADGE_TOOLTIP_FALLBACK}
+        className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5"
+      >
         ⚠ fallback
       </span>
     );
   }
   if (source === 'MIXED') {
     return (
-      <span className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5">
+      <span
+        title={SELIC_BADGE_TOOLTIP_MIXED}
+        className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5"
+      >
         ⚠ misto
       </span>
     );
@@ -95,6 +115,47 @@ function MetricRow({ label, value, theme, badge, tooltip, valueClassName }) {
         <span className={`text-sm font-bold font-mono ${valueClassName ?? theme.text}`}>{value}</span>
         {badge}
         <span className={`w-2 h-2 rounded-full ${theme.dot}`} aria-hidden="true" />
+      </div>
+    </div>
+  );
+}
+
+function DualMetricRow({ label, left, right }) {
+  // Quando ambos lados estão em estado "insuficiente" (mesma mensagem), colapsa
+  // para uma linha só com a mensagem — evita duplicação visual.
+  const sameInsufficient =
+    left.view.valueClassName && right.view.valueClassName && left.view.value === right.view.value;
+  if (sameInsufficient) {
+    return (
+      <div className="flex items-center justify-between py-2.5">
+        <span className="text-xs text-slate-500">{label}</span>
+        <span className={`text-xs font-medium ${left.view.valueClassName}`}>{left.view.value}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center justify-between py-2.5">
+      <span className="text-xs text-slate-500">{label}</span>
+      <div className="flex items-center gap-3">
+        <span className="flex items-center gap-1.5" title={left.tooltip}>
+          <span className="text-[10px] text-slate-600 font-mono">{left.caption}</span>
+          <span
+            className={`text-sm font-bold font-mono ${left.view.valueClassName ?? left.view.theme.text}`}
+          >
+            {left.view.value}
+          </span>
+          <span className={`w-2 h-2 rounded-full ${left.view.theme.dot}`} aria-hidden="true" />
+        </span>
+        <span className="text-slate-700">·</span>
+        <span className="flex items-center gap-1.5" title={right.tooltip}>
+          <span className="text-[10px] text-slate-600 font-mono">{right.caption}</span>
+          <span
+            className={`text-sm font-bold font-mono ${right.view.valueClassName ?? right.view.theme.text}`}
+          >
+            {right.view.value}
+          </span>
+          <span className={`w-2 h-2 rounded-full ${right.view.theme.dot}`} aria-hidden="true" />
+        </span>
       </div>
     </div>
   );
@@ -153,42 +214,38 @@ function cvContent(cv) {
   };
 }
 
+function excursionInsufficientLabel(avg) {
+  if (avg?.insufficientReason === 'no_excursion_data') return 'Sem dado MEP/MEN nos trades do ciclo';
+  if (avg?.insufficientReason === 'no_trades') return 'Sem trades no ciclo';
+  return '-';
+}
+
 function mepContent(avg) {
   if (!avg || avg.avgMEP == null) {
-    const label = avg?.insufficientReason === 'no_excursion_data'
-      ? 'Sem dado MEP/MEN nos trades do ciclo'
-      : avg?.insufficientReason === 'no_trades'
-        ? 'Sem trades no ciclo'
-        : '-';
     return {
-      value: label,
+      value: excursionInsufficientLabel(avg),
       theme: mepTheme(null),
       valueClassName: 'text-xs font-medium text-slate-500',
     };
   }
   const v = avg.avgMEP;
   return {
-    value: `${v >= 0 ? '+' : ''}${v.toFixed(1)}% / entry`,
+    value: `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`,
     theme: mepTheme(v),
   };
 }
 
 function menContent(avg) {
   if (!avg || avg.avgMEN == null) {
-    const label = avg?.insufficientReason === 'no_excursion_data'
-      ? 'Sem dado MEP/MEN nos trades do ciclo'
-      : avg?.insufficientReason === 'no_trades'
-        ? 'Sem trades no ciclo'
-        : '-';
     return {
-      value: label,
+      value: excursionInsufficientLabel(avg),
       theme: menTheme(null),
       valueClassName: 'text-xs font-medium text-slate-500',
     };
   }
   const v = avg.avgMEN;
   return {
-    value: `${v >= 0 ? '+' : ''}${v.toFixed(1)}% / entry`,
+    value: `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`,
     theme: menTheme(v),
   };
 }
@@ -204,13 +261,11 @@ function buildSharpeTooltip(sharpe, cycleLabel) {
 }
 
 function buildCvTooltip(cv, plan) {
-  const rrText = plan && typeof plan.targetRR === 'number' ? plan.targetRR.toFixed(1) : '?';
-  const wrText = cv && typeof cv.cvObs === 'number' && plan && typeof plan.expectedWinRate === 'number'
-    ? `${(plan.expectedWinRate * 100).toFixed(0)}%`
-    : '—';
+  const rrText = plan && typeof plan.rrTarget === 'number' ? plan.rrTarget.toFixed(1) : '?';
   return (
-    `CV normalizado compara a variabilidade do seu P&L com a esperada pelo seu plano (RR ${rrText}, ` +
-    `WR ${wrText}). 1.0 = executando exatamente o plano · >1.5 = mais errático · <0.8 = mais estável ` +
+    `CV normalizado compara a variabilidade do seu P&L com a esperada pelo seu plano (RR ${rrText}). ` +
+    'Se a WR efetiva do ciclo não for calculável, é usada a WR de breakeven 1/(1+RR) como referência. ' +
+    '1.0 = executando exatamente o plano · >1.5 = mais errático · <0.8 = mais estável ' +
     '(verificar amostra ou overfitting).'
   );
 }
@@ -223,7 +278,23 @@ const MEN_TOOLTIP =
   'MEN médio (Máxima Excursão Negativa): em média seus trades chegaram a −X% antes de fechar. ' +
   'Mostra quanto risco você aceitou correr antes do desfecho.';
 
-const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, opts }) => {
+function formatDuration(minutes) {
+  if (minutes == null || !Number.isFinite(minutes)) return '-';
+  if (minutes < 1) return `${Math.round(minutes * 60)}s`;
+  if (minutes < 60) return `${Math.round(minutes)}min`;
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return m > 0 ? `${h}h ${m}min` : `${h}h`;
+}
+
+function classifyDuration(minutes) {
+  if (minutes == null || !Number.isFinite(minutes)) return null;
+  if (minutes < 5) return { label: 'Scalping', color: 'text-purple-400' };
+  if (minutes <= 60) return { label: 'Day Trade', color: 'text-blue-400' };
+  return { label: 'Swing', color: 'text-emerald-400' };
+}
+
+const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, opts, avgTradeDuration }) => {
   const state = useCycleConsistency({ trades, plan, cycleStart, cycleEnd, opts });
   const { sharpe, cvNormalized, avgExcursion, loading, error } = state;
 
@@ -273,19 +344,10 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
             tooltip={buildCvTooltip(cvNormalized, plan)}
             valueClassName={cvView.valueClassName}
           />
-          <MetricRow
-            label="MEP médio"
-            value={mepView.value}
-            theme={mepView.theme}
-            tooltip={MEP_TOOLTIP}
-            valueClassName={mepView.valueClassName}
-          />
-          <MetricRow
-            label="MEN médio"
-            value={menView.value}
-            theme={menView.theme}
-            tooltip={MEN_TOOLTIP}
-            valueClassName={menView.valueClassName}
+          <DualMetricRow
+            label="MEP / MEN médio (% / entry)"
+            left={{ caption: 'MEP', view: mepView, tooltip: MEP_TOOLTIP }}
+            right={{ caption: 'MEN', view: menView, tooltip: MEN_TOOLTIP }}
           />
 
           {avgExcursion?.coverageBelowThreshold && avgExcursion.coverageLabel && (
@@ -295,6 +357,24 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
           )}
         </div>
       )}
+
+      {(() => {
+        const allMin = avgTradeDuration?.all;
+        const klass = classifyDuration(allMin);
+        if (!klass) return null;
+        return (
+          <div className="border-t border-slate-700/50 mt-4 pt-3">
+            <div className="flex items-center gap-3 text-[11px]">
+              <Clock className="w-3.5 h-3.5 text-slate-500" />
+              <span className="text-slate-500">Tempo medio geral:</span>
+              <span className={`font-bold ${klass.color}`}>{formatDuration(allMin)}</span>
+              <span className={`px-1.5 py-0.5 rounded ${klass.color} bg-slate-800/50`}>
+                {klass.label}
+              </span>
+            </div>
+          </div>
+        );
+      })()}
 
       <DebugBadge component="CycleConsistencyCard" embedded />
     </div>

--- a/src/components/dashboard/CycleConsistencyCard.jsx
+++ b/src/components/dashboard/CycleConsistencyCard.jsx
@@ -31,11 +31,12 @@ function deriveCycleLabel(cycleStart) {
 }
 
 function sharpeTheme(value) {
-  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500' };
-  if (value >= 1.5) return { text: 'text-emerald-400', dot: 'bg-emerald-400' };
-  if (value >= 1.2) return { text: 'text-amber-400', dot: 'bg-amber-400' };
-  if (value >= 0) return { text: 'text-orange-400', dot: 'bg-orange-400' };
-  return { text: 'text-red-400', dot: 'bg-red-400' };
+  if (value == null || !Number.isFinite(value)) return { text: 'text-slate-500', dot: 'bg-slate-500', bandLabel: '' };
+  if (value >= 2.0) return { text: 'text-emerald-400', dot: 'bg-emerald-400', bandLabel: 'Excepcional' };
+  if (value >= 1.5) return { text: 'text-emerald-400', dot: 'bg-emerald-400', bandLabel: 'Bom' };
+  if (value >= 1.0) return { text: 'text-amber-400', dot: 'bg-amber-400', bandLabel: 'OK' };
+  if (value >= 0) return { text: 'text-orange-400', dot: 'bg-orange-400', bandLabel: 'Fraco' };
+  return { text: 'text-red-400', dot: 'bg-red-400', bandLabel: 'Negativo' };
 }
 
 function cvTheme(value) {
@@ -64,23 +65,24 @@ function menTheme(value) {
 }
 
 const SELIC_BADGE_TOOLTIP_BCB =
-  'Selic histórica diária via BCB SGS-11 sendo descontada no Sharpe (taxa livre de risco real do dia).';
+  'Estamos descontando do seu retorno a Selic real de cada dia operado, conforme publicada pelo Banco Central. ' +
+  'Isso responde: "o ganho que tive valeu a pena vs deixar parado rendendo Selic?".';
 const SELIC_BADGE_TOOLTIP_FALLBACK =
-  'Selic do BCB indisponível no período — Sharpe calculado com taxa anual constante hardcoded (~14.75% a.a.). ' +
-  'Após CF agendada `fetchSelicDaily` rodar (próximo 09h BRT) e bootstrap histórico ser executado, ' +
-  'o badge fica verde com a Selic real do dia.';
+  'A integração com a Selic histórica do Banco Central ainda está sendo configurada. ' +
+  'Por enquanto estamos usando a estimativa atual (~14,75% ao ano) como referência de "deixar parado". ' +
+  'Quando o histórico estiver pronto, o número usa a Selic real do dia — pode mudar levemente.';
 const SELIC_BADGE_TOOLTIP_MIXED =
-  'Parte do período usa Selic do BCB e parte usa fallback hardcoded (gap em dias específicos). ' +
-  'Sharpe ainda é confiável; badge alerta para a mistura.';
+  'Parte do período usou Selic real do Banco Central e parte usou estimativa atual (gap em dias específicos). ' +
+  'O cálculo continua válido — esse aviso só te informa da mistura.';
 
 function selicBadge(source) {
   if (source === 'BCB') {
     return (
       <span
         title={SELIC_BADGE_TOOLTIP_BCB}
-        className="text-[10px] font-mono text-emerald-400/80 bg-emerald-500/10 border border-emerald-500/20 rounded px-1.5 py-0.5"
+        className="text-[10px] text-emerald-400/80 bg-emerald-500/10 border border-emerald-500/20 rounded px-1.5 py-0.5"
       >
-        📊 BCB
+        Selic atual
       </span>
     );
   }
@@ -88,9 +90,9 @@ function selicBadge(source) {
     return (
       <span
         title={SELIC_BADGE_TOOLTIP_FALLBACK}
-        className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5"
+        className="text-[10px] text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5"
       >
-        ⚠ fallback
+        Selic estimada
       </span>
     );
   }
@@ -98,21 +100,22 @@ function selicBadge(source) {
     return (
       <span
         title={SELIC_BADGE_TOOLTIP_MIXED}
-        className="text-[10px] font-mono text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5"
+        className="text-[10px] text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded px-1.5 py-0.5"
       >
-        ⚠ misto
+        Selic mista
       </span>
     );
   }
   return null;
 }
 
-function MetricRow({ label, value, theme, badge, tooltip, valueClassName }) {
+function MetricRow({ label, value, extra, theme, badge, tooltip, valueClassName }) {
   return (
     <div className="flex items-center justify-between py-2.5" title={tooltip}>
       <span className="text-xs text-slate-500">{label}</span>
       <div className="flex items-center gap-2">
         <span className={`text-sm font-bold font-mono ${valueClassName ?? theme.text}`}>{value}</span>
+        {extra && <span className={`text-[10px] font-bold ${theme.text}`}>{extra}</span>}
         {badge}
         <span className={`w-2 h-2 rounded-full ${theme.dot}`} aria-hidden="true" />
       </div>
@@ -191,9 +194,11 @@ function sharpeContent(sharpe, opts) {
     }
     return { value: '-', theme: sharpeTheme(null), badge: null };
   }
+  const theme = sharpeTheme(sharpe.value);
   return {
     value: sharpe.value.toFixed(2),
-    theme: sharpeTheme(sharpe.value),
+    theme,
+    bandLabel: theme.bandLabel,
     badge: selicBadge(sharpe.source),
   };
 }
@@ -252,11 +257,27 @@ function menContent(avg) {
 
 function buildSharpeTooltip(sharpe, cycleLabel) {
   const days = sharpe?.daysWithTrade ?? 0;
+  const v = sharpe?.value;
+  const periodo = cycleLabel ? `${cycleLabel} (${days} ${days === 1 ? 'dia operado' : 'dias operados'})` : `${days} ${days === 1 ? 'dia operado' : 'dias operados'}`;
+  let banda;
+  if (typeof v !== 'number' || !Number.isFinite(v)) {
+    banda = '';
+  } else if (v >= 2.0) {
+    banda = 'Acima de 2 é excepcional — verifica se a amostra é grande o suficiente pra confiar.';
+  } else if (v >= 1.5) {
+    banda = 'Entre 1,5 e 2 é bom: o risco que você correu foi bem recompensado.';
+  } else if (v >= 1.0) {
+    banda = 'Entre 1 e 1,5 é razoável: você ganhou, mas o ganho não foi muito acima do que renderia parado na Selic.';
+  } else if (v >= 0) {
+    banda = 'Entre 0 e 1 é fraco: você ganhou alguma coisa, mas o risco que tomou rendeu menos do que ficar parado na Selic.';
+  } else {
+    banda = 'Negativo significa que você perdeu — pior do que se tivesse deixado o dinheiro parado.';
+  }
   return (
-    'Sharpe = (retorno médio diário − Selic do dia) ÷ desvio padrão dos retornos × √252. ' +
-    'Mede o quanto seu retorno compensa o risco descontando a oportunidade de ganhar Selic ' +
-    `sem risco. Anualizado √252. Selic descontada apenas em dias com trade. Janela: ${cycleLabel ?? '—'} ` +
-    `(${days} dias operados).`
+    'Resposta a uma pergunta simples: "operar valeu mais a pena do que deixar o dinheiro parado rendendo Selic?". ' +
+    'Quanto maior, melhor. ' +
+    (banda ? `${banda} ` : '') +
+    `Janela: ${periodo}.`
   );
 }
 
@@ -352,6 +373,7 @@ const CycleConsistencyCard = ({ trades, plan, cycleStart, cycleEnd, cycleLabel, 
           <MetricRow
             label={`Sharpe${label ? ` (${label})` : ''}`}
             value={sharpeView.value}
+            extra={sharpeView.bandLabel}
             theme={sharpeView.theme}
             badge={sharpeView.badge}
             tooltip={buildSharpeTooltip(sharpe, label)}

--- a/src/components/dashboard/MetricsCards.jsx
+++ b/src/components/dashboard/MetricsCards.jsx
@@ -11,12 +11,13 @@
  *   v1.0.0: Extraido do StudentDashboard.
  */
 
-import { DollarSign, Target, BarChart3, Info, AlertTriangle, Clock, Activity } from 'lucide-react';
+import { DollarSign, Target, BarChart3, Info, AlertTriangle } from 'lucide-react';
 import { useState, useMemo } from 'react';
 import { formatPercent } from '../../utils/calculations';
 import { formatCurrencyDynamic } from '../../utils/currency';
 import { getFinancialInsights, getPerformanceInsights, getPlanVsResultInsights } from '../../utils/metricsInsights';
 import DebugBadge from '../DebugBadge';
+import CycleConsistencyCard from './CycleConsistencyCard';
 
 const safe = (v, d = 0) => (v != null && !isNaN(v) && isFinite(v)) ? v.toFixed(d) : '-';
 
@@ -66,42 +67,6 @@ const getRoBgColor = (efficiency) => {
   return 'bg-red-400';
 };
 
-/** CV — DEC-050: <0.5 verde, 0.5-1.0 amarelo, >1.0 vermelho */
-const getCVTheme = (level) => {
-  if (level === 'consistent') return { color: 'text-emerald-400', bar: 'bg-emerald-400', label: 'Consistente' };
-  if (level === 'moderate') return { color: 'text-amber-400', bar: 'bg-amber-400', label: 'Moderado' };
-  if (level === 'erratic') return { color: 'text-red-400', bar: 'bg-red-400', label: 'Erratico' };
-  return { color: 'text-slate-500', bar: 'bg-slate-500', label: '-' };
-};
-
-const getCVTooltip = (level) => {
-  if (level === 'consistent') return 'Resultado por trade previsivel — variancia baixa em torno da expectancia.';
-  if (level === 'moderate') return 'Resultado por trade tem dispersao moderada — fica vulneravel a sequencias adversas.';
-  if (level === 'erratic') return 'Resultado por trade muito disperso — alguns trades dominam o PL, dificil prever.';
-  return '';
-};
-
-/** ΔT — issue #164: >+20% verde (winners run), -10% a +20% amarelo, <-10% vermelho */
-const getDeltaTTheme = (level) => {
-  if (level === 'winners-run') return { color: 'text-emerald-400', bar: 'bg-emerald-400', label: 'Winners run' };
-  if (level === 'neutral') return { color: 'text-amber-400', bar: 'bg-amber-400', label: 'Equilibrado' };
-  if (level === 'holding-losses') return { color: 'text-red-400', bar: 'bg-red-400', label: 'Segura loss' };
-  return { color: 'text-slate-500', bar: 'bg-slate-500', label: '-' };
-};
-
-const getDeltaTTooltip = (level, deltaPercent) => {
-  if (level === 'winners-run') {
-    return `Voce segura ganhos e corta perdas (W ${deltaPercent.toFixed(0)}% mais longos que L) — comportamento saudavel.`;
-  }
-  if (level === 'neutral') {
-    return `Tempos de W e L similares (delta ${deltaPercent.toFixed(0)}%). Sem padrao claro de gestao em posicao.`;
-  }
-  if (level === 'holding-losses') {
-    return `Voce segura losses (W ${Math.abs(deltaPercent).toFixed(0)}% mais curtos que L) — corta ganho cedo, espera loss virar. Padrao classico de aversao a perda.`;
-  }
-  return '';
-};
-
 const getLeakageLevel = (leakage) => {
   if (leakage == null || isNaN(leakage)) return { label: '-', color: 'text-slate-400' };
   if (leakage < 0) return { label: 'Superando', color: 'text-emerald-400' };
@@ -138,24 +103,6 @@ const InfoBtn = ({ name, openTooltip, toggle }) => (
   </button>
 );
 
-/** Classifica duração média em minutos */
-const classifyDuration = (avgMinutes) => {
-  if (avgMinutes == null || isNaN(avgMinutes)) return { label: '-', color: 'text-slate-400' };
-  if (avgMinutes < 5) return { label: 'Scalping', color: 'text-purple-400' };
-  if (avgMinutes <= 60) return { label: 'Day Trade', color: 'text-blue-400' };
-  return { label: 'Swing', color: 'text-emerald-400' };
-};
-
-/** Formata minutos para texto legível */
-const formatDuration = (minutes) => {
-  if (minutes == null || isNaN(minutes)) return '-';
-  if (minutes < 1) return `${Math.round(minutes * 60)}s`;
-  if (minutes < 60) return `${Math.round(minutes)}min`;
-  const h = Math.floor(minutes / 60);
-  const m = Math.round(minutes % 60);
-  return m > 0 ? `${h}h ${m}min` : `${h}h`;
-};
-
 const MetricsCards = ({
   stats,
   aggregatedCurrentBalance,
@@ -170,9 +117,11 @@ const MetricsCards = ({
   payoff,
   asymmetryDiagnostic,
   plContext,
-  avgTradeDuration,
-  consistencyCV,
-  durationDelta,
+  trades,
+  plan,
+  cycleStart,
+  cycleEnd,
+  cycleLabel,
   mentorClassificationStats = null,
 }) => {
   const [openTooltip, setOpenTooltip] = useState(null);
@@ -452,92 +401,15 @@ const MetricsCards = ({
           )}
         </div>
 
-        {/* CONSISTÊNCIA OPERACIONAL (E2 — issue #164) */}
-        {/* Combina CV de P&L (DEC-050) + ΔT W/L. Substitui o card isolado de Tempo Médio
-            (que voltou como sub-linha do card novo, integrado ao ΔT). */}
-        {(consistencyCV || durationDelta || (avgTradeDuration && avgTradeDuration.all > 0)) && (() => {
-          const cvTheme = consistencyCV ? getCVTheme(consistencyCV.level) : null;
-          const dtTheme = durationDelta ? getDeltaTTheme(durationDelta.level) : null;
-          const allClass = avgTradeDuration?.all ? classifyDuration(avgTradeDuration.all) : null;
-
-          return (
-            <div className="glass-card p-5 relative h-full flex flex-col">
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-2">
-                  <Activity className="w-4 h-4 text-cyan-400" />
-                  <span className="text-xs text-slate-500 uppercase tracking-wider font-medium">Consistencia Operacional</span>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-
-                {/* CV de P&L */}
-                <div title={consistencyCV ? getCVTooltip(consistencyCV.level) : 'Precisa de >=2 trades com expectancia diferente de zero'}>
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-[11px] text-slate-600">CV do P&L por trade</span>
-                    {consistencyCV && cvTheme && (
-                      <span className={`text-[10px] font-bold ${cvTheme.color}`}>{cvTheme.label}</span>
-                    )}
-                  </div>
-                  {consistencyCV ? (
-                    <>
-                      <p className={`text-2xl font-bold ${cvTheme.color}`}>{consistencyCV.cv.toFixed(2)}</p>
-                      {/* Barra: posiciona o valor numa escala 0..1.5 (acima de 1.5 estoura para o final) */}
-                      <div className="mt-2 flex items-center gap-2">
-                        <div className="flex-1 h-1.5 rounded-full bg-slate-700/50 overflow-hidden">
-                          <div
-                            className={`h-full ${cvTheme.bar}`}
-                            style={{ width: `${Math.min(100, (consistencyCV.cv / 1.5) * 100)}%` }}
-                          />
-                        </div>
-                      </div>
-                      <p className="text-[10px] text-slate-600 mt-1">
-                        Faixas DEC-050: <span className="text-emerald-400/70">&lt;0.5</span> · <span className="text-amber-400/70">0.5-1.0</span> · <span className="text-red-400/70">&gt;1.0</span>
-                      </p>
-                    </>
-                  ) : (
-                    <p className="text-2xl font-bold text-slate-600">-</p>
-                  )}
-                </div>
-
-                {/* ΔT W vs L */}
-                <div title={durationDelta ? getDeltaTTooltip(durationDelta.level, durationDelta.deltaPercent) : 'Precisa de wins e losses com duracao registrada'}>
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-[11px] text-slate-600">Tempo W vs L</span>
-                    {durationDelta && dtTheme && (
-                      <span className={`text-[10px] font-bold ${dtTheme.color}`}>{dtTheme.label}</span>
-                    )}
-                  </div>
-                  {durationDelta ? (
-                    <>
-                      <p className={`text-2xl font-bold ${dtTheme.color}`}>
-                        {durationDelta.deltaPercent >= 0 ? '+' : ''}{durationDelta.deltaPercent.toFixed(0)}%
-                      </p>
-                      <div className="mt-2 flex items-center gap-3 text-[11px] text-slate-500">
-                        <span>W: <span className="font-mono text-emerald-400/80">{formatDuration(durationDelta.durationWin)}</span></span>
-                        <span>L: <span className="font-mono text-red-400/80">{formatDuration(durationDelta.durationLoss)}</span></span>
-                      </div>
-                    </>
-                  ) : (
-                    <p className="text-2xl font-bold text-slate-600">-</p>
-                  )}
-                </div>
-              </div>
-
-              {/* Sub-linha: tempo medio geral (info universal preservada do card antigo) */}
-              {allClass && (
-                <div className="border-t border-slate-700/50 mt-4 pt-3">
-                  <div className="flex items-center gap-3 text-[11px]">
-                    <Clock className="w-3.5 h-3.5 text-slate-500" />
-                    <span className="text-slate-500">Tempo medio geral:</span>
-                    <span className={`font-bold ${allClass.color}`}>{formatDuration(avgTradeDuration.all)}</span>
-                    <span className={`px-1.5 py-0.5 rounded ${allClass.color} bg-slate-800/50`}>{allClass.label}</span>
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })()}
+        {/* CONSISTÊNCIA OPERACIONAL — issue #235: Sharpe per-ciclo + CV normalizado + MEP/MEN médio.
+            ΔT W/L e tempo médio geral foram removidos (DEC-AUTO-235-T09-B). */}
+        <CycleConsistencyCard
+          trades={trades}
+          plan={plan}
+          cycleStart={cycleStart}
+          cycleEnd={cycleEnd}
+          cycleLabel={cycleLabel}
+        />
       </div>
 
       <DebugBadge component="MetricsCards" embedded />

--- a/src/components/dashboard/MetricsCards.jsx
+++ b/src/components/dashboard/MetricsCards.jsx
@@ -122,6 +122,7 @@ const MetricsCards = ({
   cycleStart,
   cycleEnd,
   cycleLabel,
+  avgTradeDuration,
   mentorClassificationStats = null,
 }) => {
   const [openTooltip, setOpenTooltip] = useState(null);

--- a/src/components/dashboard/MetricsCards.jsx
+++ b/src/components/dashboard/MetricsCards.jsx
@@ -402,13 +402,15 @@ const MetricsCards = ({
         </div>
 
         {/* CONSISTÊNCIA OPERACIONAL — issue #235: Sharpe per-ciclo + CV normalizado + MEP/MEN médio.
-            ΔT W/L e tempo médio geral foram removidos (DEC-AUTO-235-T09-B). */}
+            Sub-linha "Tempo medio geral" preservada do card antigo (info universal sem substituto
+            no momento — DEC-AUTO-235-T09-B revisada). */}
         <CycleConsistencyCard
           trades={trades}
           plan={plan}
           cycleStart={cycleStart}
           cycleEnd={cycleEnd}
           cycleLabel={cycleLabel}
+          avgTradeDuration={avgTradeDuration}
         />
       </div>
 

--- a/src/components/dashboard/MetricsCards.jsx
+++ b/src/components/dashboard/MetricsCards.jsx
@@ -123,6 +123,7 @@ const MetricsCards = ({
   cycleEnd,
   cycleLabel,
   avgTradeDuration,
+  durationDelta,
   mentorClassificationStats = null,
 }) => {
   const [openTooltip, setOpenTooltip] = useState(null);
@@ -412,6 +413,7 @@ const MetricsCards = ({
           cycleEnd={cycleEnd}
           cycleLabel={cycleLabel}
           avgTradeDuration={avgTradeDuration}
+          durationDelta={durationDelta}
         />
       </div>
 

--- a/src/components/reviews/WeeklyReviewModal.jsx
+++ b/src/components/reviews/WeeklyReviewModal.jsx
@@ -24,6 +24,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { validateReviewUrl } from '../../utils/reviewUrlValidator';
 import TakeawaysSection from './TakeawaysSection';
 import { buildClientSnapshot } from '../../utils/clientSnapshotBuilder';
+import { resolveCycle } from '../../utils/cycleResolver';
 import {
   recomputeAndReadMaturity,
   maybeDispatchMaturityAI,
@@ -68,10 +69,20 @@ const rebuildSnapshot = async (review, studentId, preloadedMaturity) => {
     }
   }
 
+  // CV normalizado per-ciclo (issue #235 F3.1) usa janela do CICLO, não da semana —
+  // mantém alinhamento com CycleConsistencyCard do dashboard.
+  const cycleRange = resolveCycle(review.cycleKey, plan);
+  const toIso = (d) =>
+    d instanceof Date && !Number.isNaN(d.getTime())
+      ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+      : null;
+
   return buildClientSnapshot({
     plan,
     trades: weekTrades,
     cycleKey: review.cycleKey ?? null,
+    cycleStart: cycleRange ? toIso(cycleRange.start) : null,
+    cycleEnd: cycleRange ? toIso(cycleRange.end) : null,
     emotionalMetrics: null,
     maturity,
   });

--- a/src/hooks/useCycleConsistency.js
+++ b/src/hooks/useCycleConsistency.js
@@ -16,7 +16,7 @@
  *
  * @param {Object} args
  * @param {Array} args.trades                — trades do escopo (já filtrados por conta/plano)
- * @param {Object} args.plan                 — plano ativo (lê targetRR + pl inicial)
+ * @param {Object} args.plan                 — plano ativo (lê rrTarget + pl inicial)
  * @param {string} args.cycleStart           — ISO `YYYY-MM-DD` (inclusive)
  * @param {string} args.cycleEnd             — ISO `YYYY-MM-DD` (inclusive)
  * @param {Object} [args.opts]               — overrides (testabilidade)

--- a/src/hooks/useCycleConsistency.js
+++ b/src/hooks/useCycleConsistency.js
@@ -1,0 +1,122 @@
+/**
+ * useCycleConsistency
+ * @version 1.0.0 (v1.54.0 — issue #235 F2.1)
+ * @description Orquestra os 3 helpers F1 do redesign do card "Consistência
+ *   Operacional" — Sharpe per-ciclo (Selic descontada), CV normalizado e
+ *   MEP/MEN médio. Recebe trades/plan/janela como props e retorna shape
+ *   pronto para consumo pelo componente F2.2.
+ *
+ *   Híbrido: CV e MEP/MEN são síncronos (puros); Sharpe é async porque
+ *   consulta Selic via Firestore. Usa cancelled flag para evitar setState
+ *   pós-unmount.
+ *
+ *   Spec: docs/dev/issues/issue-235-cycle-consistency-redesign.md
+ *   Helpers F1: src/utils/cycleConsistency/* (commits a9d1bed6, ba81cfa9, df672e9a)
+ *   Lookup Selic: src/utils/marketData/getSelicForDate.js (commit 8ecafac9)
+ *
+ * @param {Object} args
+ * @param {Array} args.trades                — trades do escopo (já filtrados por conta/plano)
+ * @param {Object} args.plan                 — plano ativo (lê targetRR + pl inicial)
+ * @param {string} args.cycleStart           — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} args.cycleEnd             — ISO `YYYY-MM-DD` (inclusive)
+ * @param {Object} [args.opts]               — overrides (testabilidade)
+ * @param {number} [args.opts.minDays]       — mínimo de dias com trade (Sharpe + CV)
+ * @param {number} [args.opts.coverageThreshold] — threshold MEP/MEN (default 0.7)
+ * @param {Function} [args.opts.getSelicForDateFn] — override de lookup Selic
+ *
+ * @returns {{
+ *   sharpe: Object|null,
+ *   cvNormalized: Object|null,
+ *   avgExcursion: Object|null,
+ *   loading: boolean,
+ *   error: Error|null
+ * }}
+ */
+
+import { useState, useEffect } from 'react';
+import { computeCycleSharpe } from '../utils/cycleConsistency/computeCycleSharpe';
+import { computeCVNormalized } from '../utils/cycleConsistency/computeCVNormalized';
+import { computeAvgExcursion } from '../utils/cycleConsistency/computeAvgExcursion';
+
+const NULL_METRICS = {
+  sharpe: null,
+  cvNormalized: null,
+  avgExcursion: null,
+};
+
+export function useCycleConsistency({ trades, plan, cycleStart, cycleEnd, opts = {} }) {
+  const [state, setState] = useState({
+    ...NULL_METRICS,
+    loading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!cycleStart || !cycleEnd || !Array.isArray(trades)) {
+      setState({ ...NULL_METRICS, loading: false, error: null });
+      return undefined;
+    }
+
+    let cancelled = false;
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    let cvNormalized;
+    let avgExcursion;
+    try {
+      cvNormalized = computeCVNormalized(trades, plan ?? {}, cycleStart, cycleEnd, opts);
+      avgExcursion = computeAvgExcursion(trades, cycleStart, cycleEnd, opts);
+    } catch (err) {
+      if (!cancelled) {
+        setState({
+          ...NULL_METRICS,
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      }
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const plStart = plan && typeof plan.pl === 'number' && Number.isFinite(plan.pl) ? plan.pl : null;
+
+    const sharpePromise = plStart === null
+      ? Promise.resolve({
+          value: null,
+          daysWithTrade: 0,
+          source: 'BCB',
+          fallbackUsed: false,
+          insufficientReason: 'no_pl_start',
+        })
+      : computeCycleSharpe(trades, cycleStart, cycleEnd, plStart, opts);
+
+    sharpePromise
+      .then((sharpe) => {
+        if (cancelled) return;
+        setState({
+          sharpe,
+          cvNormalized,
+          avgExcursion,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({
+          ...NULL_METRICS,
+          loading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trades, plan, cycleStart, cycleEnd]);
+
+  return state;
+}
+
+export default useCycleConsistency;

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -550,6 +550,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
           const day = String(d.getDate()).padStart(2, '0');
           return `${y}-${m}-${day}`;
         })()}
+        avgTradeDuration={avgTradeDuration}
         mentorClassificationStats={computeMentorClassificationStats(filteredTrades)}
       />
 

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -224,8 +224,6 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     asymmetryDiagnostic,
     plContext,
     avgTradeDuration,
-    consistencyCV,
-    durationDelta,
   } = metrics;
 
   // === Narrativa IA: dispara callable quando trigger muda (issue #119 task 14) ===
@@ -534,9 +532,24 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         payoff={payoff}
         asymmetryDiagnostic={asymmetryDiagnostic}
         plContext={plContext}
-        avgTradeDuration={avgTradeDuration}
-        consistencyCV={consistencyCV}
-        durationDelta={durationDelta}
+        trades={filteredTrades}
+        plan={studentCtx.selectedPlan}
+        cycleStart={(() => {
+          const d = studentCtx.selectedCycle?.start;
+          if (!(d instanceof Date) || Number.isNaN(d.getTime())) return null;
+          const y = d.getFullYear();
+          const m = String(d.getMonth() + 1).padStart(2, '0');
+          const day = String(d.getDate()).padStart(2, '0');
+          return `${y}-${m}-${day}`;
+        })()}
+        cycleEnd={(() => {
+          const d = studentCtx.selectedCycle?.end;
+          if (!(d instanceof Date) || Number.isNaN(d.getTime())) return null;
+          const y = d.getFullYear();
+          const m = String(d.getMonth() + 1).padStart(2, '0');
+          const day = String(d.getDate()).padStart(2, '0');
+          return `${y}-${m}-${day}`;
+        })()}
         mentorClassificationStats={computeMentorClassificationStats(filteredTrades)}
       />
 

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -224,6 +224,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     asymmetryDiagnostic,
     plContext,
     avgTradeDuration,
+    durationDelta,
   } = metrics;
 
   // === Narrativa IA: dispara callable quando trigger muda (issue #119 task 14) ===
@@ -551,6 +552,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
           return `${y}-${m}-${day}`;
         })()}
         avgTradeDuration={avgTradeDuration}
+        durationDelta={durationDelta}
         mentorClassificationStats={computeMentorClassificationStats(filteredTrades)}
       />
 

--- a/src/pages/WeeklyReviewPage.jsx
+++ b/src/pages/WeeklyReviewPage.jsx
@@ -35,6 +35,7 @@ import ReviewKpiGrid from '../components/reviews/ReviewKpiGrid';
 import ReviewTradesSection from '../components/reviews/ReviewTradesSection';
 import TakeawaysSection from '../components/reviews/TakeawaysSection';
 import { buildClientSnapshot } from '../utils/clientSnapshotBuilder';
+import { resolveCycle } from '../utils/cycleResolver';
 import { useWeeklyReviews } from '../hooks/useWeeklyReviews';
 import { useReviewMaturitySnapshot } from '../hooks/useReviewMaturitySnapshot';
 import { validateNotesText, validateReviewUrl, MAX_NOTES_LENGTH } from '../utils/reviewUrlValidator';
@@ -452,11 +453,21 @@ const rebuildSnapshotFromFirestore = async (review, { studentId = null } = {}) =
     console.warn('[rebuildSnapshotFromFirestore] maturity fetch failed:', err?.message || err);
   }
 
+  // CV normalizado per-ciclo (issue #235 F3.1) usa janela do CICLO, não da semana —
+  // mantém alinhamento com CycleConsistencyCard do dashboard.
+  const cycleRange = resolveCycle(review.cycleKey, plan);
+  const toIso = (d) =>
+    d instanceof Date && !Number.isNaN(d.getTime())
+      ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+      : null;
+
   return buildClientSnapshot({
     plan,
     trades: weekTrades,
     extraTrades,
     cycleKey: review.cycleKey || null,
+    cycleStart: cycleRange ? toIso(cycleRange.start) : null,
+    cycleEnd: cycleRange ? toIso(cycleRange.end) : null,
     emotionalMetrics: null,
     maturity,
   });

--- a/src/utils/clientSnapshotBuilder.js
+++ b/src/utils/clientSnapshotBuilder.js
@@ -11,6 +11,7 @@
 
 import { calculateTradeCompliance } from './compliance';
 import { buildWeeklyReviewSnapshot, pickPeriodTrades } from './weeklyReviewSnapshot';
+import { computeCVNormalized } from './cycleConsistency/computeCVNormalized';
 
 const round1 = (n) => Math.round(Number(n) * 10) / 10;
 const round2 = (n) => Math.round(Number(n) * 100) / 100;
@@ -184,6 +185,10 @@ const freezeMaturity = (maturity) => {
  * @param {Array}   [params.extraTrades] — trades incluídos manualmente (`review.includedTradeIds`),
  *                  pode estar fora do período. Mesclado e deduplicado por id com `trades`.
  * @param {string}  [params.cycleKey]   — chave do ciclo ativo (ex: '2026-04')
+ * @param {string}  [params.cycleStart] — ISO `YYYY-MM-DD` (inclusive). Quando presente
+ *                  com `cycleEnd`, popula `kpis.cvNormalized` via computeCVNormalized
+ *                  (issue #235 F3.1 — alinha snapshot ao card do dashboard).
+ * @param {string}  [params.cycleEnd]   — ISO `YYYY-MM-DD` (inclusive). Ver `cycleStart`.
  * @param {Object}  [params.emotionalMetrics] — metrics de useEmotionalProfile
  * @param {Object}  [params.maturity]   — doc students/{uid}/maturity/current ou null.
  *                  Quando presente, congela como `maturitySnapshot` (Fase E — issue #119 task 15).
@@ -194,6 +199,8 @@ export const buildClientSnapshot = ({
   trades,
   extraTrades = [],
   cycleKey = null,
+  cycleStart = null,
+  cycleEnd = null,
   emotionalMetrics = null,
   maturity = null,
 }) => {
@@ -226,6 +233,21 @@ export const buildClientSnapshot = ({
   const coefVariation = computeCoefVariation(safeTrades);
   const holdTimes = computeHoldTimes(safeTrades);
 
+  // CV normalizado per-ciclo (issue #235 F3.1). Coexiste com `coefVariation`
+  // (compat reversa, DEC-AUTO-235-T10): UIs novas leem `cvNormalized.value`,
+  // antigas seguem em `coefVariation`. Só popula com janela do ciclo presente.
+  let cvNormalized = null;
+  if (cycleStart && cycleEnd) {
+    const result = computeCVNormalized(safeTrades, plan, cycleStart, cycleEnd);
+    cvNormalized = {
+      value: result.value,
+      cvObs: result.cvObs,
+      cvExp: result.cvExp,
+      daysWithTrade: result.daysWithTrade,
+      insufficientReason: result.insufficientReason ?? null,
+    };
+  }
+
   const kpis = {
     pl: round2(pl),
     trades: safeTrades.length,
@@ -236,6 +258,7 @@ export const buildClientSnapshot = ({
     profitFactor,
     evPerTrade,
     coefVariation,
+    cvNormalized,
     avgHoldTimeMin: holdTimes.avgHoldTimeMin,
     avgHoldTimeWinMin: holdTimes.avgHoldTimeWinMin,
     avgHoldTimeLossMin: holdTimes.avgHoldTimeLossMin,

--- a/src/utils/cycleConsistency/computeAvgExcursion.js
+++ b/src/utils/cycleConsistency/computeAvgExcursion.js
@@ -1,0 +1,162 @@
+/**
+ * src/utils/cycleConsistency/computeAvgExcursion.js — issue #235 F1.3
+ *
+ * MEP médio (Máxima Excursão Positiva) e MEN médio (Máxima Excursão Negativa)
+ * em % por entry, agregados sobre os trades CLOSED dentro do ciclo.
+ *
+ * Algoritmo (memória de cálculo, body do issue #235 §3):
+ *
+ *   Para cada trade t com mepPrice/menPrice != null && entry > 0:
+ *     Se LONG:
+ *       mepPct_t = ((t.mepPrice - t.entry) / t.entry) × 100
+ *       menPct_t = ((t.menPrice - t.entry) / t.entry) × 100
+ *     Se SHORT:
+ *       mepPct_t = ((t.entry - t.mepPrice) / t.entry) × 100
+ *       menPct_t = ((t.entry - t.menPrice) / t.entry) × 100
+ *
+ *   avgMEP   = mean(mepPct_t) sobre trades com dado disponível
+ *   avgMEN   = mean(menPct_t) sobre trades com dado disponível
+ *   coverage = N_with_mep_men / N_total_trades_in_cycle
+ *
+ * Coverage display: se `coverage < coverageThreshold` (default 0.7), exibir
+ * `⚠ MEP/MEN em N de M trades` (transparência de amostra).
+ *
+ * Função pura: zero Firestore, zero I/O. Toda entrada vem dos argumentos.
+ * Os campos `mepPrice`/`menPrice` são populados por #187 — esta task só agrega.
+ *
+ * ⚠️ ESPELHO de functions/cycleConsistency/computeAvgExcursion.js — MANTER SINCRONIZADO ⚠️
+ * Qualquer alteração aqui replica no CJS, e vice-versa (padrão #119/#191).
+ */
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+function parseDateToIso(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  const m = BR_DATE_RE.exec(value);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return null;
+}
+
+/**
+ * MEP/MEN em % sobre entry para um único trade. Retorna null se:
+ *  - dado faltando (`mepPrice` ou `menPrice` null/undefined ou não-finito);
+ *  - `entry` ausente, não-finito ou ≤ 0 (evita divisão por zero);
+ *  - `side` inválido (qualquer valor diferente de `'LONG'` / `'SHORT'`).
+ *
+ * @param {{side?:string, entry?:number, mepPrice?:number, menPrice?:number}} trade
+ * @returns {{mepPct:number, menPct:number}|null}
+ */
+export function excursionPctForTrade(trade) {
+  if (!trade) return null;
+
+  const entry = typeof trade.entry === 'number' ? trade.entry : Number(trade.entry);
+  if (!Number.isFinite(entry) || entry <= 0) return null;
+
+  const mep = typeof trade.mepPrice === 'number' ? trade.mepPrice : Number(trade.mepPrice);
+  const men = typeof trade.menPrice === 'number' ? trade.menPrice : Number(trade.menPrice);
+  if (trade.mepPrice == null || trade.menPrice == null) return null;
+  if (!Number.isFinite(mep) || !Number.isFinite(men)) return null;
+
+  if (trade.side === 'LONG') {
+    return {
+      mepPct: ((mep - entry) / entry) * 100,
+      menPct: ((men - entry) / entry) * 100,
+    };
+  }
+  if (trade.side === 'SHORT') {
+    return {
+      mepPct: ((entry - mep) / entry) * 100,
+      menPct: ((entry - men) / entry) * 100,
+    };
+  }
+  return null;
+}
+
+/**
+ * MEP/MEN médio per-ciclo. Pure function — zero Firestore.
+ *
+ * @param {Array<{date:string,status:string,side:string,entry:number,mepPrice:number|null,menPrice:number|null}>} trades
+ * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
+ * @param {Object} [opts]
+ * @param {number} [opts.coverageThreshold=0.7]
+ * @returns {{
+ *   avgMEP:(number|null),
+ *   avgMEN:(number|null),
+ *   coverage:number,
+ *   coverageBelowThreshold:boolean,
+ *   coverageLabel?:string,
+ *   totalTrades:number,
+ *   tradesWithData:number,
+ *   insufficientReason?:('no_trades'|'no_excursion_data')
+ * }}
+ */
+export function computeAvgExcursion(trades, cycleStart, cycleEnd, opts = {}) {
+  const coverageThreshold =
+    typeof opts.coverageThreshold === 'number' ? opts.coverageThreshold : 0.7;
+
+  const inWindow = [];
+  if (Array.isArray(trades)) {
+    for (const t of trades) {
+      if (!t || t.status !== 'CLOSED') continue;
+      const iso = parseDateToIso(t.date);
+      if (iso === null) continue;
+      if (iso < cycleStart || iso > cycleEnd) continue;
+      inWindow.push(t);
+    }
+  }
+
+  const totalTrades = inWindow.length;
+  if (totalTrades === 0) {
+    return {
+      avgMEP: null,
+      avgMEN: null,
+      coverage: 0,
+      coverageBelowThreshold: false,
+      totalTrades: 0,
+      tradesWithData: 0,
+      insufficientReason: 'no_trades',
+    };
+  }
+
+  let sumMep = 0;
+  let sumMen = 0;
+  let tradesWithData = 0;
+  for (const t of inWindow) {
+    const pct = excursionPctForTrade(t);
+    if (pct === null) continue;
+    sumMep += pct.mepPct;
+    sumMen += pct.menPct;
+    tradesWithData += 1;
+  }
+
+  if (tradesWithData === 0) {
+    return {
+      avgMEP: null,
+      avgMEN: null,
+      coverage: 0,
+      coverageBelowThreshold: true,
+      coverageLabel: `⚠ MEP/MEN em 0 de ${totalTrades} trades`,
+      totalTrades,
+      tradesWithData: 0,
+      insufficientReason: 'no_excursion_data',
+    };
+  }
+
+  const coverage = tradesWithData / totalTrades;
+  const coverageBelowThreshold = coverage < coverageThreshold;
+  const result = {
+    avgMEP: sumMep / tradesWithData,
+    avgMEN: sumMen / tradesWithData,
+    coverage,
+    coverageBelowThreshold,
+    totalTrades,
+    tradesWithData,
+  };
+  if (coverageBelowThreshold) {
+    result.coverageLabel = `⚠ MEP/MEN em ${tradesWithData} de ${totalTrades} trades`;
+  }
+  return result;
+}

--- a/src/utils/cycleConsistency/computeCVNormalized.js
+++ b/src/utils/cycleConsistency/computeCVNormalized.js
@@ -1,0 +1,259 @@
+/**
+ * src/utils/cycleConsistency/computeCVNormalized.js — issue #235 F1.2
+ *
+ * CV normalizado per-ciclo: razão entre variabilidade observada do P&L
+ * diário e variabilidade teórica esperada pelo plano (RR + WR).
+ *
+ * Algoritmo (memória de cálculo, body do issue #235 §2):
+ *
+ *   ── CV observado (sobre P&L diário do ciclo) ──
+ *   mean_obs = Σ pl_dia / N
+ *   std_obs  = sqrt( Σ (pl_dia - mean_obs)² / (N - 1) )      [amostral, Bessel]
+ *   cv_obs   = std_obs / |mean_obs|                          (null se mean_obs ≈ 0)
+ *
+ *   ── CV esperado pelo plano (analítico) ──
+ *   p        = WR efetiva no ciclo (fallback plan.expectedWinRate)
+ *   RR       = plan.targetRR
+ *   mean_exp = p × RR − (1 − p)                              [unidades de R]
+ *   var_exp  = p × (RR − mean_exp)² + (1 − p) × (−1 − mean_exp)²
+ *   std_exp  = sqrt(var_exp)
+ *   cv_exp   = std_exp / |mean_exp|                          (null se mean_exp ≈ 0)
+ *
+ *   ── Normalizado ──
+ *   cv_normalized = cv_obs / cv_exp                          (ratio adimensional)
+ *
+ * Função pura: zero Firestore, zero I/O — o lookup de Selic do F1.1 não
+ * existe aqui. Toda a entrada vem dos argumentos.
+ *
+ * ⚠️ ESPELHO de functions/cycleConsistency/computeCVNormalized.js — MANTER SINCRONIZADO ⚠️
+ * Qualquer alteração aqui replica no CJS, e vice-versa (padrão #119/#191).
+ */
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+const NEAR_ZERO = 1e-9;
+
+function parseDateToIso(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  const m = BR_DATE_RE.exec(value);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return null;
+}
+
+/**
+ * Agrupa trades por dia (ISO `YYYY-MM-DD`), filtrando por janela
+ * `[cycleStart, cycleEnd]` (inclusive) e `status === 'CLOSED'`.
+ * Mesmo contrato do helper homônimo em computeCycleSharpe.js (DEC-AUTO-235-T06-A:
+ * duplicação intencional para preservar mirror discipline F1.1).
+ *
+ * @param {Array<{date:string,result:number,status:string}>} trades
+ * @param {string} cycleStart — ISO `YYYY-MM-DD`
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD`
+ * @returns {Map<string,number>} Map<dateIso, sumPL>
+ */
+export function groupTradesByDay(trades, cycleStart, cycleEnd) {
+  const map = new Map();
+  if (!Array.isArray(trades) || trades.length === 0) return map;
+
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    const iso = parseDateToIso(t.date);
+    if (iso === null) continue;
+    if (iso < cycleStart || iso > cycleEnd) continue;
+    const pl = typeof t.result === 'number' && Number.isFinite(t.result) ? t.result : null;
+    if (pl === null) continue;
+    map.set(iso, (map.get(iso) ?? 0) + pl);
+  }
+  return map;
+}
+
+/**
+ * WR efetiva sobre lista de trades CLOSED já filtrados por janela.
+ * Conta `result > 0` como win. Retorna null se a lista é vazia ou
+ * se nenhum trade tem `result` numérico finito (denominador zerado).
+ *
+ * @param {Array<{result:number,status:string}>} trades
+ * @returns {number|null}
+ */
+export function effectiveWinRate(trades) {
+  if (!Array.isArray(trades) || trades.length === 0) return null;
+  let wins = 0;
+  let total = 0;
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    if (typeof t.result !== 'number' || !Number.isFinite(t.result)) continue;
+    total += 1;
+    if (t.result > 0) wins += 1;
+  }
+  if (total === 0) return null;
+  return wins / total;
+}
+
+/**
+ * CV observado sobre array de P&L diários. Std amostral N-1 (consistente
+ * com computeSharpe / computeCycleSharpe). Retorna `cv: null` quando
+ * `|mean| ≈ 0` (CV indefinido) ou `std = 0` (degenerado).
+ *
+ * @param {number[]} dailyPLs
+ * @returns {{cv:(number|null), mean:number, std:number}}
+ */
+export function computeCvObserved(dailyPLs) {
+  if (!Array.isArray(dailyPLs) || dailyPLs.length === 0) {
+    return { cv: null, mean: 0, std: 0 };
+  }
+  const N = dailyPLs.length;
+  let sum = 0;
+  for (const v of dailyPLs) sum += v;
+  const mean = sum / N;
+
+  if (N < 2) {
+    if (Math.abs(mean) < NEAR_ZERO) return { cv: null, mean, std: 0 };
+    return { cv: 0, mean, std: 0 };
+  }
+
+  let sumSq = 0;
+  for (const v of dailyPLs) sumSq += (v - mean) ** 2;
+  const std = Math.sqrt(sumSq / (N - 1));
+
+  if (Math.abs(mean) < NEAR_ZERO) return { cv: null, mean, std };
+  return { cv: std / Math.abs(mean), mean, std };
+}
+
+/**
+ * CV esperado pelo plano. Fórmula analítica para distribuição de Bernoulli
+ * win/loss em unidades de R (ganho = +RR, perda = −1):
+ *   mean = p·RR − (1−p)
+ *   var  = p·(RR − mean)² + (1−p)·(−1 − mean)²
+ *   cv   = sqrt(var) / |mean|     (null se |mean| ≈ 0 → plano breakeven)
+ *
+ * @param {number} p   — WR (0..1)
+ * @param {number} RR  — risk-reward (>0)
+ * @returns {{cv:(number|null), mean:number, std:number}}
+ */
+export function computeCvExpected(p, RR) {
+  const mean = p * RR - (1 - p);
+  const variance = p * (RR - mean) ** 2 + (1 - p) * (-1 - mean) ** 2;
+  const std = Math.sqrt(variance);
+  if (Math.abs(mean) < NEAR_ZERO) return { cv: null, mean, std };
+  return { cv: std / Math.abs(mean), mean, std };
+}
+
+/**
+ * Resolve `p` (WR) a partir de trades efetivos, com fallback para
+ * `plan.expectedWinRate` quando trades não permitem cálculo.
+ *
+ * @param {Array<{result:number,status:string}>} trades
+ * @param {{expectedWinRate?:number}} plan
+ * @returns {number|null}
+ */
+export function resolveWinRate(trades, plan) {
+  const fromTrades = effectiveWinRate(trades);
+  if (fromTrades !== null) return fromTrades;
+  const fallback = plan && plan.expectedWinRate;
+  if (typeof fallback === 'number' && Number.isFinite(fallback)) return fallback;
+  return null;
+}
+
+/**
+ * CV normalizado per-ciclo. Pure function — zero Firestore.
+ *
+ * @param {Array<{date:string,result:number,status:string}>} trades
+ * @param {{targetRR:number, expectedWinRate?:number}} plan
+ * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
+ * @param {Object} [opts]
+ * @param {number} [opts.minDays=5]
+ * @returns {{
+ *   value:(number|null),
+ *   cvObs:(number|null),
+ *   cvExp:(number|null),
+ *   daysWithTrade:number,
+ *   insufficientReason?:('min_days'|'no_target_rr'|'breakeven_plan'|'zero_obs_mean'),
+ *   label?:string,
+ * }}
+ */
+export function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {}) {
+  const minDays = typeof opts.minDays === 'number' ? opts.minDays : 5;
+
+  const groups = groupTradesByDay(trades, cycleStart, cycleEnd);
+  const daysWithTrade = groups.size;
+
+  if (daysWithTrade < minDays) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'min_days',
+      label: `Insuficiente · ≥${minDays} dias`,
+    };
+  }
+
+  const targetRR = plan && plan.targetRR;
+  if (typeof targetRR !== 'number' || !Number.isFinite(targetRR) || targetRR <= 0) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'no_target_rr',
+      label: 'Plano sem RR alvo definido — definir para ativar métrica',
+    };
+  }
+
+  // Trades efetivamente dentro da janela (mesma filtragem do groupBy).
+  const inWindowTrades = [];
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    const iso = parseDateToIso(t.date);
+    if (iso === null) continue;
+    if (iso < cycleStart || iso > cycleEnd) continue;
+    if (typeof t.result !== 'number' || !Number.isFinite(t.result)) continue;
+    inWindowTrades.push(t);
+  }
+
+  const p = resolveWinRate(inWindowTrades, plan);
+  if (p === null) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'no_target_rr',
+      label: 'Plano sem RR alvo definido — definir para ativar métrica',
+    };
+  }
+
+  const exp = computeCvExpected(p, targetRR);
+  if (exp.cv === null) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: null,
+      daysWithTrade,
+      insufficientReason: 'breakeven_plan',
+      label: 'Plano com expectância nula — métrica indefinida',
+    };
+  }
+
+  const dailyPLs = Array.from(groups.values());
+  const obs = computeCvObserved(dailyPLs);
+  if (obs.cv === null) {
+    return {
+      value: null,
+      cvObs: null,
+      cvExp: exp.cv,
+      daysWithTrade,
+      insufficientReason: 'zero_obs_mean',
+      label: 'P&L médio diário próximo de zero — CV indefinido',
+    };
+  }
+
+  return {
+    value: obs.cv / exp.cv,
+    cvObs: obs.cv,
+    cvExp: exp.cv,
+    daysWithTrade,
+  };
+}

--- a/src/utils/cycleConsistency/computeCVNormalized.js
+++ b/src/utils/cycleConsistency/computeCVNormalized.js
@@ -12,8 +12,8 @@
  *   cv_obs   = std_obs / |mean_obs|                          (null se mean_obs ≈ 0)
  *
  *   ── CV esperado pelo plano (analítico) ──
- *   p        = WR efetiva no ciclo (fallback plan.expectedWinRate)
- *   RR       = plan.targetRR
+ *   p        = WR efetiva no ciclo (fallback breakeven 1/(1+RR) quando insuficiente)
+ *   RR       = plan.rrTarget
  *   mean_exp = p × RR − (1 − p)                              [unidades de R]
  *   var_exp  = p × (RR − mean_exp)² + (1 − p) × (−1 − mean_exp)²
  *   std_exp  = sqrt(var_exp)
@@ -140,18 +140,21 @@ export function computeCvExpected(p, RR) {
 }
 
 /**
- * Resolve `p` (WR) a partir de trades efetivos, com fallback para
- * `plan.expectedWinRate` quando trades não permitem cálculo.
+ * Resolve `p` (WR) a partir de trades efetivos, com fallback para a
+ * **WR de breakeven** dado o RR alvo (`p_be = 1/(1+RR)`). Não há campo
+ * de WR esperada no modelo do plano — fallback breakeven é a hipótese
+ * neutra para o RR escolhido.
  *
  * @param {Array<{result:number,status:string}>} trades
- * @param {{expectedWinRate?:number}} plan
+ * @param {number} rrTarget
  * @returns {number|null}
  */
-export function resolveWinRate(trades, plan) {
+export function resolveWinRate(trades, rrTarget) {
   const fromTrades = effectiveWinRate(trades);
   if (fromTrades !== null) return fromTrades;
-  const fallback = plan && plan.expectedWinRate;
-  if (typeof fallback === 'number' && Number.isFinite(fallback)) return fallback;
+  if (typeof rrTarget === 'number' && Number.isFinite(rrTarget) && rrTarget > 0) {
+    return 1 / (1 + rrTarget);
+  }
   return null;
 }
 
@@ -159,7 +162,7 @@ export function resolveWinRate(trades, plan) {
  * CV normalizado per-ciclo. Pure function — zero Firestore.
  *
  * @param {Array<{date:string,result:number,status:string}>} trades
- * @param {{targetRR:number, expectedWinRate?:number}} plan
+ * @param {{rrTarget:number}} plan — campo canônico é `rrTarget` (ver PlanManagementModal)
  * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
  * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
  * @param {Object} [opts]
@@ -190,8 +193,8 @@ export function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {
     };
   }
 
-  const targetRR = plan && plan.targetRR;
-  if (typeof targetRR !== 'number' || !Number.isFinite(targetRR) || targetRR <= 0) {
+  const rrTarget = plan && plan.rrTarget;
+  if (typeof rrTarget !== 'number' || !Number.isFinite(rrTarget) || rrTarget <= 0) {
     return {
       value: null,
       cvObs: null,
@@ -213,7 +216,7 @@ export function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {
     inWindowTrades.push(t);
   }
 
-  const p = resolveWinRate(inWindowTrades, plan);
+  const p = resolveWinRate(inWindowTrades, rrTarget);
   if (p === null) {
     return {
       value: null,
@@ -225,7 +228,7 @@ export function computeCVNormalized(trades, plan, cycleStart, cycleEnd, opts = {
     };
   }
 
-  const exp = computeCvExpected(p, targetRR);
+  const exp = computeCvExpected(p, rrTarget);
   if (exp.cv === null) {
     return {
       value: null,

--- a/src/utils/cycleConsistency/computeCycleSharpe.js
+++ b/src/utils/cycleConsistency/computeCycleSharpe.js
@@ -1,0 +1,204 @@
+/**
+ * src/utils/cycleConsistency/computeCycleSharpe.js — issue #235 F1.1
+ *
+ * Sharpe ratio per-ciclo com Selic histórica descontada apenas em dias com
+ * trade. Anualiza pelo factor √252 (DEC-AUTO-235-03).
+ *
+ * Algoritmo (memória de cálculo, body do issue #235):
+ *   returns_d   = Σ result_dia(d) / plStart                    [d ∈ dias com trade]
+ *   rfr_d       = getSelicForDate(d).rateDaily                 [um lookup por dia distinto]
+ *   excess_d    = returns_d - rfr_d
+ *   mean        = Σ excess_d / N
+ *   std         = sqrt( Σ (excess_d - mean)² / (N - 1) )       [amostral, Bessel]
+ *   sharpe      = (mean / std) * √252                          [annual]
+ *
+ * Consistência declarada: Selic é descontada APENAS para dias com trade —
+ * nem dias sem trade entram em returns_d nem em rfr_d (alinhamento numerador
+ * vs custo de oportunidade).
+ *
+ * ⚠️ ESPELHO de functions/cycleConsistency/computeCycleSharpe.js — MANTER SINCRONIZADO ⚠️
+ * Qualquer alteração aqui replica no CJS, e vice-versa (padrão #119/#191).
+ */
+
+const SQRT_252 = Math.sqrt(252);
+const SQRT_21 = Math.sqrt(21);
+
+const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BR_DATE_RE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+/**
+ * Converte string `DD/MM/YYYY` ou `YYYY-MM-DD` para ISO `YYYY-MM-DD`.
+ * Retorna null para qualquer outro formato.
+ */
+function parseDateToIso(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  const m = BR_DATE_RE.exec(value);
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  return null;
+}
+
+/**
+ * Agrupa trades por dia (ISO `YYYY-MM-DD`), filtrando por janela
+ * `[cycleStart, cycleEnd]` (inclusive) e `status === 'CLOSED'`.
+ * Trades sem `date` parseável, sem `result` numérico ou fora da janela
+ * são ignorados silenciosamente.
+ *
+ * @param {Array<{date:string,result:number,status:string}>} trades
+ * @param {string} cycleStart — ISO `YYYY-MM-DD`
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD`
+ * @returns {Map<string,number>} Map<dateIso, sumPL>
+ */
+export function groupTradesByDay(trades, cycleStart, cycleEnd) {
+  const map = new Map();
+  if (!Array.isArray(trades) || trades.length === 0) return map;
+
+  for (const t of trades) {
+    if (!t || t.status !== 'CLOSED') continue;
+    const iso = parseDateToIso(t.date);
+    if (iso === null) continue;
+    if (iso < cycleStart || iso > cycleEnd) continue;
+    const pl = typeof t.result === 'number' && Number.isFinite(t.result) ? t.result : null;
+    if (pl === null) continue;
+    map.set(iso, (map.get(iso) ?? 0) + pl);
+  }
+  return map;
+}
+
+/**
+ * Converte Map<dateIso, sumPL> em lista ordenada de `{dateIso, dailyReturn}`.
+ * `dailyReturn = sumPL / plStart` (denominador constante = balance do início
+ * do ciclo, conforme contrato do helper). Datas ordenadas asc.
+ *
+ * @param {Map<string,number>} groups
+ * @param {number} plStart
+ * @returns {Array<{dateIso:string, dailyReturn:number}>}
+ */
+export function dailyReturnsFromGroups(groups, plStart) {
+  if (!(groups instanceof Map) || groups.size === 0) return [];
+  if (typeof plStart !== 'number' || !Number.isFinite(plStart) || plStart === 0) return [];
+
+  const dates = Array.from(groups.keys()).sort();
+  return dates.map((dateIso) => ({
+    dateIso,
+    dailyReturn: groups.get(dateIso) / plStart,
+  }));
+}
+
+/**
+ * Média e desvio-padrão amostral (denominador N-1) de um array numérico.
+ * N=0 → {mean:0, std:0}. N=1 → {mean:arr[0], std:0} (sem variância amostral).
+ *
+ * @param {number[]} arr
+ * @returns {{mean:number, std:number}}
+ */
+export function meanStdSample(arr) {
+  if (!Array.isArray(arr) || arr.length === 0) return { mean: 0, std: 0 };
+  const N = arr.length;
+  let sum = 0;
+  for (const v of arr) sum += v;
+  const mean = sum / N;
+  if (N < 2) return { mean, std: 0 };
+
+  let sumSq = 0;
+  for (const v of arr) sumSq += (v - mean) ** 2;
+  const std = Math.sqrt(sumSq / (N - 1));
+  return { mean, std };
+}
+
+function aggregateSource(daySources) {
+  // daySources: Array<{isFallback:boolean}>
+  let bcbCount = 0;
+  let fallbackCount = 0;
+  for (const s of daySources) {
+    if (s.isFallback) fallbackCount += 1;
+    else bcbCount += 1;
+  }
+  const fallbackUsed = fallbackCount > 0;
+  let source;
+  if (fallbackCount === 0) source = 'BCB';
+  else if (bcbCount === 0) source = 'FALLBACK';
+  else source = 'MIXED';
+  return { source, fallbackUsed };
+}
+
+/**
+ * Resolve a função de lookup de Selic. Aceita override via `opts.getSelicForDateFn`
+ * (sempre usado em testes, evita carregar firebase). Sem override, importa
+ * dinamicamente o helper real — nunca side-effect na carga do módulo.
+ */
+async function resolveGetSelicFn(opts) {
+  if (typeof opts.getSelicForDateFn === 'function') return opts.getSelicForDateFn;
+  const mod = await import('../marketData/getSelicForDate.js');
+  return mod.getSelicForDate;
+}
+
+/**
+ * Sharpe per-ciclo anualizado, com Selic histórica descontada por dia operado.
+ *
+ * @param {Array<{date:string,result:number,status:string}>} trades
+ * @param {string} cycleStart — ISO `YYYY-MM-DD` (inclusive)
+ * @param {string} cycleEnd   — ISO `YYYY-MM-DD` (inclusive)
+ * @param {number} plStart    — balance no início do ciclo (R$); denominador R$→%
+ * @param {Object} [opts]
+ * @param {number} [opts.minDays=5]               — mínimo de dias distintos com trade
+ * @param {('annual'|'monthly')} [opts.periodicity='annual']
+ * @param {Function} [opts.getSelicForDateFn]     — override (testabilidade)
+ * @returns {Promise<{value:(number|null), daysWithTrade:number, source:('BCB'|'FALLBACK'|'MIXED'), insufficientReason?:string, fallbackUsed:boolean}>}
+ */
+export async function computeCycleSharpe(trades, cycleStart, cycleEnd, plStart, opts = {}) {
+  const minDays = typeof opts.minDays === 'number' ? opts.minDays : 5;
+  const periodicity = opts.periodicity ?? 'annual';
+  const multiplier = periodicity === 'monthly' ? SQRT_21 : SQRT_252;
+
+  const groups = groupTradesByDay(trades, cycleStart, cycleEnd);
+  const daysWithTrade = groups.size;
+
+  if (daysWithTrade < minDays) {
+    return {
+      value: null,
+      daysWithTrade,
+      source: 'BCB',
+      insufficientReason: 'min_days',
+      fallbackUsed: false,
+    };
+  }
+
+  const dailyReturns = dailyReturnsFromGroups(groups, plStart);
+  const getSelicFn = await resolveGetSelicFn(opts);
+
+  const lookups = await Promise.all(
+    dailyReturns.map((d) => Promise.resolve(getSelicFn(d.dateIso)))
+  );
+
+  const excess = [];
+  const daySources = [];
+  for (let i = 0; i < dailyReturns.length; i += 1) {
+    const r = lookups[i] ?? {};
+    const rateDaily = typeof r.rateDaily === 'number' && Number.isFinite(r.rateDaily) ? r.rateDaily : 0;
+    const isFallback = r.isFallback === true || r.source === 'FALLBACK';
+    daySources.push({ isFallback });
+    excess.push(dailyReturns[i].dailyReturn - rateDaily);
+  }
+
+  const { source, fallbackUsed } = aggregateSource(daySources);
+  const { mean, std } = meanStdSample(excess);
+
+  if (std === 0) {
+    return {
+      value: null,
+      daysWithTrade,
+      source,
+      insufficientReason: 'zero_variance',
+      fallbackUsed,
+    };
+  }
+
+  const value = (mean / std) * multiplier;
+  return {
+    value,
+    daysWithTrade,
+    source,
+    fallbackUsed,
+  };
+}

--- a/src/utils/marketData/getSelicForDate.js
+++ b/src/utils/marketData/getSelicForDate.js
@@ -1,0 +1,122 @@
+/**
+ * src/utils/marketData/getSelicForDate.js — issue #235 Fase F0.3
+ *
+ * Resolve a taxa Selic diária (`rateDaily`, fração) para uma data ISO,
+ * lendo `systemConfig/selic/history/<YYYY-MM-DD>` (gravado pela CF F0.1
+ * `fetchSelicDaily` e backfill F0.2). Aplica carry-forward em
+ * fim-de-semana / feriado e cai em fallback hardcoded em gap longo
+ * ou erro de Firestore — NUNCA throw.
+ *
+ * ⚠️ ESPELHO de functions/marketData/getSelicForDate.js — MANTER SINCRONIZADO ⚠️
+ * Qualquer mudança aqui replica no CJS, e vice-versa (padrão #119/#191).
+ *
+ * Schema esperado (lock INV-10 com fetchSelicDaily.js):
+ *   { date: 'YYYY-MM-DD', rateDaily: number, source: string, fetchedAt: Timestamp }
+ *
+ * INV-15: leitura apenas, namespace já aprovado em F0.1.
+ */
+
+import {
+  getDoc,
+  doc,
+  collection,
+  getDocs,
+  query,
+  where,
+  orderBy,
+  limit,
+} from 'firebase/firestore';
+import { db as defaultDb } from '../../firebase';
+
+// Fonte: /mnt/c/000-Marcio/Temp/bcb-mock-spec.md (Selic 14.75% a.a. ÷ 252 d.u. ÷ 100).
+// Última calibração: 2026-05-02. Revisar se Selic se mover ±2 p.p.
+export const SELIC_FALLBACK_DAILY = 14.75 / 252 / 100;
+export const SELIC_HISTORY_PATH = 'systemConfig/selic/history';
+const FALLBACK_SOURCE = 'FALLBACK';
+const DEFAULT_MAX_CARRY_FORWARD_DAYS = 7;
+
+/**
+ * Diferença em dias inteiros entre duas datas ISO `YYYY-MM-DD`.
+ * Usa UTC midnight pra evitar drift de timezone (DST etc.).
+ *
+ * @param {string} isoA — data final
+ * @param {string} isoB — data inicial
+ * @returns {number} isoA - isoB em dias
+ */
+export function daysDiffIso(isoA, isoB) {
+  const a = Date.parse(`${isoA}T00:00:00Z`);
+  const b = Date.parse(`${isoB}T00:00:00Z`);
+  return Math.round((a - b) / 86400000);
+}
+
+function makeFallback(rateDaily) {
+  return {
+    rateDaily,
+    source: FALLBACK_SOURCE,
+    dateUsed: null,
+    isCarryForward: false,
+    isFallback: true,
+  };
+}
+
+/**
+ * Resolve `rateDaily` para `dateIso`.
+ *
+ * @param {string} dateIso                                    — `YYYY-MM-DD`
+ * @param {Object} [opts]
+ * @param {Object} [opts.db]                                  — Firestore instance (default: client web SDK)
+ * @param {number} [opts.maxCarryForwardDays=7]               — gap máximo aceito antes do fallback
+ * @param {number} [opts.fallbackRateDaily=SELIC_FALLBACK_DAILY]
+ * @returns {Promise<{rateDaily:number, source:string, dateUsed:string|null, isCarryForward:boolean, isFallback:boolean}>}
+ */
+export async function getSelicForDate(dateIso, opts = {}) {
+  const dbRef = opts.db ?? defaultDb;
+  const maxCarryForwardDays = opts.maxCarryForwardDays ?? DEFAULT_MAX_CARRY_FORWARD_DAYS;
+  const fallbackRateDaily = opts.fallbackRateDaily ?? SELIC_FALLBACK_DAILY;
+
+  try {
+    const exactRef = doc(dbRef, `${SELIC_HISTORY_PATH}/${dateIso}`);
+    const exactSnap = await getDoc(exactRef);
+    if (exactSnap.exists()) {
+      const data = exactSnap.data();
+      return {
+        rateDaily: data.rateDaily,
+        source: data.source,
+        dateUsed: dateIso,
+        isCarryForward: false,
+        isFallback: false,
+      };
+    }
+
+    const colRef = collection(dbRef, SELIC_HISTORY_PATH);
+    const q = query(
+      colRef,
+      where('date', '<=', dateIso),
+      orderBy('date', 'desc'),
+      limit(1)
+    );
+    const snap = await getDocs(q);
+    if (snap.empty || !snap.docs?.length) {
+      return makeFallback(fallbackRateDaily);
+    }
+
+    const data = snap.docs[0].data();
+    const foundDate = data.date;
+    const daysBack = daysDiffIso(dateIso, foundDate);
+    if (daysBack >= 0 && daysBack <= maxCarryForwardDays) {
+      return {
+        rateDaily: data.rateDaily,
+        source: data.source,
+        dateUsed: foundDate,
+        isCarryForward: daysBack > 0,
+        isFallback: false,
+      };
+    }
+    return makeFallback(fallbackRateDaily);
+  } catch (err) {
+    const code = err?.code ?? 'firestore_error';
+    const message = err?.message ?? String(err);
+    console.error(`[getSelicForDate] ${code}: ${message} (date=${dateIso})`);
+    return makeFallback(fallbackRateDaily);
+  }
+}

--- a/src/version.js
+++ b/src/version.js
@@ -4,7 +4,7 @@
  *
  * CHANGELOG:
  * - 1.54.0: feat: redesign card "Consistência Operacional" — Sharpe per-ciclo (com Selic
- *   histórica diária descontada via BCB SGS-11), CV normalizado (`cv_obs / cv_exp(plan.targetRR, WR)`
+ *   histórica diária descontada via BCB SGS-11), CV normalizado (`cv_obs / cv_exp(plan.rrTarget, WR)`
  *   substitui CV puro), MEP/MEN médio visível ao aluno (#187 já coleta). Infra nova: CF agendada
  *   `fetchSelicDaily` cron 09h BRT + script bootstrap retroativo + helper `getSelicForDate` com
  *   carry-forward + fallback hardcoded (issue #235). 2 collections novas Firestore aprovadas


### PR DESCRIPTION
Closes #235

## Summary

- Card "Consistência Operacional" no StudentDashboard substitui CV puro por **CV normalizado** (cv_obs / cv_exp do plano) e adiciona **Sharpe per-ciclo com Selic histórica descontada**, **MEP médio** e **MEN médio**.
- Infra Selic via BCB SGS-11: CF agendada diária `fetchSelicDaily` + script de bootstrap desde 2024-01-01 + helper `getSelicForDate` (carry-forward + fallback) + rules autenticadas.
- 3 helpers ESM↔CJS espelhados em `cycleConsistency/`: `computeCycleSharpe`, `computeCVNormalized`, `computeAvgExcursion`.
- Hook `useCycleConsistency` orquestra os 3 helpers + Selic; componente `CycleConsistencyCard` consome via Hook.
- `frozenSnapshot.kpis.cvNormalized` populado em novas reviews semanais (sem migração legado — DEC-AUTO-235-16).

## Decisões consumadas

17 decisões antecipadas (DEC-AUTO-235-01..17) + decisões autônomas durante execução (DEC-AUTO-235-T01-A..T10-A) — detalhadas no `.deccs-235.md` (DEC numéricas) e no control file `docs/dev/issues/issue-235-cycle-consistency-redesign.md` (DEC com sufixo Tnn-X).

## Cross-refs

- #72 (Fechamento de Ciclo) — F3.2 (`cycleClosures.metrics`) **NÃO incluída** nesta PR pois #72 Fase 1 ainda não mergeada (`cycleClosures` collection não existe). Quando #72 Fase 1 aterrissar, abrir issue de continuação para popular `cycleClosures.metrics.{sharpeAdapted, cvNormalized, avgMEP, avgMEN, sharpeRfrSource}` no fechamento.
- #102 (Revisão Semanal) — `frozenSnapshot.kpis.cvNormalized` adicionado; `coefVariation` legado mantido para compat reversa.
- #187 (Yahoo bars / MEP/MEN) — reutiliza `mepPrice`/`menPrice` já populados; nenhuma mudança no enrichment.
- #119 (Maturity Engine) — gates `sharpe-1_2`/`sharpe-1_5` **inalterados** (DEC-AUTO-235-17).

## Test plan

- [ ] Card "Consistência Operacional" no StudentDashboard exibe 4 métricas com badges/tooltips.
- [ ] Estados degenerados ("Insuficiente · ≥X dias", "Plano sem RR alvo definido") aparecem quando esperado.
- [ ] Badge `📊 BCB` / `⚠ fallback` reflete fonte da Selic.
- [ ] Badge `⚠ MEP/MEN em N de M trades` quando coverage < 70%.
- [ ] Nova review semanal grava `frozenSnapshot.kpis.cvNormalized` (DRAFT → publish).
- [ ] CF `fetchSelicDaily` agendada deploy (cc-close-issue.sh dispara auto-deploy de `functions/`).

## Suítes

- root: 2918 / 0 (vitest run)
- functions: 84 / 0 (vitest run)
- build: ok (vite build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)