### PR TITLE
fix(#254): regra de leitura para collectionGroup('payments')

### DIFF
--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-16 | #254 | `fix/issue-254-payments-cg-rules` | 04/05/2026 | escrita |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -27,3 +27,4 @@
 | 1.55.5 | #248 | `feat/issue-248-followup-checkbox-redesign` | 04/05/2026 | consumida (PR #249 squash `d1507a8b`) |
 | 1.56.0 | #250 | `feat/issue-250-monthly-payments-summary` | 04/05/2026 | consumida (PR #251 squash `2f263a91`) |
 | 1.56.1 | #252 | `feat/issue-252-payments-in-month-expand` | 04/05/2026 | consumida (PR #253 squash `4e2a57fa`) |
+| 1.56.2 | #254 | `fix/issue-254-payments-cg-rules` | 04/05/2026 | reservada |

--- a/firestore.rules
+++ b/firestore.rules
@@ -286,6 +286,11 @@ service cloud.firestore {
       allow read: if isMentor();
     }
 
+    // collectionGroup('payments') — read-only do mentor (escrita só via path direto, issue #254)
+    match /{path=**}/payments/{paymentId} {
+      allow read: if isMentor();
+    }
+
     // ========== Maturity Engine — Progressão 4D × 5 stages (CHUNK-09, issue #119) ==========
     // INV-15 aprovada. Subcollection /maturity/{current|history/{YYYY-MM-DD}}.
     // Aluno lê próprio, mentor lê alunos dele. Apenas CF (admin SDK) escreve.

--- a/src/version.js
+++ b/src/version.js
@@ -341,10 +341,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.56.1',
-  build: '20260504',
-  display: 'v1.56.1',
-  full: '1.56.1+20260504',
+  version: '1.56.2',
+  build: '20260504h',
+  display: 'v1.56.2',
+  full: '1.56.2+20260504h',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

Sem essa regra o listener do hook `usePayments` (#250/#252) era negado silenciosamente em prod e o card "Recebido em {mês}" mostrava sempre R$ 0,00 mesmo havendo pagamentos.

3 linhas em `firestore.rules`. Análogo à regra de `collectionGroup('subscriptions')`.

## ⚠️ Deploy de rules necessário

Merge sozinho **não** atualiza as rules em prod. Após merge, rodar:

```
firebase deploy --only firestore:rules
```

## Test plan

- [x] Build verde (não toca código)
- [ ] Pós-deploy de rules: card "Recebido em maio" mostra valores reais
- [ ] Click em chip de mês: bloco "Recebidos" preenchido

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)