### PR TITLE
feat(#248): redesign filtro follow-up — checkbox + on/off (compacto)

### DIFF
--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-16 | #248 | `feat/issue-248-followup-checkbox-redesign` | 04/05/2026 | escrita |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -24,3 +24,4 @@
 | 1.55.2 | #242 | `fix/issue-242-parser-stop-semantic` | 04/05/2026 | consumida (PR #244 squash `34642608`) |
 | 1.55.3 | #243 | `feat/issue-243-subscription-followup` | 04/05/2026 | consumida (PR #245 squash `fcef6a87`) |
 | 1.55.4 | #246 | `feat/issue-246-followup-segment-filters` | 04/05/2026 | consumida (PR #247 squash `fa573da1`) |
+| 1.55.5 | #248 | `feat/issue-248-followup-checkbox-redesign` | 04/05/2026 | reservada |

--- a/src/pages/SubscriptionsPage.jsx
+++ b/src/pages/SubscriptionsPage.jsx
@@ -543,21 +543,30 @@ const SubscriptionsPage = () => {
             <button key={`t-${f.value}`} onClick={() => { setTypeFilter(f.value); setPage(0); }} className={`px-3 py-2 rounded-xl text-sm whitespace-nowrap transition-colors ${typeFilter === f.value ? 'bg-violet-500/20 text-violet-400 border border-violet-500/30' : 'text-slate-400 hover:text-white hover:bg-slate-800/50 border border-transparent'}`}>{f.label}</button>
           ))}
           <span className="border-l border-slate-700 mx-1" />
-          {[
-            { value: 'all', label: 'Todos FU', count: subscriptions.length },
-            { value: 'on', label: 'Em follow-up', count: subscriptions.filter(s => s.inFollowUp === true).length },
-            { value: 'off', label: 'Sem follow-up', count: subscriptions.filter(s => s.inFollowUp !== true).length },
-          ].map(f => (
+          <label className="flex items-center gap-2 px-3 py-2 rounded-xl text-sm cursor-pointer hover:bg-slate-800/50 transition-colors">
+            <input
+              type="checkbox"
+              checked={followUpFilter !== 'all'}
+              onChange={(e) => { setFollowUpFilter(e.target.checked ? 'on' : 'all'); setPage(0); }}
+              className="w-4 h-4 rounded accent-emerald-500"
+            />
+            <MessageCircle className={`w-3.5 h-3.5 ${followUpFilter !== 'all' ? 'text-emerald-400' : 'text-slate-500'}`} />
+            <span className={followUpFilter !== 'all' ? 'text-emerald-400' : 'text-slate-400'}>Follow up</span>
+          </label>
+          <div className="flex rounded-xl overflow-hidden border border-slate-700/50">
             <button
-              key={`fu-${f.value}`}
-              onClick={() => { setFollowUpFilter(f.value); setPage(0); }}
-              className={`flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm whitespace-nowrap transition-colors ${followUpFilter === f.value ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30' : 'text-slate-400 hover:text-white hover:bg-slate-800/50 border border-transparent'}`}
-            >
-              {f.value !== 'all' && <MessageCircle className="w-3.5 h-3.5" />}
-              {f.label}
-              <span className={`text-xs px-1.5 py-0.5 rounded-full ${followUpFilter === f.value ? 'bg-emerald-500/30' : 'bg-slate-700/50'}`}>{f.count}</span>
-            </button>
-          ))}
+              type="button"
+              disabled={followUpFilter === 'all'}
+              onClick={() => { setFollowUpFilter('on'); setPage(0); }}
+              className={`px-3 py-2 text-xs transition-colors ${followUpFilter === 'on' ? 'bg-emerald-500/30 text-emerald-300' : followUpFilter === 'all' ? 'text-slate-600 cursor-not-allowed' : 'text-slate-400 hover:bg-slate-800/50'}`}
+            >on</button>
+            <button
+              type="button"
+              disabled={followUpFilter === 'all'}
+              onClick={() => { setFollowUpFilter('off'); setPage(0); }}
+              className={`px-3 py-2 text-xs transition-colors border-l border-slate-700/50 ${followUpFilter === 'off' ? 'bg-emerald-500/30 text-emerald-300' : followUpFilter === 'all' ? 'text-slate-600 cursor-not-allowed' : 'text-slate-400 hover:bg-slate-800/50'}`}
+            >off</button>
+          </div>
         </div>
       </div>
 

--- a/src/version.js
+++ b/src/version.js
@@ -338,10 +338,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.55.4',
-  build: '20260504',
-  display: 'v1.55.4',
-  full: '1.55.4+20260504',
+  version: '1.55.5',
+  build: '20260504e',
+  display: 'v1.55.5',
+  full: '1.55.5+20260504e',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

Substitui os 3 chips de #246 por **1 checkbox "Follow up" + dual switch on/off**.

- Checkbox unchecked → mostra TODOS (sem filtro de FU).
- Checkbox checked + on → só `inFollowUp === true`.
- Checkbox checked + off → só `inFollowUp !== true`.

Mockup do Marcio: `☐ Follow up [on/off]`. Compacto, pt-BR ok (sem "Todos FU").

State `followUpFilter: 'all'|'on'|'off'` preservado — filtro lógico inalterado, só UI muda. 11 tests existentes seguem cobrindo.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)