### PR TITLE
feat(#246): 3 chips de filtro de follow-up (Todos / Em / Sem)

### DIFF
--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-16 | #246 | `feat/issue-246-followup-segment-filters` | 04/05/2026 | escrita |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -23,3 +23,4 @@
 | 1.55.1 | #240 | `fix/issue-240-plan-coverage-and-perf-dedup` | 04/05/2026 | consumida (PR #241 squash `ff43c1d1`) |
 | 1.55.2 | #242 | `fix/issue-242-parser-stop-semantic` | 04/05/2026 | consumida (PR #244 squash `34642608`) |
 | 1.55.3 | #243 | `feat/issue-243-subscription-followup` | 04/05/2026 | consumida (PR #245 squash `fcef6a87`) |
+| 1.55.4 | #246 | `feat/issue-246-followup-segment-filters` | 04/05/2026 | reservada |

--- a/src/__tests__/utils/subscriptions-followup.test.js
+++ b/src/__tests__/utils/subscriptions-followup.test.js
@@ -1,14 +1,21 @@
 /**
- * Tests: Follow-up filter logic — issue #243
+ * Tests: Follow-up filter logic — issue #243 + #246
  *
- * Filtro: subs.filter(s => s.inFollowUp === true)
- * Toggle: { inFollowUp: !sub.inFollowUp } — undefined → true → false → true
- * Default: undefined em docs antigos = não está em follow-up
+ * Filtro 3 estados (#246): 'all' | 'on' | 'off'
+ *   on  = inFollowUp === true
+ *   off = inFollowUp !== true (inclui false e undefined legacy)
+ * Toggle (#243): { inFollowUp: !sub.inFollowUp } — undefined → true → false → true
  */
 
 import { describe, it, expect } from 'vitest';
 
 const filterFollowUp = (subs) => subs.filter((s) => s.inFollowUp === true);
+
+const filterByFollowUp = (subs, mode) => {
+  if (mode === 'on') return subs.filter((s) => s.inFollowUp === true);
+  if (mode === 'off') return subs.filter((s) => s.inFollowUp !== true);
+  return subs;
+};
 
 const toggleFollowUp = (sub) => ({ inFollowUp: !sub.inFollowUp });
 
@@ -59,5 +66,33 @@ describe('Follow-up counter', () => {
       { inFollowUp: true },
     ];
     expect(subs.filter((s) => s.inFollowUp === true).length).toBe(3);
+  });
+});
+
+describe('Follow-up segment filter (#246)', () => {
+  const subs = [
+    { id: 'a', inFollowUp: true },
+    { id: 'b', inFollowUp: false },
+    { id: 'c' }, // legacy
+    { id: 'd', inFollowUp: true },
+    { id: 'e', inFollowUp: false },
+  ];
+
+  it("'all' não filtra (mostra todos)", () => {
+    expect(filterByFollowUp(subs, 'all').map((s) => s.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it("'on' mostra só inFollowUp === true", () => {
+    expect(filterByFollowUp(subs, 'on').map((s) => s.id)).toEqual(['a', 'd']);
+  });
+
+  it("'off' mostra inFollowUp !== true (inclui false E legacy undefined)", () => {
+    expect(filterByFollowUp(subs, 'off').map((s) => s.id)).toEqual(['b', 'c', 'e']);
+  });
+
+  it('on + off === all (sem leak)', () => {
+    const onCount = filterByFollowUp(subs, 'on').length;
+    const offCount = filterByFollowUp(subs, 'off').length;
+    expect(onCount + offCount).toBe(subs.length);
   });
 });

--- a/src/pages/SubscriptionsPage.jsx
+++ b/src/pages/SubscriptionsPage.jsx
@@ -216,7 +216,7 @@ const SubscriptionsPage = () => {
 
   const [statusFilter, setStatusFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
-  const [followUpOnly, setFollowUpOnly] = useState(false);
+  const [followUpFilter, setFollowUpFilter] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('studentName');
   const [sortDir, setSortDir] = useState('asc');
@@ -292,7 +292,8 @@ const SubscriptionsPage = () => {
     let result = [...subscriptions];
     if (statusFilter !== 'all') result = result.filter(s => s.status === statusFilter);
     if (typeFilter !== 'all') result = result.filter(s => s.type === typeFilter);
-    if (followUpOnly) result = result.filter(s => s.inFollowUp === true);
+    if (followUpFilter === 'on') result = result.filter(s => s.inFollowUp === true);
+    else if (followUpFilter === 'off') result = result.filter(s => s.inFollowUp !== true);
     if (searchTerm.trim()) {
       const term = searchTerm.toLowerCase();
       result = result.filter(s => s.studentName?.toLowerCase().includes(term) || s.studentEmail?.toLowerCase().includes(term));
@@ -316,7 +317,7 @@ const SubscriptionsPage = () => {
       return (a.studentName ?? '').localeCompare(b.studentName ?? '');
     });
     return result;
-  }, [subscriptions, statusFilter, typeFilter, followUpOnly, searchTerm, sortBy, sortDir]);
+  }, [subscriptions, statusFilter, typeFilter, followUpFilter, searchTerm, sortBy, sortDir]);
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const safePage = Math.min(page, totalPages - 1);
@@ -542,15 +543,21 @@ const SubscriptionsPage = () => {
             <button key={`t-${f.value}`} onClick={() => { setTypeFilter(f.value); setPage(0); }} className={`px-3 py-2 rounded-xl text-sm whitespace-nowrap transition-colors ${typeFilter === f.value ? 'bg-violet-500/20 text-violet-400 border border-violet-500/30' : 'text-slate-400 hover:text-white hover:bg-slate-800/50 border border-transparent'}`}>{f.label}</button>
           ))}
           <span className="border-l border-slate-700 mx-1" />
-          <button
-            onClick={() => { setFollowUpOnly(v => !v); setPage(0); }}
-            className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm whitespace-nowrap transition-colors ${followUpOnly ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' : 'text-slate-400 hover:text-white hover:bg-slate-800/50 border border-transparent'}`}
-            title="Mostrar só assinaturas em follow-up"
-          >
-            <MessageCircle className="w-3.5 h-3.5" />
-            Em follow-up
-            <span className={`text-xs px-1.5 py-0.5 rounded-full ${followUpOnly ? 'bg-emerald-500/30' : 'bg-slate-700/50'}`}>{subscriptions.filter(s => s.inFollowUp === true).length}</span>
-          </button>
+          {[
+            { value: 'all', label: 'Todos FU', count: subscriptions.length },
+            { value: 'on', label: 'Em follow-up', count: subscriptions.filter(s => s.inFollowUp === true).length },
+            { value: 'off', label: 'Sem follow-up', count: subscriptions.filter(s => s.inFollowUp !== true).length },
+          ].map(f => (
+            <button
+              key={`fu-${f.value}`}
+              onClick={() => { setFollowUpFilter(f.value); setPage(0); }}
+              className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm whitespace-nowrap transition-colors ${followUpFilter === f.value ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' : 'text-slate-400 hover:text-white hover:bg-slate-800/50 border border-transparent'}`}
+            >
+              {f.value !== 'all' && <MessageCircle className="w-3.5 h-3.5" />}
+              {f.label}
+              <span className={`text-xs px-1.5 py-0.5 rounded-full ${followUpFilter === f.value ? 'bg-emerald-500/30' : 'bg-slate-700/50'}`}>{f.count}</span>
+            </button>
+          ))}
         </div>
       </div>
 

--- a/src/version.js
+++ b/src/version.js
@@ -337,10 +337,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.55.3',
-  build: '20260504',
-  display: 'v1.55.3',
-  full: '1.55.3+20260504',
+  version: '1.55.4',
+  build: '20260504d',
+  display: 'v1.55.4',
+  full: '1.55.4+20260504d',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

- Substitui chip toggle único `Em follow-up` por 3 chips exclusivos com contadores: **Todos FU / Em follow-up / Sem follow-up**.
- Necessidade urgente: Marcio cobrando alunos AGORA precisa ver os dois segmentos.
- State `followUpOnly:bool` → `followUpFilter:'all'|'on'|'off'`.
- `off` filtra `inFollowUp !== true` (inclui `false` E `undefined` legacy → soma 100% sem leak).

## Test plan

- [x] 11 testes (4 novos cobrindo 'all'/'on'/'off' + invariante `on + off === all`)
- [x] Tests verde
- [ ] Smoke manual no `/subscriptions` pós-merge

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)