### PR TITLE
feat(#250): resumo de pagamentos do mês no Fluxo de Caixa

### DIFF
--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-16 | #250 | `feat/issue-250-monthly-payments-summary` | 04/05/2026 | escrita |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -25,3 +25,4 @@
 | 1.55.3 | #243 | `feat/issue-243-subscription-followup` | 04/05/2026 | consumida (PR #245 squash `fcef6a87`) |
 | 1.55.4 | #246 | `feat/issue-246-followup-segment-filters` | 04/05/2026 | consumida (PR #247 squash `fa573da1`) |
 | 1.55.5 | #248 | `feat/issue-248-followup-checkbox-redesign` | 04/05/2026 | consumida (PR #249 squash `d1507a8b`) |
+| 1.56.0 | #250 | `feat/issue-250-monthly-payments-summary` | 04/05/2026 | reservada |

--- a/src/__tests__/utils/monthlyPayments.test.js
+++ b/src/__tests__/utils/monthlyPayments.test.js
@@ -1,0 +1,101 @@
+/**
+ * Tests: aggregatePaymentsForMonth — issue #250
+ */
+
+import { describe, it, expect } from 'vitest';
+import { aggregatePaymentsForMonth } from '../../utils/monthlyPayments';
+
+// Produção grava T12:00:00Z (DEC equivalente ao addSubscription para evitar TZ shift em BR).
+const mkPayment = (date, amount, opts = {}) => ({
+  date: new Date(`${date}T12:00:00Z`),
+  amount,
+  currency: opts.currency ?? 'BRL',
+  studentId: opts.studentId ?? 'sX',
+  ...opts,
+});
+
+describe('aggregatePaymentsForMonth', () => {
+  it('filtra pagamentos do mês alvo (year + month 0-indexed)', () => {
+    const payments = [
+      mkPayment('2026-04-15', 1000), // abril → fora
+      mkPayment('2026-05-03', 1200), // maio
+      mkPayment('2026-05-28', 800), // maio
+      mkPayment('2026-06-01', 500), // junho → fora
+    ];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4); // mês 4 = maio
+    expect(r.count).toBe(2);
+    expect(r.total).toBe(2000);
+  });
+
+  it('ordena por data desc', () => {
+    const payments = [
+      mkPayment('2026-05-01', 100, { id: 'a' }),
+      mkPayment('2026-05-15', 200, { id: 'b' }),
+      mkPayment('2026-05-10', 300, { id: 'c' }),
+    ];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4);
+    expect(r.list.map((p) => p.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('enriquece com studentName quando map fornecido', () => {
+    const payments = [mkPayment('2026-05-10', 100, { studentId: 'uid-joao' })];
+    const map = new Map([['uid-joao', 'João Silva']]);
+    const r = aggregatePaymentsForMonth(payments, 2026, 4, map);
+    expect(r.list[0].studentName).toBe('João Silva');
+  });
+
+  it('fallback para studentId quando map não tem entry', () => {
+    const payments = [mkPayment('2026-05-10', 100, { studentId: 'uid-x' })];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4, new Map());
+    expect(r.list[0].studentName).toBe('uid-x');
+  });
+
+  it('soma só BRL (outras moedas ignoradas no total)', () => {
+    const payments = [
+      mkPayment('2026-05-10', 1000), // BRL
+      mkPayment('2026-05-12', 500, { currency: 'USD' }),
+      mkPayment('2026-05-15', 200), // BRL
+    ];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4);
+    expect(r.count).toBe(3); // count inclui todos
+    expect(r.total).toBe(1200); // total só BRL
+  });
+
+  it('lida com Timestamp do Firestore (val.toDate())', () => {
+    const fakeTimestamp = { toDate: () => new Date('2026-05-10T12:00:00Z') };
+    const payments = [{ date: fakeTimestamp, amount: 500, currency: 'BRL', studentId: 's' }];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4);
+    expect(r.count).toBe(1);
+    expect(r.total).toBe(500);
+  });
+
+  it('mês vazio retorna zeros', () => {
+    const r = aggregatePaymentsForMonth([], 2026, 4);
+    expect(r).toEqual({ total: 0, count: 0, list: [] });
+  });
+
+  it('payments null/undefined → zeros', () => {
+    expect(aggregatePaymentsForMonth(null, 2026, 4)).toEqual({ total: 0, count: 0, list: [] });
+    expect(aggregatePaymentsForMonth(undefined, 2026, 4)).toEqual({ total: 0, count: 0, list: [] });
+  });
+
+  it('amount inválido (string vazia, NaN) → trata como 0', () => {
+    const payments = [
+      mkPayment('2026-05-10', 1000),
+      { date: new Date('2026-05-12T12:00:00Z'), amount: 'abc', currency: 'BRL', studentId: 's' },
+      { date: new Date('2026-05-13T12:00:00Z'), amount: null, currency: 'BRL', studentId: 's' },
+    ];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4);
+    expect(r.count).toBe(3);
+    expect(r.total).toBe(1000);
+  });
+
+  it('payment sem date → ignora', () => {
+    const payments = [
+      mkPayment('2026-05-10', 100),
+      { amount: 500, currency: 'BRL', studentId: 's' }, // sem date
+    ];
+    const r = aggregatePaymentsForMonth(payments, 2026, 4);
+    expect(r.count).toBe(1);
+  });
+});

--- a/src/components/RenewalForecast.jsx
+++ b/src/components/RenewalForecast.jsx
@@ -5,9 +5,15 @@
  */
 
 import { useMemo, useState } from 'react';
-import { TrendingUp, User } from 'lucide-react';
+import { TrendingUp, User, CheckCircle2, ChevronDown, ChevronUp } from 'lucide-react';
 import { groupRenewalsByMonth, formatBRL, formatDateBR } from '../utils/renewalForecast';
+import { useCurrentMonthPayments } from '../hooks/useCurrentMonthPayments';
 import DebugBadge from './DebugBadge';
+
+const MONTH_NAME_BR_FULL = [
+  'janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho',
+  'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro'
+];
 
 const MONTHS_COUNT = 12;
 
@@ -75,6 +81,18 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
 
   const expanded = expandedMonth ? forecastMap[expandedMonth] : null;
 
+  // ── Recebido no mês corrente (issue #250) ──
+  const studentsMap = useMemo(() => {
+    const m = new Map();
+    for (const s of subscriptions ?? []) {
+      if (s.studentId && s.studentName) m.set(s.studentId, s.studentName);
+    }
+    return m;
+  }, [subscriptions]);
+  const monthlyPayments = useCurrentMonthPayments(studentsMap);
+  const [paymentsExpanded, setPaymentsExpanded] = useState(false);
+  const currentMonthLabel = MONTH_NAME_BR_FULL[now.getMonth()];
+
   // Anos para o dropdown: atual -1 até +5 (janela de 7 anos, cobre qualquer cenário razoável)
   const baseYear = now.getFullYear();
   const yearOptions = Array.from({ length: 7 }, (_, i) => baseYear - 1 + i);
@@ -96,6 +114,18 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
               <span className="text-slate-700">·</span>
               <span>Total visível: <span className="text-violet-300 font-medium">{formatBRL(totalVisible)}</span></span>
             </div>
+            <button
+              type="button"
+              onClick={() => monthlyPayments.count > 0 && setPaymentsExpanded(v => !v)}
+              disabled={monthlyPayments.count === 0}
+              className={`mt-1.5 flex items-center gap-1.5 text-xs ${monthlyPayments.count > 0 ? 'text-emerald-400 hover:text-emerald-300 cursor-pointer' : 'text-slate-600 cursor-default'}`}
+            >
+              <CheckCircle2 className="w-3.5 h-3.5" />
+              <span>
+                Recebido em {currentMonthLabel}: <span className="font-medium">{formatBRL(monthlyPayments.total)}</span> <span className="text-slate-500">({monthlyPayments.count} pagamento{monthlyPayments.count === 1 ? '' : 's'})</span>
+              </span>
+              {monthlyPayments.count > 0 && (paymentsExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />)}
+            </button>
           </div>
         </div>
 
@@ -204,6 +234,20 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
           </div>
         );
       })()}
+
+      {/* Detalhe pagamentos do mês corrente (issue #250) */}
+      {paymentsExpanded && monthlyPayments.count > 0 && (
+        <div className="mt-3 pt-3 border-t border-emerald-500/20 max-w-md">
+          <p className="text-[10px] uppercase tracking-wide text-emerald-500/70 mb-1.5">Pagamentos de {currentMonthLabel}</p>
+          {monthlyPayments.list.map((p) => (
+            <div key={p.id} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs py-0.5 items-center">
+              <span className="text-slate-300 truncate">{p.studentName}</span>
+              <span className="text-slate-500 text-[11px]">{formatDateBR(p.dateObj)}</span>
+              <span className="text-emerald-400 font-medium text-right">{formatBRL(p.amount)}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
       {!embedded && <DebugBadge component="RenewalForecast" />}
     </div>

--- a/src/hooks/useCurrentMonthPayments.js
+++ b/src/hooks/useCurrentMonthPayments.js
@@ -1,0 +1,41 @@
+/**
+ * useCurrentMonthPayments — issue #250
+ * @description Listener real-time do collection group `payments`, agrega o mês corrente.
+ *
+ * Source: students/{uid}/subscriptions/{subId}/payments/{pid}
+ * Mês corrente = `new Date()` na timezone do browser (assume mentor em BR).
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import { collectionGroup, onSnapshot, query } from 'firebase/firestore';
+import { db } from '../firebase';
+import { useAuth } from '../contexts/AuthContext';
+import { aggregatePaymentsForMonth } from '../utils/monthlyPayments';
+
+export const useCurrentMonthPayments = (studentsMap) => {
+  const { user, isMentor } = useAuth();
+  const [payments, setPayments] = useState([]);
+
+  useEffect(() => {
+    if (!user || !isMentor()) {
+      setPayments([]);
+      return;
+    }
+    const q = query(collectionGroup(db, 'payments'));
+    const unsubscribe = onSnapshot(q, (snap) => {
+      const data = snap.docs.map((d) => {
+        const segments = d.ref.path.split('/');
+        return { id: d.id, studentId: segments[1], ...d.data() };
+      });
+      setPayments(data);
+    });
+    return () => unsubscribe();
+  }, [user, isMentor]);
+
+  const summary = useMemo(() => {
+    const now = new Date();
+    return aggregatePaymentsForMonth(payments, now.getFullYear(), now.getMonth(), studentsMap);
+  }, [payments, studentsMap]);
+
+  return summary;
+};

--- a/src/utils/monthlyPayments.js
+++ b/src/utils/monthlyPayments.js
@@ -1,0 +1,48 @@
+/**
+ * monthlyPayments — issue #250
+ * @description Agrega pagamentos de um mês específico a partir do collection group `payments`.
+ *
+ * Path origem: students/{uid}/subscriptions/{subId}/payments/{pid}
+ * Schema: { date: Timestamp|Date, amount: number, currency: 'BRL'|..., studentId derivado do path }
+ */
+
+const toDate = (val) => {
+  if (!val) return null;
+  if (val instanceof Date) return val;
+  if (typeof val.toDate === 'function') return val.toDate();
+  return new Date(val);
+};
+
+/**
+ * Agrega pagamentos de um mês.
+ *
+ * @param {Array} payments — lista de payment docs com `date`, `amount`, `currency`, `studentId`
+ * @param {number} year — ano do mês alvo
+ * @param {number} month — mês 0-indexed (0=jan, 4=mai)
+ * @param {Map<string,string>} studentsMap — map studentId → nome (opcional)
+ * @returns {{ total: number, count: number, list: Array }}
+ *   - total: soma de `amount` em BRL (outras moedas não somam — warning fica fora desta função)
+ *   - count: quantidade de pagamentos no mês
+ *   - list: pagamentos do mês ordenados por data desc, enriquecidos com `studentName` e `dateObj`
+ */
+export const aggregatePaymentsForMonth = (payments, year, month, studentsMap = new Map()) => {
+  if (!Array.isArray(payments)) return { total: 0, count: 0, list: [] };
+
+  const filtered = payments
+    .map((p) => ({ ...p, dateObj: toDate(p.date) }))
+    .filter((p) => p.dateObj && p.dateObj.getFullYear() === year && p.dateObj.getMonth() === month);
+
+  filtered.sort((a, b) => b.dateObj - a.dateObj);
+
+  const enriched = filtered.map((p) => ({
+    ...p,
+    studentName: studentsMap.get(p.studentId) ?? p.studentId,
+  }));
+
+  const total = enriched.reduce((sum, p) => {
+    const cur = p.currency ?? 'BRL';
+    return cur === 'BRL' ? sum + (Number(p.amount) || 0) : sum;
+  }, 0);
+
+  return { total, count: enriched.length, list: enriched };
+};

--- a/src/version.js
+++ b/src/version.js
@@ -339,10 +339,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.55.5',
-  build: '20260504',
-  display: 'v1.55.5',
-  full: '1.55.5+20260504',
+  version: '1.56.0',
+  build: '20260504f',
+  display: 'v1.56.0',
+  full: '1.56.0+20260504f',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

Adiciona ao card "Fluxo de caixa previsto" um totalizador do **mês corrente** com expand de detalhe (V2 do mockup aprovado).

- Linha emerald no header: `✅ Recebido em {mês}: R$ X.XXX (N pagamentos)`.
- Click no chevron → tabela aluno / data / valor (ordenada por data desc).
- Real-time via `collectionGroup('payments')` — novo pagamento aparece sem refresh.
- Helper puro `aggregatePaymentsForMonth` testado com 10 cenários (filtro, sort, BRL-only, Timestamp Firestore, edge cases).
- Bump 1.55.5 → 1.56.0 (feature minor).

Memória de cálculo:
- Soma só `currency === 'BRL'` (outras moedas entram no `count` mas não no `total`).
- `date` filtrado pelo mês na timezone local (mentor BR; payments gravados como `T12:00:00Z` evitam shift).
- `studentName` via map enriquecido em `RenewalForecast` a partir de `subscriptions.studentName`.

## Test plan

- [x] 10 tests novos, suite total 3004/3004 verde
- [x] Build vite verde
- [ ] Smoke `/subscriptions`: card mostra mês corrente, click expande lista
- [ ] Registrar novo pagamento → vê aparecer em real-time

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)