### PR TITLE
fix(#252): expand de mês mostra Recebidos + Inadimplentes + Vencimentos

### DIFF
--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-16 | #252 | `feat/issue-252-payments-in-month-expand` | 04/05/2026 | escrita |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -26,3 +26,4 @@
 | 1.55.4 | #246 | `feat/issue-246-followup-segment-filters` | 04/05/2026 | consumida (PR #247 squash `fa573da1`) |
 | 1.55.5 | #248 | `feat/issue-248-followup-checkbox-redesign` | 04/05/2026 | consumida (PR #249 squash `d1507a8b`) |
 | 1.56.0 | #250 | `feat/issue-250-monthly-payments-summary` | 04/05/2026 | consumida (PR #251 squash `2f263a91`) |
+| 1.56.1 | #252 | `feat/issue-252-payments-in-month-expand` | 04/05/2026 | reservada |

--- a/src/components/RenewalForecast.jsx
+++ b/src/components/RenewalForecast.jsx
@@ -7,7 +7,8 @@
 import { useMemo, useState } from 'react';
 import { TrendingUp, User, CheckCircle2, ChevronDown, ChevronUp } from 'lucide-react';
 import { groupRenewalsByMonth, formatBRL, formatDateBR } from '../utils/renewalForecast';
-import { useCurrentMonthPayments } from '../hooks/useCurrentMonthPayments';
+import { aggregatePaymentsForMonth } from '../utils/monthlyPayments';
+import { usePayments } from '../hooks/usePayments';
 import DebugBadge from './DebugBadge';
 
 const MONTH_NAME_BR_FULL = [
@@ -31,7 +32,7 @@ const buildMonthSlots = (startMonth, startYear) => {
     const month = d.getMonth();
     const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`;
     const label = d.toLocaleDateString('pt-BR', { month: 'short' }).replace('.', '');
-    slots.push({ monthKey, label, year });
+    slots.push({ monthKey, label, year, month });
   }
   return slots;
 };
@@ -81,7 +82,7 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
 
   const expanded = expandedMonth ? forecastMap[expandedMonth] : null;
 
-  // ── Recebido no mês corrente (issue #250) ──
+  // ── Pagamentos recebidos (issue #250 + #252) ──
   const studentsMap = useMemo(() => {
     const m = new Map();
     for (const s of subscriptions ?? []) {
@@ -89,9 +90,21 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
     }
     return m;
   }, [subscriptions]);
-  const monthlyPayments = useCurrentMonthPayments(studentsMap);
+  const allPayments = usePayments();
+  const paymentsByMonth = useMemo(() => {
+    const map = {};
+    for (const slot of slots) {
+      map[slot.monthKey] = aggregatePaymentsForMonth(allPayments, slot.year, slot.month, studentsMap);
+    }
+    return map;
+  }, [allPayments, slots, studentsMap]);
+  const monthlyPayments = useMemo(
+    () => aggregatePaymentsForMonth(allPayments, now.getFullYear(), now.getMonth(), studentsMap),
+    [allPayments, studentsMap]
+  );
   const [paymentsExpanded, setPaymentsExpanded] = useState(false);
   const currentMonthLabel = MONTH_NAME_BR_FULL[now.getMonth()];
+  const expandedPayments = expandedMonth ? paymentsByMonth[expandedMonth] : null;
 
   // Anos para o dropdown: atual -1 até +5 (janela de 7 anos, cobre qualquer cenário razoável)
   const baseYear = now.getFullYear();
@@ -158,6 +171,9 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
         {slots.map((slot) => {
           const data = forecastMap[slot.monthKey];
           const hasData = !!data;
+          const slotPayments = paymentsByMonth[slot.monthKey];
+          const hasPayments = (slotPayments?.count ?? 0) > 0;
+          const isExpandable = hasData || hasPayments;
           const isActive = expandedMonth === slot.monthKey;
           const overdueStudents = data?.students.filter(s => s.overdue) ?? [];
           const scheduledStudents = data?.students.filter(s => !s.overdue) ?? [];
@@ -169,17 +185,17 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
           return (
             <button
               key={slot.monthKey}
-              onClick={() => hasData && setExpandedMonth(isActive ? null : slot.monthKey)}
+              onClick={() => isExpandable && setExpandedMonth(isActive ? null : slot.monthKey)}
               className={`flex flex-col items-center py-2 px-1 rounded-lg border transition-colors ${
                 isActive
                   ? hasOverdue && !hasScheduled ? 'bg-red-500/10 border-red-500/40' : 'bg-violet-500/15 border-violet-500/40'
                   : hasOverdue && !hasScheduled
                     ? 'bg-red-500/5 border-red-500/20 hover:bg-red-500/10 hover:border-red-500/30 cursor-pointer'
-                    : hasData
+                    : isExpandable
                       ? 'bg-slate-800/30 border-slate-700/30 hover:bg-slate-800/50 hover:border-slate-600/40 cursor-pointer'
                       : 'bg-slate-800/10 border-slate-800/20 cursor-default opacity-50'
               }`}
-              disabled={!hasData}
+              disabled={!isExpandable}
             >
               <span className={`text-[10px] uppercase tracking-wide ${isActive ? 'text-violet-300' : 'text-slate-500'}`}>
                 {slot.label}
@@ -196,8 +212,22 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
                       {formatBRL(overdueAmount)}
                     </span>
                   )}
+                  {hasPayments && (
+                    <span className="text-[10px] font-bold text-emerald-400 mt-0.5">
+                      ✓ {formatBRL(slotPayments.total)}
+                    </span>
+                  )}
                   <span className="text-[9px] text-slate-500 flex items-center gap-0.5 mt-0.5">
                     <User className="w-2 h-2" />{data.students.length}
+                  </span>
+                </>
+              ) : hasPayments ? (
+                <>
+                  <span className="text-[10px] font-bold text-emerald-400 mt-0.5">
+                    ✓ {formatBRL(slotPayments.total)}
+                  </span>
+                  <span className="text-[9px] text-slate-500 flex items-center gap-0.5 mt-0.5">
+                    <User className="w-2 h-2" />{slotPayments.count}
                   </span>
                 </>
               ) : (
@@ -208,29 +238,58 @@ const RenewalForecast = ({ subscriptions, embedded = false }) => {
         })}
       </div>
 
-      {/* Detalhe expandido embaixo */}
-      {expanded && (() => {
-        const overdue = expanded.students.filter(s => s.overdue);
-        const scheduled = expanded.students.filter(s => !s.overdue);
-        const overdueTotal = overdue.reduce((sum, s) => sum + s.amount, 0);
-        const scheduledTotal = scheduled.reduce((sum, s) => sum + s.amount, 0);
+      {/* Detalhe expandido — Recebidos + Inadimplentes + Vencimentos (issue #252) */}
+      {expandedMonth && (expanded || (expandedPayments?.count ?? 0) > 0) && (() => {
+        const overdue = expanded?.students.filter(s => s.overdue) ?? [];
+        const scheduled = expanded?.students.filter(s => !s.overdue) ?? [];
+        const received = expandedPayments?.list ?? [];
+        const expandedSlot = slots.find(s => s.monthKey === expandedMonth);
+        const expandedMonthLabel = expandedSlot ? MONTH_NAME_BR_FULL[expandedSlot.month] : '';
 
         return (
-          <div className="mt-3 pt-3 border-t border-slate-800/50 max-w-md">
-            {overdue.map((s, i) => (
-              <div key={`o-${i}`} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs py-0.5 items-center">
-                <span className="text-red-400 truncate">{s.name}</span>
-                <span className="text-red-400/50 text-[11px]">venceu {formatDateBR(s.endDate)}</span>
-                <span className="text-red-400 font-medium text-right">{formatBRL(s.amount)}</span>
+          <div className="mt-3 pt-3 border-t border-slate-800/50 max-w-md space-y-2">
+            {received.length > 0 && (
+              <div>
+                <p className="text-[10px] uppercase tracking-wide text-emerald-500/70 mb-1">
+                  Recebidos em {expandedMonthLabel} ({received.length} · {formatBRL(expandedPayments.total)})
+                </p>
+                {received.map((p) => (
+                  <div key={p.id} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs py-0.5 items-center">
+                    <span className="text-slate-300 truncate">{p.studentName}</span>
+                    <span className="text-slate-500 text-[11px]">{formatDateBR(p.dateObj)}</span>
+                    <span className="text-emerald-400 font-medium text-right">{formatBRL(p.amount)}</span>
+                  </div>
+                ))}
               </div>
-            ))}
-            {scheduled.map((s, i) => (
-              <div key={`s-${i}`} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs py-0.5 items-center">
-                <span className="text-slate-300 truncate">{s.name}</span>
-                <span className="text-slate-500 text-[11px]">{formatDateBR(s.endDate)}</span>
-                <span className="text-white font-medium text-right">{formatBRL(s.amount)}</span>
+            )}
+            {overdue.length > 0 && (
+              <div>
+                {received.length > 0 && (
+                  <p className="text-[10px] uppercase tracking-wide text-red-500/70 mb-1">Inadimplentes</p>
+                )}
+                {overdue.map((s, i) => (
+                  <div key={`o-${i}`} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs py-0.5 items-center">
+                    <span className="text-red-400 truncate">{s.name}</span>
+                    <span className="text-red-400/50 text-[11px]">venceu {formatDateBR(s.endDate)}</span>
+                    <span className="text-red-400 font-medium text-right">{formatBRL(s.amount)}</span>
+                  </div>
+                ))}
               </div>
-            ))}
+            )}
+            {scheduled.length > 0 && (
+              <div>
+                {(received.length > 0 || overdue.length > 0) && (
+                  <p className="text-[10px] uppercase tracking-wide text-slate-500/70 mb-1">Vencimentos</p>
+                )}
+                {scheduled.map((s, i) => (
+                  <div key={`s-${i}`} className="grid grid-cols-[1fr_auto_auto] gap-x-3 text-xs py-0.5 items-center">
+                    <span className="text-slate-300 truncate">{s.name}</span>
+                    <span className="text-slate-500 text-[11px]">{formatDateBR(s.endDate)}</span>
+                    <span className="text-white font-medium text-right">{formatBRL(s.amount)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         );
       })()}

--- a/src/hooks/usePayments.js
+++ b/src/hooks/usePayments.js
@@ -1,18 +1,18 @@
 /**
- * useCurrentMonthPayments — issue #250
- * @description Listener real-time do collection group `payments`, agrega o mês corrente.
+ * usePayments — issue #252 (sucessor de useCurrentMonthPayments do #250)
+ * @description Listener real-time do collection group `payments`. Retorna a
+ *   lista bruta enriched com `studentId` (derivado do path); a agregação por
+ *   mês é responsabilidade do caller via `aggregatePaymentsForMonth`.
  *
  * Source: students/{uid}/subscriptions/{subId}/payments/{pid}
- * Mês corrente = `new Date()` na timezone do browser (assume mentor em BR).
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { collectionGroup, onSnapshot, query } from 'firebase/firestore';
 import { db } from '../firebase';
 import { useAuth } from '../contexts/AuthContext';
-import { aggregatePaymentsForMonth } from '../utils/monthlyPayments';
 
-export const useCurrentMonthPayments = (studentsMap) => {
+export const usePayments = () => {
   const { user, isMentor } = useAuth();
   const [payments, setPayments] = useState([]);
 
@@ -32,10 +32,5 @@ export const useCurrentMonthPayments = (studentsMap) => {
     return () => unsubscribe();
   }, [user, isMentor]);
 
-  const summary = useMemo(() => {
-    const now = new Date();
-    return aggregatePaymentsForMonth(payments, now.getFullYear(), now.getMonth(), studentsMap);
-  }, [payments, studentsMap]);
-
-  return summary;
+  return payments;
 };

--- a/src/version.js
+++ b/src/version.js
@@ -340,10 +340,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.56.0',
-  build: '20260504',
-  display: 'v1.56.0',
-  full: '1.56.0+20260504',
+  version: '1.56.1',
+  build: '20260504g',
+  display: 'v1.56.1',
+  full: '1.56.1+20260504g',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

Marcio testou v1.56.0 (#250) clicando no chip do mês de maio e só viu inadimplentes + vencimentos. Faltava integrar os recebidos no mesmo expand.

- Renomeia `useCurrentMonthPayments` → `usePayments` (lista bruta).
- `RenewalForecast` agrega payments por slot via `aggregatePaymentsForMonth`.
- Expand de cada mês passa a mostrar **3 seções**: Recebidos (verde) / Inadimplentes (vermelho) / Vencimentos.
- Chip mostra `✓ R$ X` em verde quando há pagamentos no mês.
- Chip fica clicável mesmo sem forecast, se houver pagamentos (mês onde todos pagaram → forecast vazio mas recebidos ≠ 0).
- Linha verde do header preservada (atalho rápido do mês corrente).

## Test plan

- [x] 10 tests do helper continuam verde
- [x] Build verde
- [ ] Smoke prod: click mai/26 mostra os 3 blocos

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)