### PR TITLE
fix(#240): gate plano retroativo (dia, não hora) + dedup performance import

### DIFF
--- a/docs/dev/issues/issue-240-plan-coverage-and-perf-dedup.md
+++ b/docs/dev/issues/issue-240-plan-coverage-and-perf-dedup.md
@@ -73,10 +73,11 @@ cobre = (createdMs == null || opDay >= createdDay)
 
 ## Sessions
 
-- task A1+A2 [planCoverage day-of-year] commit pending — `planCoversDate` compara `YYYY-MM-DD` UTC; 4 testes novos + 16 baseline preservados (20/20 ok)
-- task B1..B3 [csv-staging dedup] commit pending — `useCsvStaging.activateTrade/Batch` aceitam `existingTrades`, reusam `checkDuplication` exportado de `orderTradeCreation`, retornam `skipped[]`; wrappers em `StudentDashboard`+`TradesJournal`+`CsvImportManager` propagam trades do plano
-- task B4 [test cross-source] commit pending — 1 teste novo em `orderTradeCreation.test.js` documenta cobertura cross-source (manual + order_import + csv)
-- task C1 [suite full] — 184 arquivos / 2938 testes passando; vite build limpo
+- task A1+A2 [planCoverage day-of-year] commit `1cd32a16` — `planCoversDate` compara `YYYY-MM-DD` UTC; 4 testes novos + 16 baseline preservados (20/20 ok)
+- task B1..B3 [csv-staging dedup] commit `1cd32a16` — `useCsvStaging.activateTrade/Batch` aceitam `existingTrades`, reusam `checkDuplication` exportado de `orderTradeCreation`, retornam `skipped[]`; wrappers em `StudentDashboard`+`TradesJournal`+`CsvImportManager` propagam trades do plano
+- task B4 [test cross-source] commit `1cd32a16` — 1 teste novo em `orderTradeCreation.test.js` documenta cobertura cross-source (manual + order_import + csv)
+- task D1+D2 [csv perf MEP/MEN auto-enrich] commit pending — opt (A) auto-enrich silencioso. Novo helper puro `src/utils/csvEnrichmentPatch.js` (preenche só campos vazios, nunca sobrescreve, default `excursionSource: 'profitpro'`). `useCsvStaging` aceita `options.updateTradeFn`; quando duplicata + CSV traz mep/men que faltam → chama `updateTradeFn(matchedId, patch)` validado por `validateExcursionPrices`; retorna `enriched[]`. 13 testes novos (`csvEnrichmentPatch.test.js`).
+- task C1 [suite full] — 185 arquivos / 2952 testes passando; vite build limpo
 
 ## Shared Deltas
 
@@ -89,6 +90,7 @@ cobre = (createdMs == null || opDay >= createdDay)
 
 - DEC-AUTO-240-01 — `planCoversDate` compara dia local (UTC normalizado) ao invés de timestamp ms; tradeoff de borda noturna documentado em memória de cálculo.
 - DEC-AUTO-240-02 — `useCsvStaging` reusa `checkDuplication` exportado de `orderTradeCreation.js` (DRY); ambos pipelines passam a aplicar o mesmo critério.
+- DEC-AUTO-240-03 — Auto-enrich silencioso de MEP/MEN/`excursionSource` quando duplicata é detectada e o trade existente NÃO tem o campo. Conservador: nunca sobrescreve, sempre via `updateTrade` (gateway oficial), validado por `validateExcursionPrices` antes do write. Default `excursionSource: 'profitpro'` quando CSV não vem com origem explícita.
 
 ## Chunks
 

--- a/docs/dev/issues/issue-240-plan-coverage-and-perf-dedup.md
+++ b/docs/dev/issues/issue-240-plan-coverage-and-perf-dedup.md
@@ -1,0 +1,97 @@
+# Issue #240 — fix: plano retroativo (hora vs data) + dedup performance import
+
+## Autorização
+
+- [x] Mockup — N/A (fix técnico, sem UI nova; exceção autorizada por Marcio: "precisa corrigir tudo... fast track")
+- [x] Memória de cálculo — abaixo
+- [x] Marcio autorizou: "precisa corrigir tudo. E a importação de performance precisa checar se existe trade seja por criação manual ou por ordem... assim como a importação de ordem faz. Agora esse erro do plano é ridículo, precisa corrigir asap. Não há sessões em paralelo, faça fast track" (04/05/2026)
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Bug 1 — `planCoverage.planCoversDate` compara timestamps com hora; plano criado às 14h não cobre ordem das 11h do mesmo dia. Bloqueia importação de ordens do dia em que o plano nasceu.
+
+Bug 2 — `useCsvStaging.confirmStaging` cria trades sem checar duplicatas. Aluno que importa ordens (gera trades `order_import`) e depois importa performance no mesmo plano vê trades duplicados.
+
+## Spec
+
+Issue body em `gh issue view 240`.
+
+## Memória de Cálculo
+
+### Bug 1 — Cobertura por dia local
+
+**Inputs (atual):**
+- `plan.createdAt` → Firestore Timestamp / ISO / ms (com hora exata)
+- `plan.closedAt` → idem (opcional)
+- `op.entryTime` → string ISO (`2026-05-04T11:39:20`)
+
+**Fórmula nova:**
+```
+toDay(value) → 'YYYY-MM-DD' (timezone local do servidor que gravou)
+opDay = toDay(opMs)
+createdDay = toDay(createdMs)  // se houver
+closedDay = toDay(closedMs)    // se houver
+
+cobre = (createdMs == null || opDay >= createdDay)
+     && (closedMs == null || opDay <= closedDay)
+     && (plan.active !== false)
+     && (accountId match)
+```
+
+**Exemplo (cenário do CSV `040526-ORDER.csv`):**
+- `op.entryTime = '2026-05-04T11:39:20'` → `opDay = '2026-05-04'`
+- `plan.createdAt = '2026-05-04T14:00:00'` → `createdDay = '2026-05-04'`
+- `opDay >= createdDay` → **true** → plano cobre ✓ (antes retornava false)
+
+**Caso limite — fuso horário:** `toMs` já normaliza para epoch ms; `toDay` aplica `Date.toISOString().slice(0,10)` (UTC) — consistente entre cliente e Firestore (que sempre serializa em UTC). Plano criado 04/05 23h BRT (= 05/05 02h UTC) cobre ordem 04/05 23:30 BRT (= 05/05 02:30 UTC) — ambos viram `'2026-05-05'` em UTC, comparação consistente. **Aceito o tradeoff:** dia de virada (entre 21h BRT e meia-noite) o "dia" é UTC, não local — mas como `entryTime` do CSV também é serializado pelo broker em hora local sem fuso, o resultado é simétrico.
+
+### Bug 2 — Dedup em performance import
+
+**Reusar:** `checkDuplication(tradeData, existingTrades)` em `src/utils/orderTradeCreation.js:244-292`.
+
+**Critério (já implementado):** ticker (case-insensitive) ∧ side ∧ qty (±0.01) ∧ entryTime (±5min via `CORRELATION_WINDOW_MS`). Fallback por data quando trade existente sem hora.
+
+**Integração no CSV staging:**
+1. `useCsvStaging.confirmStaging(batchId)` lê `existingTrades` do plano (já tem via `useTrades` no caller).
+2. Antes de cada `addTrade(tradeData)`, chama `checkDuplication(tradeData, existingTrades)`.
+3. Se `isDuplicate` → pula, incrementa `duplicatesSkipped`, registra `matchedTradeId` no return.
+4. Caller (`CsvImportWizard`) exibe contagem na tela final ("X duplicatas ignoradas — já existiam de import anterior").
+
+**Caso limite — trade manual sem `entryTime`:** `checkDuplication` cai no fallback por data (linha 277-287); cobre. Trade do plano sem ticker (legado) é comparado por uppercase('') ≠ uppercase('WINM26') → não bate (correto, segue criando).
+
+## Phases
+
+- A1 — fix `planCoverage.js` (compare por dia, não ms)
+- A2 — testes `planCoverage.test.js` (caso 14h-cobre-11h-mesmo-dia + edges)
+- B1 — propagar `existingTrades` ao caller de `confirmStaging`
+- B2 — `confirmStaging` chama `checkDuplication` antes de `addTrade`
+- B3 — atualizar `CreationResultPanel` ou tela DONE do `CsvImportWizard` para mostrar "X duplicatas ignoradas"
+- B4 — testes do dedup no `useCsvStaging` (mock trades existentes, casos: same window / outside window / different ticker)
+- C1 — npm test full + smoke local
+- C2 — encerramento via `cc-close-issue.sh 240`
+
+## Sessions
+
+- task A1+A2 [planCoverage day-of-year] commit pending — `planCoversDate` compara `YYYY-MM-DD` UTC; 4 testes novos + 16 baseline preservados (20/20 ok)
+- task B1..B3 [csv-staging dedup] commit pending — `useCsvStaging.activateTrade/Batch` aceitam `existingTrades`, reusam `checkDuplication` exportado de `orderTradeCreation`, retornam `skipped[]`; wrappers em `StudentDashboard`+`TradesJournal`+`CsvImportManager` propagam trades do plano
+- task B4 [test cross-source] commit pending — 1 teste novo em `orderTradeCreation.test.js` documenta cobertura cross-source (manual + order_import + csv)
+- task C1 [suite full] — 184 arquivos / 2938 testes passando; vite build limpo
+
+## Shared Deltas
+
+- `src/version.js` — bump v1.55.1 (já no main, commit `6d37fa9d`)
+- `docs/registry/chunks.md` — lock CHUNK-10+CHUNK-07 (já no main)
+- `docs/registry/versions.md` — v1.55.1 reservada (já no main)
+- `CHANGELOG.md` — entrada `[1.55.1] - 04/05/2026` (no encerramento)
+
+## Decisions
+
+- DEC-AUTO-240-01 — `planCoversDate` compara dia local (UTC normalizado) ao invés de timestamp ms; tradeoff de borda noturna documentado em memória de cálculo.
+- DEC-AUTO-240-02 — `useCsvStaging` reusa `checkDuplication` exportado de `orderTradeCreation.js` (DRY); ambos pipelines passam a aplicar o mesmo critério.
+
+## Chunks
+
+- CHUNK-10 (escrita) — `planCoverage.js`
+- CHUNK-07 (escrita) — `useCsvStaging.js` + caller
+- CHUNK-04 (leitura) — `tradeGateway.addTrade` chamado pelo caller

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,5 +5,5 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
-
-_(sem locks ativos)_
+| CHUNK-10 | #240 | `fix/issue-240-plan-coverage-and-perf-dedup` | 04/05/2026 | escrita |
+| CHUNK-07 | #240 | `fix/issue-240-plan-coverage-and-perf-dedup` | 04/05/2026 | escrita |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -20,3 +20,4 @@
 | 1.53.0 | #229 | `feat/issue-229-stop-breakeven-hesitation-detectors` | 01/05/2026 | consumida (PR #230 squash `fa23e496`) |
 | 1.54.0 | #235 | `feat/issue-235-cycle-consistency-redesign` | 02/05/2026 | consumida (PR #236 squash `ea8e7bff`) |
 | 1.55.0 | #237 | `feat/issue-237-contacts-assinaturas` | 02/05/2026 | consumida (PR #238 squash `1ad8198a`) |
+| 1.55.1 | #240 | `fix/issue-240-plan-coverage-and-perf-dedup` | 04/05/2026 | reservada |

--- a/src/__tests__/utils/csvEnrichmentPatch.test.js
+++ b/src/__tests__/utils/csvEnrichmentPatch.test.js
@@ -1,0 +1,149 @@
+/**
+ * csvEnrichmentPatch.test.js
+ * @description Issue #240 — auto-enrich silencioso de MEP/MEN do CSV de
+ *   performance em trades existentes (criados por order_import ou manual).
+ *   Regra forte: NUNCA sobrescrever campo já preenchido no trade existente.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeExcursionEnrichmentPatch } from '../../utils/csvEnrichmentPatch';
+
+const tradeData = (overrides = {}) => ({
+  ticker: 'WINJ26',
+  side: 'LONG',
+  entry: '120000',
+  exit: '120500',
+  qty: '2',
+  mepPrice: 120800,
+  menPrice: 119500,
+  excursionSource: 'profitpro',
+  ...overrides,
+});
+
+const existing = (overrides = {}) => ({
+  id: 'trade-001',
+  ticker: 'WINJ26',
+  side: 'LONG',
+  entry: 120000,
+  exit: 120500,
+  qty: 2,
+  source: 'order_import',
+  importBatchId: 'batch-A',
+  // mepPrice/menPrice/excursionSource ausentes por default
+  ...overrides,
+});
+
+describe('computeExcursionEnrichmentPatch', () => {
+  it('preenche mepPrice + menPrice + excursionSource quando trade existente NÃO tem', () => {
+    const result = computeExcursionEnrichmentPatch(tradeData(), existing());
+    expect(result).not.toBeNull();
+    expect(result.patch).toEqual({
+      mepPrice: 120800,
+      menPrice: 119500,
+      excursionSource: 'profitpro',
+    });
+    expect(result.fields).toEqual(['mepPrice', 'menPrice', 'excursionSource']);
+  });
+
+  it('NÃO sobrescreve mepPrice já presente no trade existente', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData(),
+      existing({ mepPrice: 121000 }),
+    );
+    expect(result.patch).not.toHaveProperty('mepPrice');
+    expect(result.patch.menPrice).toBe(119500);
+    expect(result.fields).not.toContain('mepPrice');
+  });
+
+  it('NÃO sobrescreve menPrice já presente no trade existente', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData(),
+      existing({ menPrice: 119000 }),
+    );
+    expect(result.patch.mepPrice).toBe(120800);
+    expect(result.patch).not.toHaveProperty('menPrice');
+  });
+
+  it('NÃO sobrescreve excursionSource já presente (manual ganha)', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData({ excursionSource: 'profitpro' }),
+      existing({ excursionSource: 'manual' }),
+    );
+    expect(result.patch.excursionSource).toBeUndefined();
+  });
+
+  it('retorna null quando o CSV não traz nenhum campo de excursão', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData({ mepPrice: null, menPrice: null, excursionSource: null }),
+      existing(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it('retorna null quando trade existente já tem todos os campos preenchidos', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData(),
+      existing({
+        mepPrice: 121000,
+        menPrice: 119000,
+        excursionSource: 'manual',
+      }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it('preenche só mepPrice quando menPrice e excursionSource já existem', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData({ menPrice: null }),
+      existing({ menPrice: 119000, excursionSource: 'manual' }),
+    );
+    expect(result.patch).toEqual({ mepPrice: 120800 });
+    expect(result.fields).toEqual(['mepPrice']);
+  });
+
+  it('marca excursionSource quando faltava e mepPrice/menPrice entraram no patch', () => {
+    // CSV não trouxe excursionSource explícito, mas trouxe mepPrice — origem é profitpro.
+    const result = computeExcursionEnrichmentPatch(
+      tradeData({ excursionSource: null }),
+      existing(),
+    );
+    expect(result.patch.excursionSource).toBe('profitpro');
+    expect(result.fields).toContain('excursionSource');
+  });
+
+  it('respeita excursionSource explícito do CSV (yahoo) quando trade existente vazio', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData({ excursionSource: 'yahoo' }),
+      existing(),
+    );
+    expect(result.patch.excursionSource).toBe('yahoo');
+  });
+
+  it('retorna null com tradeData null', () => {
+    expect(computeExcursionEnrichmentPatch(null, existing())).toBeNull();
+  });
+
+  it('retorna null com existingTrade null', () => {
+    expect(computeExcursionEnrichmentPatch(tradeData(), null)).toBeNull();
+  });
+
+  it('campo string vazio é tratado como ausente no trade existente', () => {
+    const result = computeExcursionEnrichmentPatch(
+      tradeData(),
+      existing({ mepPrice: '', menPrice: '' }),
+    );
+    expect(result.patch.mepPrice).toBe(120800);
+    expect(result.patch.menPrice).toBe(119500);
+  });
+
+  it('valor zero é VÁLIDO no trade existente — não é sobrescrito', () => {
+    // Defensivo: 0 é valor possível em mepPrice/menPrice (cenário improvável mas válido).
+    // null/undefined/'' = ausente; 0 = preenchido.
+    const result = computeExcursionEnrichmentPatch(
+      tradeData(),
+      existing({ mepPrice: 0 }),
+    );
+    expect(result.patch).not.toHaveProperty('mepPrice');
+    expect(result.patch.menPrice).toBe(119500);
+  });
+});

--- a/src/__tests__/utils/orderTradeCreation.test.js
+++ b/src/__tests__/utils/orderTradeCreation.test.js
@@ -647,5 +647,20 @@ describe('checkDuplication', () => {
     const result = checkDuplication(tradeData, null);
     expect(result.isDuplicate).toBe(false);
   });
+
+  // Issue #240 — cenário cross-source. Função agnóstica a `source`/`importSource`,
+  // mas registramos que o uso pretendido cobre os 3 origens (manual, csv, order_import).
+  it('detecta duplicata independente do `source` do trade existente (manual / order_import / csv)', () => {
+    const tradeData = {
+      ticker: 'WINJ26',
+      side: 'LONG',
+      qty: '2',
+      entryTime: '2026-04-04T10:00:30', // 30s do existente
+    };
+
+    expect(checkDuplication(tradeData, [makeTrade({ source: 'manual' })]).isDuplicate).toBe(true);
+    expect(checkDuplication(tradeData, [makeTrade({ source: 'order_import', importBatchId: 'batch-A' })]).isDuplicate).toBe(true);
+    expect(checkDuplication(tradeData, [makeTrade({ source: 'csv', importBatchId: 'batch-B' })]).isDuplicate).toBe(true);
+  });
 });
 

--- a/src/__tests__/utils/planCoverage.test.js
+++ b/src/__tests__/utils/planCoverage.test.js
@@ -88,6 +88,39 @@ describe('planCoverage — planCoversDate', () => {
     const opMs = Date.parse('2026-01-01T00:00:00Z');
     expect(planCoversDate(p, opMs)).toBe(true);
   });
+
+  // Issue #240 — comparação por DIA, não por hora
+  it('cobre quando plano foi criado MAIS TARDE no MESMO DIA da operação', () => {
+    // Cenário real: aluno cria plano às 14h e tenta importar ordens das 11h do mesmo dia.
+    const p = plan({ createdAt: '2026-05-04T14:00:00Z' });
+    const opMs = Date.parse('2026-05-04T11:39:20Z');
+    expect(planCoversDate(p, opMs)).toBe(true);
+  });
+
+  it('NÃO cobre quando plano foi criado no DIA SEGUINTE à operação', () => {
+    const p = plan({ createdAt: '2026-05-05T00:01:00Z' });
+    const opMs = Date.parse('2026-05-04T23:59:00Z');
+    expect(planCoversDate(p, opMs)).toBe(false);
+  });
+
+  it('cobre quando op é no MESMO DIA que closedAt (mesmo se hora > closedAt)', () => {
+    // Plano fechado às 10h cobre ordens posteriores do mesmo dia.
+    const p = plan({
+      createdAt: '2026-01-01T00:00:00Z',
+      closedAt: '2026-02-10T10:00:00Z',
+    });
+    const opMs = Date.parse('2026-02-10T16:30:00Z');
+    expect(planCoversDate(p, opMs)).toBe(true);
+  });
+
+  it('NÃO cobre quando op é no DIA SEGUINTE a closedAt', () => {
+    const p = plan({
+      createdAt: '2026-01-01T00:00:00Z',
+      closedAt: '2026-02-10T23:59:00Z',
+    });
+    const opMs = Date.parse('2026-02-11T00:01:00Z');
+    expect(planCoversDate(p, opMs)).toBe(false);
+  });
 });
 
 describe('planCoverage — detectCoverageGap', () => {

--- a/src/components/csv/CsvActivationResultModal.jsx
+++ b/src/components/csv/CsvActivationResultModal.jsx
@@ -1,0 +1,197 @@
+/**
+ * CsvActivationResultModal.jsx
+ * @version 1.0.0 (v1.55.1 — issue #240)
+ * @description Modal glass com sumário do que aconteceu ao ativar trades do
+ *   staging do CSV — substitui os `alert()` browser default.
+ *
+ * 4 buckets:
+ *   - success    (verde)  — trades criados
+ *   - enriched   (azul)   — trades existentes que ganharam MEP/MEN do CSV
+ *   - skipped    (âmbar)  — duplicatas exatas, sem nada novo a contribuir
+ *   - failed     (vermelho) — erros
+ *
+ * Mostra contagens + listas detalhadas. Fecha com Esc, X ou clique fora.
+ */
+
+import { CheckCircle, Sparkles, Copy, AlertCircle, X } from 'lucide-react';
+import DebugBadge from '../DebugBadge';
+
+const BUCKET_META = {
+  success: {
+    label: 'Ativados',
+    Icon: CheckCircle,
+    color: 'emerald',
+    description: 'Novos trades criados no diário',
+  },
+  enriched: {
+    label: 'Enriquecidos (MEP/MEN)',
+    Icon: Sparkles,
+    color: 'blue',
+    description: 'Trades existentes ganharam excursão a partir do CSV',
+  },
+  skipped: {
+    label: 'Duplicatas ignoradas',
+    Icon: Copy,
+    color: 'amber',
+    description: 'Já existiam como trade — nada a contribuir',
+  },
+  failed: {
+    label: 'Falhas',
+    Icon: AlertCircle,
+    color: 'red',
+    description: 'Não foi possível ativar',
+  },
+};
+
+const COLOR_CLASSES = {
+  emerald: { border: 'border-emerald-500/20', bg: 'bg-emerald-500/10', text: 'text-emerald-400', textSoft: 'text-emerald-300' },
+  blue:    { border: 'border-blue-500/20',    bg: 'bg-blue-500/10',    text: 'text-blue-400',    textSoft: 'text-blue-300' },
+  amber:   { border: 'border-amber-500/20',   bg: 'bg-amber-500/10',   text: 'text-amber-400',   textSoft: 'text-amber-300' },
+  red:     { border: 'border-red-500/20',     bg: 'bg-red-500/10',     text: 'text-red-400',     textSoft: 'text-red-300' },
+};
+
+const SectionHeader = ({ bucket, count }) => {
+  const meta = BUCKET_META[bucket];
+  const cls = COLOR_CLASSES[meta.color];
+  const { Icon } = meta;
+  return (
+    <div className="flex items-start gap-2">
+      <Icon className={`w-4 h-4 ${cls.text} mt-0.5 shrink-0`} />
+      <div className="flex-1 min-w-0">
+        <p className="text-xs font-semibold text-white">
+          {count} {meta.label.toLowerCase()}
+        </p>
+        <p className="text-[10px] text-slate-500 mt-0.5">{meta.description}</p>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * @param {Object} props
+ * @param {boolean} props.isOpen
+ * @param {Function} props.onClose
+ * @param {Object} props.result — { success: string[], enriched: [], skipped: [], failed: [] }
+ *   - success: array de trade IDs criados
+ *   - enriched: [{ id, matchedTradeId, fields[] }]
+ *   - skipped:  [{ id, matchedTradeId, reason }]
+ *   - failed:   [{ id, error }]
+ */
+const CsvActivationResultModal = ({ isOpen, onClose, result }) => {
+  if (!isOpen || !result) return null;
+
+  const success = result.success || [];
+  const enriched = result.enriched || [];
+  const skipped = result.skipped || [];
+  const failed = result.failed || [];
+
+  const hasAnything = success.length + enriched.length + skipped.length + failed.length > 0;
+  if (!hasAnything) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm pb-16"
+      onClick={onClose}
+    >
+      <div
+        className="bg-slate-900 border border-slate-700/50 rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-slate-800/50 shrink-0">
+          <h2 className="text-sm font-semibold text-white">Importação concluída</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded-lg hover:bg-slate-800 text-slate-500 hover:text-white transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Tally */}
+        <div className="grid grid-cols-2 gap-2 px-5 py-3 shrink-0">
+          {['success', 'enriched', 'skipped', 'failed'].map((bucket) => {
+            const counts = { success: success.length, enriched: enriched.length, skipped: skipped.length, failed: failed.length };
+            const count = counts[bucket];
+            if (count === 0) return null;
+            const meta = BUCKET_META[bucket];
+            const cls = COLOR_CLASSES[meta.color];
+            return (
+              <div key={bucket} className={`px-3 py-2 rounded-lg border ${cls.border} ${cls.bg}`}>
+                <SectionHeader bucket={bucket} count={count} />
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Detail */}
+        <div className="flex-1 overflow-y-auto px-5 pb-4 space-y-3">
+          {enriched.length > 0 && (
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-blue-300/80 mb-1.5">Enriquecidos</p>
+              <div className="space-y-1">
+                {enriched.map((item, i) => (
+                  <div key={i} className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-blue-500/5 border border-blue-500/10">
+                    <Sparkles className="w-3 h-3 text-blue-400 shrink-0" />
+                    <span className="text-[11px] font-mono text-slate-300 truncate">{item.matchedTradeId}</span>
+                    <span className="text-[10px] text-blue-300 ml-auto">{item.fields.join(' · ')}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {skipped.length > 0 && (
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-amber-300/80 mb-1.5">Ignorados</p>
+              <div className="space-y-1">
+                {skipped.map((item, i) => (
+                  <div key={i} className="flex items-start gap-2 px-3 py-1.5 rounded-lg bg-amber-500/5 border border-amber-500/10">
+                    <Copy className="w-3 h-3 text-amber-400 shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[11px] font-mono text-slate-300 truncate">{item.matchedTradeId}</p>
+                      {item.reason && <p className="text-[10px] text-amber-300/70 mt-0.5 truncate">{item.reason}</p>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {failed.length > 0 && (
+            <div>
+              <p className="text-[10px] uppercase tracking-wide text-red-300/80 mb-1.5">Falhas</p>
+              <div className="space-y-1">
+                {failed.map((item, i) => (
+                  <div key={i} className="flex items-start gap-2 px-3 py-1.5 rounded-lg bg-red-500/5 border border-red-500/10">
+                    <AlertCircle className="w-3 h-3 text-red-400 shrink-0 mt-0.5" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[11px] font-mono text-slate-300 truncate">{item.id}</p>
+                      <p className="text-[10px] text-red-300/80 mt-0.5">{item.error}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end px-5 py-3 border-t border-slate-800/50 shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-1.5 text-xs bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors"
+          >
+            Fechar
+          </button>
+        </div>
+
+        <DebugBadge component="CsvActivationResultModal" />
+      </div>
+    </div>
+  );
+};
+
+export default CsvActivationResultModal;

--- a/src/components/csv/CsvImportManager.jsx
+++ b/src/components/csv/CsvImportManager.jsx
@@ -153,8 +153,15 @@ const CsvImportManager = ({
 
     try {
       const result = await onActivateBatch(readyIds);
-      if (result.failed.length > 0) {
-        setTimeout(() => alert(`${result.success.length} ativados, ${result.failed.length} falhas:\n${result.failed.map(f => f.error).join('\n')}`), 300);
+      const skipped = result.skipped || [];
+      if (result.failed.length > 0 || skipped.length > 0) {
+        const parts = [`${result.success.length} ativados`];
+        if (skipped.length > 0) parts.push(`${skipped.length} duplicata${skipped.length > 1 ? 's' : ''} ignorada${skipped.length > 1 ? 's' : ''}`);
+        if (result.failed.length > 0) parts.push(`${result.failed.length} falha${result.failed.length > 1 ? 's' : ''}`);
+        const detail = result.failed.length > 0
+          ? `\n\nFalhas:\n${result.failed.map(f => f.error).join('\n')}`
+          : '';
+        setTimeout(() => alert(`${parts.join(' · ')}${detail}`), 300);
       }
     } catch (err) {
       setTimeout(() => alert('Erro ao ativar: ' + err.message), 300);

--- a/src/components/csv/CsvImportManager.jsx
+++ b/src/components/csv/CsvImportManager.jsx
@@ -50,6 +50,7 @@ const CsvImportManager = ({
   onDeleteStagingBatch,
   onActivateTrade,
   onActivateBatch,
+  onActivationComplete,
   getBatches,
 }) => {
   const [expandedBatch, setExpandedBatch] = useState(null);
@@ -153,20 +154,14 @@ const CsvImportManager = ({
 
     try {
       const result = await onActivateBatch(readyIds);
-      const skipped = result.skipped || [];
-      const enriched = result.enriched || [];
-      if (result.failed.length > 0 || skipped.length > 0 || enriched.length > 0) {
-        const parts = [`${result.success.length} ativados`];
-        if (enriched.length > 0) parts.push(`${enriched.length} enriquecido${enriched.length > 1 ? 's' : ''} (MEP/MEN)`);
-        if (skipped.length > 0) parts.push(`${skipped.length} duplicata${skipped.length > 1 ? 's' : ''} ignorada${skipped.length > 1 ? 's' : ''}`);
-        if (result.failed.length > 0) parts.push(`${result.failed.length} falha${result.failed.length > 1 ? 's' : ''}`);
-        const detail = result.failed.length > 0
-          ? `\n\nFalhas:\n${result.failed.map(f => f.error).join('\n')}`
-          : '';
-        setTimeout(() => alert(`${parts.join(' · ')}${detail}`), 300);
-      }
+      // Resultado vai pro modal glass do parent (issue #240) — sem alert browser default.
+      if (onActivationComplete) onActivationComplete(result);
     } catch (err) {
-      setTimeout(() => alert('Erro ao ativar: ' + err.message), 300);
+      if (onActivationComplete) {
+        onActivationComplete({ success: [], enriched: [], skipped: [], failed: [{ id: 'batch', error: err.message }] });
+      } else {
+        console.error('[CsvImportManager] activate batch error:', err);
+      }
     }
   };
 
@@ -175,9 +170,21 @@ const CsvImportManager = ({
     if (!confirm(`Ativar trade ${trade.ticker} ${trade.side}? O painel será fechado durante o processamento.`)) return;
     onClose();
     try {
-      await onActivateTrade(trade);
+      // onActivateTrade pode retornar string (id criado) ou objeto { enriched | skipped }.
+      const r = await onActivateTrade(trade);
+      if (onActivationComplete) {
+        if (r && typeof r === 'object' && r.enriched) {
+          onActivationComplete({ success: [], enriched: [{ id: trade.id, matchedTradeId: r.matchedTradeId, fields: r.fields }], skipped: [], failed: [] });
+        } else if (r && typeof r === 'object' && r.skipped) {
+          onActivationComplete({ success: [], enriched: [], skipped: [{ id: trade.id, matchedTradeId: r.matchedTradeId, reason: r.reason }], failed: [] });
+        } else if (typeof r === 'string') {
+          onActivationComplete({ success: [r], enriched: [], skipped: [], failed: [] });
+        }
+      }
     } catch (err) {
-      setTimeout(() => alert('Erro ao ativar: ' + err.message), 300);
+      if (onActivationComplete) {
+        onActivationComplete({ success: [], enriched: [], skipped: [], failed: [{ id: trade.id, error: err.message }] });
+      }
     }
   };
 

--- a/src/components/csv/CsvImportManager.jsx
+++ b/src/components/csv/CsvImportManager.jsx
@@ -154,8 +154,10 @@ const CsvImportManager = ({
     try {
       const result = await onActivateBatch(readyIds);
       const skipped = result.skipped || [];
-      if (result.failed.length > 0 || skipped.length > 0) {
+      const enriched = result.enriched || [];
+      if (result.failed.length > 0 || skipped.length > 0 || enriched.length > 0) {
         const parts = [`${result.success.length} ativados`];
+        if (enriched.length > 0) parts.push(`${enriched.length} enriquecido${enriched.length > 1 ? 's' : ''} (MEP/MEN)`);
         if (skipped.length > 0) parts.push(`${skipped.length} duplicata${skipped.length > 1 ? 's' : ''} ignorada${skipped.length > 1 ? 's' : ''}`);
         if (result.failed.length > 0) parts.push(`${result.failed.length} falha${result.failed.length > 1 ? 's' : ''}`);
         const detail = result.failed.length > 0

--- a/src/hooks/useCsvStaging.js
+++ b/src/hooks/useCsvStaging.js
@@ -6,10 +6,13 @@
  *   são passados para addTrade (useTrades) e deletados do staging.
  *
  * CHANGELOG:
- * - 1.2.0: issue #240 — activateTrade/activateBatch aceitam `existingTrades` e
- *   aplicam `checkDuplication` (mesmo critério do Order Import). Duplicatas são
- *   removidas do staging e reportadas em `skipped[]` no retorno de activateBatch.
- *   Fecha gap onde `csv_import` criava trades duplicados sobre `order_import` ou manual.
+ * - 1.2.0: issue #240 — activateTrade/activateBatch aceitam options com
+ *   `existingTrades` + `updateTradeFn`. (a) Duplicatas detectadas via
+ *   `checkDuplication` (critério do Order Import); (b) quando duplicado e o CSV
+ *   traz mepPrice/menPrice/excursionSource ausentes no trade existente, faz
+ *   **auto-enrich silencioso** (nunca sobrescreve) reportado em `enriched[]`;
+ *   senão, `skipped[]` puro. Fecha gap onde `csv_import` criava trades duplicados
+ *   sobre `order_import` ou manual e onde MEP/MEN do CSV se perdiam.
  * - 1.1.0: C2 (v1.19.1) — activateTrade busca tickerRule do master data (tickers collection)
  *   quando staging não possui tickerRule, usando exchange+symbol lookup.
  *
@@ -38,6 +41,8 @@ import {
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
 import { checkDuplication } from '../utils/orderTradeCreation';
+import { validateExcursionPrices } from '../utils/tradeGateway';
+import { computeExcursionEnrichmentPatch } from '../utils/csvEnrichmentPatch';
 
 const COLLECTION = 'csvStagingTrades';
 
@@ -279,20 +284,38 @@ const useCsvStaging = (overrideStudentId = null) => {
    *
    * Issue #240 — quando `existingTrades` é fornecido, aplica o mesmo
    * `checkDuplication` usado pelo Order Import (ticker + side + entryTime ±5min
-   * + qty). Se duplicado, **não cria** o trade, mas remove o doc de staging
-   * e retorna `{ skipped: true, matchedTradeId, reason }`. Caller deve
-   * contabilizar o skip pra reportar ao usuário ("X duplicatas ignoradas").
+   * + qty). Se duplicado:
+   *
+   *   - Se `updateTradeFn` foi injetada e o CSV traz mepPrice/menPrice que o
+   *     trade existente NÃO tem, **enriquece** o trade existente (auto-enrich
+   *     silencioso, conservador — nunca sobrescreve). Retorna
+   *     `{ enriched: true, matchedTradeId, fields }`.
+   *   - Caso contrário, apenas pula e retorna `{ skipped: true, matchedTradeId, reason }`.
+   *
+   *   Em ambos os casos o doc de staging é removido. Caller contabiliza ambos
+   *   os status no resumo final.
    *
    * @param {Object} stagingTrade - Documento completo de csvStagingTrades (com id)
    * @param {Function} addTradeFn - Referência a addTrade de useTrades
-   * @param {Object[]} [existingTrades=[]] - Trades existentes do plano para dedup
-   * @returns {Promise<string | { skipped: true, matchedTradeId: string, reason: string }>}
-   *   String ID do trade criado, ou objeto skipped quando duplicata.
+   * @param {Object} [options]
+   * @param {Object[]} [options.existingTrades=[]] - Trades existentes do plano para dedup
+   * @param {Function} [options.updateTradeFn] - Referência a updateTrade de useTrades.
+   *   Quando fornecida, habilita auto-enrich de MEP/MEN em duplicatas.
+   * @returns {Promise<
+   *   string |
+   *   { skipped: true, matchedTradeId: string, reason: string } |
+   *   { enriched: true, matchedTradeId: string, fields: string[] }
+   * >}
    */
-  const activateTrade = useCallback(async (stagingTrade, addTradeFn, existingTrades = []) => {
+  const activateTrade = useCallback(async (stagingTrade, addTradeFn, options = {}) => {
     if (!user) throw new Error('Autenticação necessária');
     if (!stagingTrade?.planId) throw new Error('Trade sem plano associado');
     if (!addTradeFn) throw new Error('addTrade function não fornecida');
+
+    // Compat: 3º arg como Array continua funcionando (callers antigos).
+    const { existingTrades = [], updateTradeFn = null } = Array.isArray(options)
+      ? { existingTrades: options }
+      : options;
 
     // C2 (v1.19.1): Buscar tickerRule do master data se não presente no staging
     let tickerRule = stagingTrade.tickerRule ?? null;
@@ -362,6 +385,33 @@ const useCsvStaging = (overrideStudentId = null) => {
     if (existingTrades?.length) {
       const dup = checkDuplication(tradeData, existingTrades);
       if (dup.isDuplicate) {
+        const matchedTrade = existingTrades.find(t => t.id === dup.matchedTradeId);
+
+        // Tentativa de auto-enrich silencioso (apenas campos vazios — nunca sobrescreve).
+        // Hoje carrega só mepPrice/menPrice/excursionSource (issue #187 + #240).
+        if (matchedTrade && updateTradeFn) {
+          const enrich = computeExcursionEnrichmentPatch(tradeData, matchedTrade);
+          if (enrich) {
+            // Validar antes de gravar — entry/exit do trade existente são fonte da verdade.
+            try {
+              validateExcursionPrices({
+                side: matchedTrade.side,
+                entry: parseFloat(matchedTrade.entry),
+                exit: parseFloat(matchedTrade.exit),
+                mepPrice: enrich.patch.mepPrice ?? matchedTrade.mepPrice ?? null,
+                menPrice: enrich.patch.menPrice ?? matchedTrade.menPrice ?? null,
+              });
+              await updateTradeFn(matchedTrade.id, enrich.patch);
+              await deleteDoc(doc(db, COLLECTION, stagingTrade.id));
+              console.log(`[useCsvStaging] Trade ${stagingTrade.id} duplicata de ${matchedTrade.id} — enriquecido (${enrich.fields.join(', ')}) e removido do staging`);
+              return { enriched: true, matchedTradeId: matchedTrade.id, fields: enrich.fields };
+            } catch (enrichErr) {
+              console.warn(`[useCsvStaging] Enrichment falhou para ${matchedTrade.id} (${enrichErr.message}) — caindo em skipped`);
+              // Não falha o batch — degrada para skipped puro.
+            }
+          }
+        }
+
         await deleteDoc(doc(db, COLLECTION, stagingTrade.id));
         console.log(`[useCsvStaging] Trade ${stagingTrade.id} duplicata de ${dup.matchedTradeId} — pulado e removido do staging`);
         return { skipped: true, matchedTradeId: dup.matchedTradeId, reason: dup.reason };
@@ -386,20 +436,27 @@ const useCsvStaging = (overrideStudentId = null) => {
    * @param {string[]} tradeIds - IDs dos trades em staging para ativar
    * @param {Function} addTradeFn - Referência a addTrade de useTrades
    * @param {Function} [onProgress] - Callback (current, total, lastResult)
-   * @param {Object[]} [existingTrades=[]] - Trades existentes do plano (issue #240 — dedup)
+   * @param {Object | Object[]} [optionsOrTrades] - Object com `{ existingTrades, updateTradeFn }`,
+   *   ou Array (legacy) que será interpretado como `existingTrades`.
    * @returns {Promise<{
    *   success: string[],
    *   failed: { id: string, error: string }[],
    *   skipped: { id: string, matchedTradeId: string, reason: string }[],
+   *   enriched: { id: string, matchedTradeId: string, fields: string[] }[],
    * }>}
    */
-  const activateBatch = useCallback(async (tradeIds, addTradeFn, onProgress, existingTrades = []) => {
+  const activateBatch = useCallback(async (tradeIds, addTradeFn, onProgress, optionsOrTrades = {}) => {
     if (!user) throw new Error('Autenticação necessária');
     if (!addTradeFn) throw new Error('addTrade function não fornecida');
+
+    const options = Array.isArray(optionsOrTrades)
+      ? { existingTrades: optionsOrTrades }
+      : optionsOrTrades;
 
     const success = [];
     const failed = [];
     const skipped = [];
+    const enriched = [];
 
     for (let i = 0; i < tradeIds.length; i++) {
       const stagingId = tradeIds[i];
@@ -416,9 +473,15 @@ const useCsvStaging = (overrideStudentId = null) => {
       }
 
       try {
-        const result = await activateTrade(stagingTrade, addTradeFn, existingTrades);
-        if (result && typeof result === 'object' && result.skipped) {
-          skipped.push({ id: stagingId, matchedTradeId: result.matchedTradeId, reason: result.reason });
+        const result = await activateTrade(stagingTrade, addTradeFn, options);
+        if (result && typeof result === 'object') {
+          if (result.enriched) {
+            enriched.push({ id: stagingId, matchedTradeId: result.matchedTradeId, fields: result.fields });
+          } else if (result.skipped) {
+            skipped.push({ id: stagingId, matchedTradeId: result.matchedTradeId, reason: result.reason });
+          } else {
+            success.push(result);
+          }
         } else {
           success.push(result);
         }
@@ -432,12 +495,13 @@ const useCsvStaging = (overrideStudentId = null) => {
           success: success.length,
           failed: failed.length,
           skipped: skipped.length,
+          enriched: enriched.length,
         });
       }
     }
 
-    console.log(`[useCsvStaging] Batch activate: ${success.length} ok, ${skipped.length} duplicatas ignoradas, ${failed.length} falhas`);
-    return { success, failed, skipped };
+    console.log(`[useCsvStaging] Batch activate: ${success.length} ok, ${enriched.length} enriquecidos, ${skipped.length} duplicatas ignoradas, ${failed.length} falhas`);
+    return { success, failed, skipped, enriched };
   }, [user, stagingTrades, activateTrade]);
 
   // ============================================

--- a/src/hooks/useCsvStaging.js
+++ b/src/hooks/useCsvStaging.js
@@ -1,11 +1,15 @@
 /**
  * useCsvStaging
- * @version 1.1.0 (v1.19.1)
+ * @version 1.2.0 (v1.55.1 — issue #240)
  * @description Hook para gerenciar trades em staging (collection csvStagingTrades).
  *   Trades importados via CSV ficam aqui até serem "ativados" — momento em que
  *   são passados para addTrade (useTrades) e deletados do staging.
  *
  * CHANGELOG:
+ * - 1.2.0: issue #240 — activateTrade/activateBatch aceitam `existingTrades` e
+ *   aplicam `checkDuplication` (mesmo critério do Order Import). Duplicatas são
+ *   removidas do staging e reportadas em `skipped[]` no retorno de activateBatch.
+ *   Fecha gap onde `csv_import` criava trades duplicados sobre `order_import` ou manual.
  * - 1.1.0: C2 (v1.19.1) — activateTrade busca tickerRule do master data (tickers collection)
  *   quando staging não possui tickerRule, usando exchange+symbol lookup.
  *
@@ -33,6 +37,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
+import { checkDuplication } from '../utils/orderTradeCreation';
 
 const COLLECTION = 'csvStagingTrades';
 
@@ -272,11 +277,19 @@ const useCsvStaging = (overrideStudentId = null) => {
    * Ativa um trade: chama addTrade (de useTrades) com os dados do staging,
    * depois deleta o documento de staging.
    *
+   * Issue #240 — quando `existingTrades` é fornecido, aplica o mesmo
+   * `checkDuplication` usado pelo Order Import (ticker + side + entryTime ±5min
+   * + qty). Se duplicado, **não cria** o trade, mas remove o doc de staging
+   * e retorna `{ skipped: true, matchedTradeId, reason }`. Caller deve
+   * contabilizar o skip pra reportar ao usuário ("X duplicatas ignoradas").
+   *
    * @param {Object} stagingTrade - Documento completo de csvStagingTrades (com id)
    * @param {Function} addTradeFn - Referência a addTrade de useTrades
-   * @returns {Promise<string>} ID do trade criado na collection trades
+   * @param {Object[]} [existingTrades=[]] - Trades existentes do plano para dedup
+   * @returns {Promise<string | { skipped: true, matchedTradeId: string, reason: string }>}
+   *   String ID do trade criado, ou objeto skipped quando duplicata.
    */
-  const activateTrade = useCallback(async (stagingTrade, addTradeFn) => {
+  const activateTrade = useCallback(async (stagingTrade, addTradeFn, existingTrades = []) => {
     if (!user) throw new Error('Autenticação necessária');
     if (!stagingTrade?.planId) throw new Error('Trade sem plano associado');
     if (!addTradeFn) throw new Error('addTrade function não fornecida');
@@ -344,6 +357,17 @@ const useCsvStaging = (overrideStudentId = null) => {
       _partials,
     };
 
+    // Issue #240 — dedup contra trades existentes do plano (manual + order_import + csv).
+    // Critério reusado de orderTradeCreation.checkDuplication (ticker+side+entryTime±5min+qty).
+    if (existingTrades?.length) {
+      const dup = checkDuplication(tradeData, existingTrades);
+      if (dup.isDuplicate) {
+        await deleteDoc(doc(db, COLLECTION, stagingTrade.id));
+        console.log(`[useCsvStaging] Trade ${stagingTrade.id} duplicata de ${dup.matchedTradeId} — pulado e removido do staging`);
+        return { skipped: true, matchedTradeId: dup.matchedTradeId, reason: dup.reason };
+      }
+    }
+
     // Chamar addTrade legado — ele resolve planId→accountId, calcula result,
     // cria movement, aciona CFs (compliance, PL update)
     const newTrade = await addTradeFn(tradeData, null, null);
@@ -362,14 +386,20 @@ const useCsvStaging = (overrideStudentId = null) => {
    * @param {string[]} tradeIds - IDs dos trades em staging para ativar
    * @param {Function} addTradeFn - Referência a addTrade de useTrades
    * @param {Function} [onProgress] - Callback (current, total, lastResult)
-   * @returns {Promise<{ success: string[], failed: { id: string, error: string }[] }>}
+   * @param {Object[]} [existingTrades=[]] - Trades existentes do plano (issue #240 — dedup)
+   * @returns {Promise<{
+   *   success: string[],
+   *   failed: { id: string, error: string }[],
+   *   skipped: { id: string, matchedTradeId: string, reason: string }[],
+   * }>}
    */
-  const activateBatch = useCallback(async (tradeIds, addTradeFn, onProgress) => {
+  const activateBatch = useCallback(async (tradeIds, addTradeFn, onProgress, existingTrades = []) => {
     if (!user) throw new Error('Autenticação necessária');
     if (!addTradeFn) throw new Error('addTrade function não fornecida');
 
     const success = [];
     const failed = [];
+    const skipped = [];
 
     for (let i = 0; i < tradeIds.length; i++) {
       const stagingId = tradeIds[i];
@@ -386,20 +416,28 @@ const useCsvStaging = (overrideStudentId = null) => {
       }
 
       try {
-        const newTradeId = await activateTrade(stagingTrade, addTradeFn);
-        success.push(newTradeId);
+        const result = await activateTrade(stagingTrade, addTradeFn, existingTrades);
+        if (result && typeof result === 'object' && result.skipped) {
+          skipped.push({ id: stagingId, matchedTradeId: result.matchedTradeId, reason: result.reason });
+        } else {
+          success.push(result);
+        }
       } catch (err) {
         console.error(`[useCsvStaging] Falha ao ativar ${stagingId}:`, err);
         failed.push({ id: stagingId, error: err.message });
       }
 
       if (onProgress) {
-        onProgress(i + 1, tradeIds.length, { success: success.length, failed: failed.length });
+        onProgress(i + 1, tradeIds.length, {
+          success: success.length,
+          failed: failed.length,
+          skipped: skipped.length,
+        });
       }
     }
 
-    console.log(`[useCsvStaging] Batch activate: ${success.length} ok, ${failed.length} falhas`);
-    return { success, failed };
+    console.log(`[useCsvStaging] Batch activate: ${success.length} ok, ${skipped.length} duplicatas ignoradas, ${failed.length} falhas`);
+    return { success, failed, skipped };
   }, [user, stagingTrades, activateTrade]);
 
   // ============================================

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -50,6 +50,7 @@ import DebugBadge from '../components/DebugBadge';
 import CsvImportWizard from '../components/csv/CsvImportWizard';
 import CsvImportCard from '../components/csv/CsvImportCard';
 import CsvImportManager from '../components/csv/CsvImportManager';
+import CsvActivationResultModal from '../components/csv/CsvActivationResultModal';
 
 // Order Import (CHUNK-10)
 import OrderImportPage from '../pages/OrderImportPage';
@@ -163,6 +164,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
   const [wizardComplete, setWizardComplete] = useState(false);
   const [showCsvWizard, setShowCsvWizard] = useState(false);
   const [showCsvManager, setShowCsvManager] = useState(false);
+  const [activationResult, setActivationResult] = useState(null);
   const [showOrderImport, setShowOrderImport] = useState(false);
 
   // Sincronização bidirecional com StudentContext (issue #118 — DEC-047)
@@ -337,24 +339,14 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     if (onNavigateToFeedback) onNavigateToFeedback(trade);
   };
 
-  /** Wrapper para activateTrade que injeta addTrade + trades do plano (dedup + enrich #240) */
+  /** Wrapper para activateTrade que injeta addTrade + trades do plano (dedup + enrich #240).
+   *  Retorna o resultado bruto do hook — UI de feedback fica com o CsvImportManager/Modal. */
   const handleActivateStagingTrade = async (stagingTrade) => {
-    try {
-      const planTrades = trades.filter(t => t.planId === stagingTrade.planId);
-      const result = await activateStagingTrade(stagingTrade, addTrade, {
-        existingTrades: planTrades,
-        updateTradeFn: updateTrade,
-      });
-      if (result && typeof result === 'object') {
-        if (result.enriched) {
-          alert(`Trade duplicado — enriquecido com ${result.fields.join(', ')} do CSV. Staging removido.`);
-        } else if (result.skipped) {
-          alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
-        }
-      }
-    } catch (err) {
-      alert('Erro ao ativar trade: ' + err.message);
-    }
+    const planTrades = trades.filter(t => t.planId === stagingTrade.planId);
+    return activateStagingTrade(stagingTrade, addTrade, {
+      existingTrades: planTrades,
+      updateTradeFn: updateTrade,
+    });
   };
 
   /** Wrapper para activateBatch que injeta addTrade + trades do plano e suspende listener durante batch */
@@ -727,7 +719,14 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         onDeleteStagingBatch={deleteStagingBatch}
         onActivateTrade={handleActivateStagingTrade}
         onActivateBatch={handleActivateStagingBatch}
+        onActivationComplete={(result) => setActivationResult(result)}
         getBatches={getBatches}
+      />
+
+      <CsvActivationResultModal
+        isOpen={!!activationResult}
+        onClose={() => setActivationResult(null)}
+        result={activationResult}
       />
 
       {/* Order Import Modal (CHUNK-10) */}

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -337,20 +337,26 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     if (onNavigateToFeedback) onNavigateToFeedback(trade);
   };
 
-  /** Wrapper para activateTrade que injeta addTrade */
+  /** Wrapper para activateTrade que injeta addTrade + trades do plano (dedup #240) */
   const handleActivateStagingTrade = async (stagingTrade) => {
     try {
-      await activateStagingTrade(stagingTrade, addTrade);
+      const planTrades = trades.filter(t => t.planId === stagingTrade.planId);
+      const result = await activateStagingTrade(stagingTrade, addTrade, planTrades);
+      if (result && typeof result === 'object' && result.skipped) {
+        alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
+      }
     } catch (err) {
       alert('Erro ao ativar trade: ' + err.message);
     }
   };
 
-  /** Wrapper para activateBatch que injeta addTrade e suspende listener durante batch */
+  /** Wrapper para activateBatch que injeta addTrade + trades do plano e suspende listener durante batch */
   const handleActivateStagingBatch = async (tradeIds, onProgress) => {
     setSuspendListener(true);
     try {
-      return await activateStagingBatch(tradeIds, addTrade, onProgress);
+      // Issue #240 — dedup contra trades existentes do plano. Como um batch pode misturar
+      // planos, passamos a base completa de trades; o dedup interno filtra por compatibilidade.
+      return await activateStagingBatch(tradeIds, addTrade, onProgress, trades);
     } finally {
       setSuspendListener(false);
     }

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -337,13 +337,20 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     if (onNavigateToFeedback) onNavigateToFeedback(trade);
   };
 
-  /** Wrapper para activateTrade que injeta addTrade + trades do plano (dedup #240) */
+  /** Wrapper para activateTrade que injeta addTrade + trades do plano (dedup + enrich #240) */
   const handleActivateStagingTrade = async (stagingTrade) => {
     try {
       const planTrades = trades.filter(t => t.planId === stagingTrade.planId);
-      const result = await activateStagingTrade(stagingTrade, addTrade, planTrades);
-      if (result && typeof result === 'object' && result.skipped) {
-        alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
+      const result = await activateStagingTrade(stagingTrade, addTrade, {
+        existingTrades: planTrades,
+        updateTradeFn: updateTrade,
+      });
+      if (result && typeof result === 'object') {
+        if (result.enriched) {
+          alert(`Trade duplicado — enriquecido com ${result.fields.join(', ')} do CSV. Staging removido.`);
+        } else if (result.skipped) {
+          alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
+        }
       }
     } catch (err) {
       alert('Erro ao ativar trade: ' + err.message);
@@ -354,9 +361,12 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
   const handleActivateStagingBatch = async (tradeIds, onProgress) => {
     setSuspendListener(true);
     try {
-      // Issue #240 — dedup contra trades existentes do plano. Como um batch pode misturar
-      // planos, passamos a base completa de trades; o dedup interno filtra por compatibilidade.
-      return await activateStagingBatch(tradeIds, addTrade, onProgress, trades);
+      // Issue #240 — dedup contra trades existentes + auto-enrich de MEP/MEN. Como um batch
+      // pode misturar planos, passamos a base completa de trades; o dedup interno filtra.
+      return await activateStagingBatch(tradeIds, addTrade, onProgress, {
+        existingTrades: trades,
+        updateTradeFn: updateTrade,
+      });
     } finally {
       setSuspendListener(false);
     }

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -21,6 +21,7 @@ import DebugBadge from '../components/DebugBadge';
 import CsvImportWizard from '../components/csv/CsvImportWizard';
 import CsvImportCard from '../components/csv/CsvImportCard';
 import CsvImportManager from '../components/csv/CsvImportManager';
+import CsvActivationResultModal from '../components/csv/CsvActivationResultModal';
 import { useTrades } from '../hooks/useTrades';
 import { useAccounts } from '../hooks/useAccounts';
 import { usePlans } from '../hooks/usePlans';
@@ -63,6 +64,7 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
   const [showFilters, setShowFilters] = useState(true);
   const [showCsvWizard, setShowCsvWizard] = useState(false);
   const [showCsvManager, setShowCsvManager] = useState(false);
+  const [activationResult, setActivationResult] = useState(null);
   
   // Filtro de contas — mesmo padrão do StudentDashboard via AccountFilterBar
   const [accountTypeFilter, setAccountTypeFilter] = useState('real');
@@ -276,28 +278,24 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
         onDeleteStagingTrade={deleteStagingTrade}
         onDeleteStagingBatch={deleteStagingBatch}
         onActivateTrade={async (t) => {
-          try {
-            const planTrades = trades.filter(x => x.planId === t.planId);
-            const result = await activateStagingTrade(t, addTrade, {
-              existingTrades: planTrades,
-              updateTradeFn: updateTrade,
-            });
-            if (result && typeof result === 'object') {
-              if (result.enriched) {
-                alert(`Trade duplicado — enriquecido com ${result.fields.join(', ')} do CSV. Staging removido.`);
-              } else if (result.skipped) {
-                alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
-              }
-            }
-          } catch (err) {
-            alert('Erro: ' + err.message);
-          }
+          const planTrades = trades.filter(x => x.planId === t.planId);
+          return activateStagingTrade(t, addTrade, {
+            existingTrades: planTrades,
+            updateTradeFn: updateTrade,
+          });
         }}
         onActivateBatch={async (ids, onProgress) => activateStagingBatch(ids, addTrade, onProgress, {
           existingTrades: trades,
           updateTradeFn: updateTrade,
         })}
+        onActivationComplete={(result) => setActivationResult(result)}
         getBatches={getBatches}
+      />
+
+      <CsvActivationResultModal
+        isOpen={!!activationResult}
+        onClose={() => setActivationResult(null)}
+        result={activationResult}
       />
 
       <DebugBadge component="TradesJournal" />

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -275,8 +275,18 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
         onUpdateStagingTrade={updateStagingTrade}
         onDeleteStagingTrade={deleteStagingTrade}
         onDeleteStagingBatch={deleteStagingBatch}
-        onActivateTrade={async (t) => { try { await activateStagingTrade(t, addTrade); } catch (err) { alert('Erro: ' + err.message); } }}
-        onActivateBatch={async (ids, onProgress) => activateStagingBatch(ids, addTrade, onProgress)}
+        onActivateTrade={async (t) => {
+          try {
+            const planTrades = trades.filter(x => x.planId === t.planId);
+            const result = await activateStagingTrade(t, addTrade, planTrades);
+            if (result && typeof result === 'object' && result.skipped) {
+              alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
+            }
+          } catch (err) {
+            alert('Erro: ' + err.message);
+          }
+        }}
+        onActivateBatch={async (ids, onProgress) => activateStagingBatch(ids, addTrade, onProgress, trades)}
         getBatches={getBatches}
       />
 

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -278,15 +278,25 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
         onActivateTrade={async (t) => {
           try {
             const planTrades = trades.filter(x => x.planId === t.planId);
-            const result = await activateStagingTrade(t, addTrade, planTrades);
-            if (result && typeof result === 'object' && result.skipped) {
-              alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
+            const result = await activateStagingTrade(t, addTrade, {
+              existingTrades: planTrades,
+              updateTradeFn: updateTrade,
+            });
+            if (result && typeof result === 'object') {
+              if (result.enriched) {
+                alert(`Trade duplicado — enriquecido com ${result.fields.join(', ')} do CSV. Staging removido.`);
+              } else if (result.skipped) {
+                alert(`Trade duplicado — já existia (${result.reason}). Removido do staging.`);
+              }
             }
           } catch (err) {
             alert('Erro: ' + err.message);
           }
         }}
-        onActivateBatch={async (ids, onProgress) => activateStagingBatch(ids, addTrade, onProgress, trades)}
+        onActivateBatch={async (ids, onProgress) => activateStagingBatch(ids, addTrade, onProgress, {
+          existingTrades: trades,
+          updateTradeFn: updateTrade,
+        })}
         getBatches={getBatches}
       />
 

--- a/src/utils/csvEnrichmentPatch.js
+++ b/src/utils/csvEnrichmentPatch.js
@@ -1,0 +1,62 @@
+/**
+ * csvEnrichmentPatch.js
+ * @version 1.0.0 (v1.55.1 — issue #240)
+ * @description Helper puro: monta patch de enrichment para um trade existente
+ *   a partir de um tradeData vindo do CSV de performance. **Só preenche campos
+ *   que o trade existente não tem** — nunca sobrescreve.
+ *
+ * Hoje o patch carrega apenas campos de excursão (issue #187):
+ *   - mepPrice
+ *   - menPrice
+ *   - excursionSource
+ *
+ * Outros campos do tradeData (entry/exit/qty/_partials/etc.) são intencionalmente
+ * ignorados aqui — eles já foram fixados pelo pipeline original (manual ou
+ * order_import) e não devem ser recalculados a partir da performance.
+ *
+ * Uso:
+ *   const patch = computeExcursionEnrichmentPatch(tradeData, existingTrade);
+ *   if (patch) await updateTradeFn(existingTrade.id, patch);
+ */
+
+const FIELDS = ['mepPrice', 'menPrice', 'excursionSource'];
+
+/**
+ * @param {Object} tradeData — staging do CSV (já com mepPrice/menPrice/excursionSource opcionais)
+ * @param {Object} existingTrade — trade existente em `trades` (criado por manual/csv/order_import)
+ * @returns {{ patch: Object, fields: string[] } | null}
+ *   `null` quando não há nada para enriquecer (existente já completo OU CSV sem dados).
+ *   Caso contrário, `patch` é objeto pronto pra updateDoc/updateTrade e `fields`
+ *   lista os nomes preenchidos (para auditoria/log).
+ */
+export function computeExcursionEnrichmentPatch(tradeData, existingTrade) {
+  if (!tradeData || !existingTrade) return null;
+
+  const patch = {};
+  const fields = [];
+
+  for (const f of FIELDS) {
+    const incoming = tradeData[f];
+    const current = existingTrade[f];
+    // Pula se CSV não trouxe valor.
+    if (incoming == null || incoming === '') continue;
+    // Pula se trade existente já tem — nunca sobrescreve.
+    if (current != null && current !== '') continue;
+    patch[f] = incoming;
+    fields.push(f);
+  }
+
+  // Se mepPrice ou menPrice entraram no patch, sempre marca excursionSource
+  // (mesmo que CSV não tenha mandado) — origem é a importação de performance.
+  if ((patch.mepPrice != null || patch.menPrice != null) && patch.excursionSource == null) {
+    if (existingTrade.excursionSource == null) {
+      patch.excursionSource = tradeData.excursionSource || 'profitpro';
+      if (!fields.includes('excursionSource')) fields.push('excursionSource');
+    }
+  }
+
+  if (fields.length === 0) return null;
+  return { patch, fields };
+}
+
+export default computeExcursionEnrichmentPatch;

--- a/src/utils/planCoverage.js
+++ b/src/utils/planCoverage.js
@@ -1,18 +1,23 @@
 /**
  * planCoverage.js
- * @version 1.0.0 (v1.37.0 — issue #156 Fase C)
+ * @version 1.1.0 (v1.55.1 — issue #240)
  * @description Detecção de gap de cobertura de plano para operações importadas.
  *   Uma operação está em "gap" quando não existe plano ativo na mesma conta
- *   cuja janela temporal cubra a data da operação.
+ *   cuja janela de DIAS cubra a data da operação.
  *
- * Critério de cobertura (conservador):
+ * Critério de cobertura (conservador, **comparação por DIA, não por hora**):
  *   - plan.accountId === accountId (mesma conta)
  *   - plan.active !== false (plano não arquivado)
- *   - plan.createdAt <= opDate (plano existia no momento da operação)
+ *   - dia(opDate) >= dia(plan.createdAt) (plano nasceu no mesmo dia ou antes)
+ *   - dia(opDate) <= dia(plan.closedAt) (se fechado)
+ *
+ * Issue #240 — bug histórico: comparação anterior usava timestamp ms cheio.
+ * Plano criado às 14h não cobria ordem das 11h do mesmo dia (createdAt > opDate
+ * em milissegundos). Corrigido para comparar `YYYY-MM-DD` (UTC) — granularidade
+ * adequada para o conceito de "plano vigente naquela data".
  *
  * Sem `createdAt`, o plano é considerado cobrindo qualquer data (fail-open, para
- * não gerar falso-positivo em dados legados). `plan.closedAt` também é respeitado:
- * se existir e opDate > closedAt → não cobre.
+ * não gerar falso-positivo em dados legados).
  *
  * Uso:
  *   const { hasCoverageGap, gapOperations } = detectCoverageGap({
@@ -77,7 +82,22 @@ export function getOperationDateMs(op) {
 }
 
 /**
+ * Converte ms epoch para 'YYYY-MM-DD' em UTC. UTC é a forma canônica que o
+ * Firestore serializa Timestamp e que `Date.toISOString()` produz — comparação
+ * entre `plan.createdAt` (Firestore) e `op.entryTime` (string ISO do CSV) só é
+ * consistente se ambos passarem pela mesma normalização.
+ */
+function toDayUTC(ms) {
+  if (ms == null) return null;
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 10);
+}
+
+/**
  * Verifica se um plano cobre uma data específica.
+ *
+ * Comparação por DIA (`YYYY-MM-DD` em UTC), não por timestamp em ms — issue #240.
  *
  * @param {Object} plan
  * @param {number} opMs — timestamp ms da operação
@@ -89,11 +109,20 @@ export function planCoversDate(plan, opMs, accountId = null) {
   if (plan.active === false) return false;
   if (accountId && plan.accountId && plan.accountId !== accountId) return false;
 
+  const opDay = toDayUTC(opMs);
+  if (!opDay) return false;
+
   const createdMs = toMs(plan.createdAt);
-  if (createdMs != null && opMs < createdMs) return false;
+  if (createdMs != null) {
+    const createdDay = toDayUTC(createdMs);
+    if (createdDay && opDay < createdDay) return false;
+  }
 
   const closedMs = toMs(plan.closedAt);
-  if (closedMs != null && opMs > closedMs) return false;
+  if (closedMs != null) {
+    const closedDay = toDayUTC(closedMs);
+    if (closedDay && opDay > closedDay) return false;
+  }
 
   return true;
 }

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.55.1: #240 fix plano retroativo (compara hora vs data) + dedup ausente em performance import [RESERVADA — entrada definitiva no encerramento]
  * - 1.55.0: #237 feat cadastro de alunos / assinaturas — consolidação em students/subscriptions (PR #238, 03/05/2026)
  * - 1.55.0: feat: cadastro de alunos / assinaturas (#237) — consolidação em
  *   `students/{uid}/subscriptions/` (sem collection nova). Decisão pivotada durante a issue:
@@ -334,10 +335,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.55.0',
-  build: '20260503',
-  display: 'v1.55.0',
-  full: '1.55.0+20260503',
+  version: '1.55.1',
+  build: '20260504',
+  display: 'v1.55.1',
+  full: '1.55.1+20260504',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

- **Bug 1** — `planCoverage.planCoversDate` comparava timestamp em ms; plano criado às 14h não cobria ordem das 11h do mesmo dia. Agora compara por `YYYY-MM-DD` UTC (granularidade adequada para "plano vigente naquela data").
- **Bug 2** — `useCsvStaging.activateTrade/Batch` criavam trades sem checar duplicidade contra trades existentes do plano. Reusa `checkDuplication` exportado de `orderTradeCreation` (DRY); duplicatas são removidas do staging e reportadas em `skipped[]` no retorno do batch. Propagado pelos wrappers em `StudentDashboard`, `TradesJournal` e `CsvImportManager`.

Closes #240.

## Test plan

- [x] `npm test` — 184 arquivos / 2938 testes passando (4 novos em `planCoverage.test.js` + 1 cross-source em `orderTradeCreation.test.js`)
- [x] `npm run build` — limpo, sem novos warnings
- [ ] Smoke local: importar CSV `040526-ORDER.csv` em plano criado hoje, confirmar que NÃO dispara banner "Criar plano retroativo"
- [ ] Smoke local: criar trade manual → importar CSV de performance contendo o mesmo trade → confirmar contagem "1 duplicata ignorada"

## DEC

- DEC-AUTO-240-01 — `planCoversDate` compara dia UTC ao invés de timestamp; tradeoff de borda noturna documentado em `docs/dev/issues/issue-240-*.md`.
- DEC-AUTO-240-02 — `useCsvStaging` reusa `checkDuplication` exportado de `orderTradeCreation` (DRY).