### PR TITLE
fix(#266): relatório diário Assinaturas — auto-recovery + label + BRT today

### DIFF
--- a/docs/dev/issues/issue-266-subscription-email-overdue.md
+++ b/docs/dev/issues/issue-266-subscription-email-overdue.md
@@ -1,0 +1,125 @@
+# Issue #266 — fix: relatório diário Assinaturas mostra renovações futuras como inadimplentes
+
+> Template enxuto (R4). Worktree: `~/projects/issue-266` · Branch: `fix/issue-266-subscription-email-overdue` · Versão reservada: **v1.61.1**
+
+## Autorização
+
+- [x] Mockup — exceção autorizada (bug fix, sem UI nova; label do email descrito em texto)
+- [x] Memória de cálculo — apresentada no issue body (auto-recovery table)
+- [x] Marcio autorizou — 11/05/2026 "confirmo"
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Email diário do CF `checkSubscriptions` (recebido por Marcio em 11/05/2026) classificou 4 assinaturas com `renewalDate` no FUTURO como "INADIMPLENTES EM ABERTO": Wilson (21/05), Yoaquim (03/12), Rodrigo (31/05), Gizele (31/05). Gizele também com R$ 0,00 — diagnóstico próprio. Causa raiz documentada no issue body: CF não tem auto-recovery + label cosmético usa `Math.abs` + `updateSubscription` UI é cego.
+
+## Spec
+
+Ver issue body: #266.
+
+## Mockup — label do email
+
+```
+ANTES (bug)                                    DEPOIS (fix)
+INADIMPLENTES EM ABERTO                        INADIMPLENTES EM ABERTO
+• Wilson — venceu 21/05/2026 (10 dias)         • João Paulo — venceu há 96 dias (03/02/2026)
+                                               • Rafael — venceu há 10 dias (01/05/2026)
+
+                                               (Wilson/Yoaquim/Rodrigo/Gizele saem
+                                                desta seção após auto-recovery; aparecem
+                                                em "Vencendo Hoje" / "Vencendo em 7 Dias"
+                                                / silenciosas, conforme daysToRenewal)
+```
+
+## Memória de cálculo — auto-recovery no CF
+
+**Inputs:**
+- `sub.status` em `students/{uid}/subscriptions/{subId}` (Firestore)
+- `sub.renewalDate` (Timestamp)
+- `sub.gracePeriodDays` (default 5)
+- `student.loginBlockedReason` em `students/{uid}` (default null)
+
+**Cálculo:**
+- `today` = data do CF (00:00:00 BRT)
+- `daysToRenewal = daysBetween(today, renewalDate)` (assinado; positivo = futuro)
+- `graceDays = sub.gracePeriodDays ?? 5`
+
+**Decisão para sub com `status === 'overdue'`:**
+
+| Condição | Ação no Firestore | Roteamento no email |
+|---|---|---|
+| `daysToRenewal > 7` (futuro, longe) | `status → active`. Se `student.loginBlockedReason === 'auto'`: desbloqueia (`loginBlocked: false`, `loginBlockedReason: null`, Auth user enabled) | silenciosa (só conta em totalActive + monthlyRevenue) |
+| `1 ≤ daysToRenewal ≤ 7` | `status → active` + desbloqueio condicional | `expiringSoon` |
+| `daysToRenewal === 0` | `status → active` + desbloqueio condicional | `expiringToday` |
+| `-graceDays ≤ daysToRenewal < 0` | `status → active` + desbloqueio condicional (assinatura dentro do grace = ainda ativa por política) | `expiringToday` (atenção: já vencida, dentro do grace) |
+| `daysToRenewal < -graceDays` | mantém `status: 'overdue'` | `existingOverdue` (comportamento atual) |
+| `renewalDate` ausente/inválido | mantém `status: 'overdue'` | `existingOverdue` |
+
+**Exemplo numérico — Wilson em 11/05/2026:**
+- `sub.status = 'overdue'`, `sub.renewalDate = 21/05/2026`, `graceDays = 5`
+- `daysToRenewal = 10` → cai em "futuro, longe"
+- Firestore: batch update `status: 'active'`. Se student.loginBlockedReason === 'auto': desbloqueia.
+- Email: silenciosa (não aparece em nenhuma seção).
+
+**Casos limites:**
+- Trial com status='overdue' — N/A, trial usa `expired`, não `overdue`. Lógica do trial não muda.
+- Sub com `status='active'` e `renewalDate < -graceDays` — comportamento atual mantido (vira `newOverdue`).
+- Múltiplas subs do mesmo student — auto-recovery por sub individualmente.
+- Sub com `gracePeriodDays === 0` — `-graceDays === 0`, então `daysToRenewal === 0` ainda recupera (today). Negativo qualquer cai em existingOverdue.
+
+## Memória de cálculo — label cosmético
+
+**ANTES (`checkSubscriptions.js:75-79`):**
+```js
+const days = Math.abs(daysBetween(today, date));
+const dateLabel = isOverdue
+  ? `venceu ${formatBrDate(date)} (${days} dias)`
+  : `vence ${formatBrDate(date)}`;
+```
+
+**DEPOIS:**
+```js
+const diff = daysBetween(today, date);  // assinado
+let dateLabel;
+if (diff < 0) {
+  dateLabel = `venceu há ${Math.abs(diff)} dia${Math.abs(diff) === 1 ? '' : 's'} (${formatBrDate(date)})`;
+} else if (diff === 0) {
+  dateLabel = `vence hoje (${formatBrDate(date)})`;
+} else {
+  dateLabel = `vence em ${diff} dia${diff === 1 ? '' : 's'} (${formatBrDate(date)})`;
+}
+```
+
+Aplica em ambas as seções (newOverdue e existingOverdue). Plural correto.
+
+## Phases
+
+- F0 — diagnóstico readonly em prod: subs com `status='overdue'` + `renewalDate >= today − graceDays`; também investigar Gizele R$ 0,00 (script `scripts/issue-266-diag-overdue.mjs`)
+- F1 — testes unitários (INV-05): auto-recovery (5 cenários) + label (3 cenários) + defensive hook (2 cenários)
+- F2 — fix CF (`functions/subscriptions/checkSubscriptions.js`): auto-recovery + desbloqueio + label
+- F3 — defensive `updateSubscription` (`src/hooks/useSubscriptions.js`): renewalDate futuro + status overdue → reset active
+- F4 — deploy CF (`firebase deploy --only functions:checkSubscriptions`)
+- F5 — verificação D+1: email do dia seguinte sem Wilson/Yoaquim/Rodrigo (Gizele com diagnóstico próprio em F0)
+- F6 — encerramento via `cc-close-issue.sh 266`
+
+## Sessions
+
+_(preenche durante execução, 1 linha/task)_
+
+## Shared Deltas
+
+- `src/version.js` — bump 1.61.0 → 1.61.1, build 20260511 (já tem entrada CHANGELOG reservada)
+- `docs/registry/versions.md` — marcar v1.61.1 consumida
+- `docs/registry/chunks.md` — liberar CHUNK-02 (ESCRITA #266)
+- `CHANGELOG.md` — nova entrada `[1.61.1] - 11/05/2026`
+
+## Decisions
+
+_(ID texto em docs/decisions.md)_
+
+- DEC-AUTO-266-01 — auto-recovery no CF é safe-by-default: status overdue só é mantido quando renewalDate < today − graceDays. Reconcilia divergência entre UI (computa on-the-fly) e CF (lê literal Firestore).
+- DEC-AUTO-266-02 — desbloqueio de Auth fica condicional a `loginBlockedReason === 'auto'`. Bloqueios manuais (mentor) não são revertidos automaticamente. Mirror simétrico do autobloqueio em G1 #263.
+
+## Chunks
+
+- CHUNK-02 Student (ESCRITA) — toca CF `checkSubscriptions` (subscriptions subcollection + students doc) + hook `useSubscriptions` (defensive em updateSubscription)

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -12,3 +12,4 @@
 | CHUNK-06 (Emotional) — leitura | #259 | `feat/issue-259-cycle-closure` | 07/05/2026 | input pra eventos comportamentais e curva emocional |
 | CHUNK-08 (Mentor Feedback) — leitura | #259 | `feat/issue-259-cycle-closure` | 07/05/2026 | input pra mentor.threadsHighlighted |
 | CHUNK-09 (Onboarding/4D) — leitura | #259 | `feat/issue-259-cycle-closure` | 07/05/2026 | input pra maturity scores |
+| CHUNK-02 (Student) — ESCRITA | #266 | `fix/issue-266-subscription-email-overdue` | 11/05/2026 | fix relatório diário Assinaturas: auto-recovery CF + label cosmético + defensive updateSubscription |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -31,3 +31,4 @@
 | 1.56.3 | #256 | `fix/issue-256-filter-counters-intersect` | 05/05/2026 | consumida (PR #257 squash `2f1bfe48`) |
 | 1.58.0 | #259 | `feat/issue-259-cycle-closure` | 07/05/2026 | reservada — pula 1.57.x consumida em hot-patches (#258, polish, fix balão) sem registro no registry |
 | 1.61.0 | #263 | `feat/issue-263-students-plan-filter` | 07/05/2026 | consumida (PR #265 squash `c00681c2`) |
+| 1.61.1 | #266 | `fix/issue-266-subscription-email-overdue` | 11/05/2026 | reservada — fix relatório diário Assinaturas (overdue recovery + label) |

--- a/functions/__tests__/subscriptions/helpers.test.js
+++ b/functions/__tests__/subscriptions/helpers.test.js
@@ -1,0 +1,160 @@
+/**
+ * Tests: helpers de subscription (issue #266)
+ *
+ * Cobre:
+ *  - getBrazilToday (calendar day em BRT, robusto contra TZ do servidor)
+ *  - daysBetweenSigned (assinado, baseado em calendar day BRT)
+ *  - formatDateLabel (futuro/hoje/passado + plural)
+ *  - classifyOverdueSub (auto-recovery)
+ *
+ * Convenção dos testes: instâncias de Date usam o construtor Date.UTC com 03:00
+ * para representar BRT-midnight (mesma forma que getBrazilToday devolve).
+ * Isso isola os testes da timezone do shell rodando vitest.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  getBrazilToday,
+  daysBetweenSigned,
+  formatDateLabel,
+  classifyOverdueSub,
+} = require('../../subscriptions/helpers.js');
+
+// BRT midnight para a calendar day informada (UTC 03:00).
+const brtMidnight = (y, m, d) => new Date(Date.UTC(y, m - 1, d, 3, 0, 0, 0));
+
+describe('getBrazilToday', () => {
+  it('11/05/2026 às 11:00 UTC (08:00 BRT) → BRT midnight 11/05/2026', () => {
+    const now = new Date('2026-05-11T11:00:00Z');
+    expect(getBrazilToday(now).toISOString()).toBe(brtMidnight(2026, 5, 11).toISOString());
+  });
+  it('11/05/2026 às 02:00 UTC (= 10/05 23:00 BRT) → BRT midnight 10/05/2026', () => {
+    const now = new Date('2026-05-11T02:00:00Z');
+    expect(getBrazilToday(now).toISOString()).toBe(brtMidnight(2026, 5, 10).toISOString());
+  });
+  it('11/05/2026 às 23:00 UTC (= 11/05 20:00 BRT) → BRT midnight 11/05/2026', () => {
+    const now = new Date('2026-05-11T23:00:00Z');
+    expect(getBrazilToday(now).toISOString()).toBe(brtMidnight(2026, 5, 11).toISOString());
+  });
+});
+
+describe('daysBetweenSigned (BRT calendar day)', () => {
+  it('retorna 0 para o mesmo dia BRT', () => {
+    expect(daysBetweenSigned(brtMidnight(2026, 5, 11), brtMidnight(2026, 5, 11))).toBe(0);
+  });
+  it('retorna positivo quando to é no futuro', () => {
+    expect(daysBetweenSigned(brtMidnight(2026, 5, 11), brtMidnight(2026, 5, 21))).toBe(10);
+  });
+  it('retorna negativo quando to é no passado', () => {
+    expect(daysBetweenSigned(brtMidnight(2026, 5, 11), brtMidnight(2026, 5, 1))).toBe(-10);
+  });
+  it('hora do instante não afeta o resultado (mesma calendar day BRT)', () => {
+    const t1 = new Date('2026-05-11T11:00:00Z'); // BRT 08:00 May 11
+    const t2 = new Date('2026-05-11T23:00:00Z'); // BRT 20:00 May 11
+    expect(daysBetweenSigned(t1, t2)).toBe(0);
+  });
+});
+
+describe('formatDateLabel (issue #266)', () => {
+  const today = brtMidnight(2026, 5, 11);
+
+  it('data futura > 1 dia: "vence em N dias (DD/MM/YYYY)"', () => {
+    expect(formatDateLabel(today, brtMidnight(2026, 5, 21))).toBe('vence em 10 dias (21/05/2026)');
+  });
+  it('data futura 1 dia: "vence amanhã"', () => {
+    expect(formatDateLabel(today, brtMidnight(2026, 5, 12))).toBe('vence amanhã (12/05/2026)');
+  });
+  it('data hoje: "vence hoje"', () => {
+    expect(formatDateLabel(today, brtMidnight(2026, 5, 11))).toBe('vence hoje (11/05/2026)');
+  });
+  it('data ontem: "venceu ontem"', () => {
+    expect(formatDateLabel(today, brtMidnight(2026, 5, 10))).toBe('venceu ontem (10/05/2026)');
+  });
+  it('data passada > 1 dia: "venceu há N dias"', () => {
+    expect(formatDateLabel(today, brtMidnight(2026, 5, 1))).toBe('venceu há 10 dias (01/05/2026)');
+  });
+  it('caso do bug Wilson Fu — antes saía "venceu 21/05/2026 (10 dias)" para data futura', () => {
+    const label = formatDateLabel(today, brtMidnight(2026, 5, 21));
+    expect(label).not.toMatch(/^venceu/);
+    expect(label).toMatch(/^vence em/);
+  });
+});
+
+describe('classifyOverdueSub (auto-recovery #266)', () => {
+  const today = brtMidnight(2026, 5, 11);
+
+  // ── Casos de RECOVERY ──
+
+  it('renewalDate 10 dias no futuro → recover, urgency=silent (caso Wilson Fu)', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 21), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('recover');
+    expect(r.urgency).toBe('silent');
+    expect(r.daysToRenewal).toBe(10);
+  });
+
+  it('renewalDate 206 dias no futuro → recover, urgency=silent (caso Yoaquim)', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 12, 3), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('recover');
+    expect(r.urgency).toBe('silent');
+    expect(r.daysToRenewal).toBe(206);
+  });
+
+  it('renewalDate em 7 dias → recover, urgency=soon', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 18), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('recover');
+    expect(r.urgency).toBe('soon');
+  });
+
+  it('renewalDate hoje → recover, urgency=today', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 11), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('recover');
+    expect(r.urgency).toBe('today');
+  });
+
+  it('renewalDate -3 dias (dentro do grace de 5) → recover, urgency=today', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 8), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('recover');
+    expect(r.urgency).toBe('today');
+    expect(r.daysToRenewal).toBe(-3);
+  });
+
+  it('renewalDate exatamente -5 dias (limite do grace) → recover', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 6), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('recover');
+    expect(r.urgency).toBe('today');
+  });
+
+  // ── Casos de KEEP_OVERDUE ──
+
+  it('renewalDate -6 dias (1 dia além do grace) → keep_overdue', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 5), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('keep_overdue');
+  });
+
+  it('renewalDate -97 dias (caso João Paulo) → keep_overdue', () => {
+    const r = classifyOverdueSub({ renewalDate: brtMidnight(2026, 2, 3), gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('keep_overdue');
+    expect(r.daysToRenewal).toBe(-97);
+  });
+
+  it('renewalDate ausente → keep_overdue (nada a recuperar)', () => {
+    const r = classifyOverdueSub({ renewalDate: null, gracePeriodDays: 5 }, today);
+    expect(r.action).toBe('keep_overdue');
+    expect(r.daysToRenewal).toBe(null);
+  });
+
+  // ── Default de grace ──
+
+  it('gracePeriodDays ausente usa default 5', () => {
+    expect(classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 6) }, today).action).toBe('recover');
+    expect(classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 5) }, today).action).toBe('keep_overdue');
+  });
+
+  it('gracePeriodDays 0 → qualquer atraso mantém overdue', () => {
+    expect(classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 11), gracePeriodDays: 0 }, today).action).toBe('recover');
+    expect(classifyOverdueSub({ renewalDate: brtMidnight(2026, 5, 10), gracePeriodDays: 0 }, today).action).toBe('keep_overdue');
+  });
+});

--- a/functions/subscriptions/checkSubscriptions.js
+++ b/functions/subscriptions/checkSubscriptions.js
@@ -3,20 +3,28 @@
  * @description Verifica assinaturas diariamente às 8h BRT.
  *   1. Detecta assinaturas vencendo em 7 dias (paid) e trials expirando
  *   2. Detecta e marca inadimplentes (renewalDate + gracePeriod ultrapassados)
- *   3. Expira trials automaticamente quando trialEndsAt < hoje
- *   4. Sincroniza accessTier no documento do student
- *   5. Envia email consolidado ao mentor se houver ocorrências
+ *   3. Recupera subs overdue cujo renewalDate voltou pro futuro (issue #266)
+ *   4. Expira trials automaticamente quando trialEndsAt < hoje
+ *   5. Sincroniza accessTier no documento do student
+ *   6. Envia email consolidado ao mentor se houver ocorrências
  *
  * DEC-055: Subscriptions como subcollection de students
  * DEC-056: type trial/paid + trialEndsAt + accessTier
  *
- * Issue: #094
+ * Issue: #094 + #266 (auto-recovery + label cosmético + today em BRT)
  * Path: students/{studentId}/subscriptions/{subId}
  * Email: via collection `mail` (firebase/firestore-send-email extension)
  */
 
 const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
+const {
+  getBrazilToday,
+  daysBetweenSigned,
+  formatBrDate,
+  formatDateLabel,
+  classifyOverdueSub,
+} = require('./helpers');
 
 if (!admin.apps.length) admin.initializeApp();
 const db = admin.firestore();
@@ -24,24 +32,11 @@ const db = admin.firestore();
 const MENTOR_EMAIL = 'marcio.portes@me.com';
 const FROM_EMAIL = 'Tchio-Alpha <marcio.portes@me.com>';
 
-// ── Helpers ──────────────────────────────────────────────
-
-const formatBrDate = (date) => {
-  if (!date) return '-';
-  const d = date instanceof Date ? date : date.toDate ? date.toDate() : new Date(date);
-  return d.toLocaleDateString('pt-BR', { timeZone: 'America/Sao_Paulo' });
-};
+// ── Helpers locais (não puros) ───────────────────────────
 
 const formatCurrency = (value, currency = 'BRL') => {
   if (value === undefined || value === null || isNaN(value)) return 'R$ 0,00';
   return new Intl.NumberFormat('pt-BR', { style: 'currency', currency }).format(value);
-};
-
-const daysBetween = (from, to) => {
-  const msPerDay = 1000 * 60 * 60 * 24;
-  const f = new Date(from); f.setHours(0, 0, 0, 0);
-  const t = new Date(to); t.setHours(0, 0, 0, 0);
-  return Math.ceil((t - f) / msPerDay);
 };
 
 const toDate = (val) => {
@@ -69,14 +64,13 @@ const buildReportHtml = (today, sections, summaryData) => {
   const renderSection = (title, items, color, isOverdue = false) => {
     if (items.length === 0) return '';
     const rows = items.map(s => {
-      const date = isOverdue
-        ? toDate(s.type === 'trial' ? s.trialEndsAt : s.renewalDate)
-        : toDate(s.type === 'trial' ? s.trialEndsAt : s.renewalDate);
-      const days = Math.abs(daysBetween(today, date));
+      const date = toDate(s.type === 'trial' ? s.trialEndsAt : s.renewalDate);
       const typeLabel = s.type === 'trial' ? ' [Trial]' : '';
-      const dateLabel = isOverdue
-        ? `venceu ${formatBrDate(date)} (${days} dias)`
-        : `vence ${formatBrDate(date)}`;
+      // Issue #266: label condicional por sinal de daysBetween — antes usava
+      // Math.abs e dizia "venceu" para data futura quando isOverdue=true.
+      const dateLabel = date
+        ? formatDateLabel(today, date)
+        : (isOverdue ? 'data de vencimento indefinida' : 'vence em data indefinida');
       const valueLabel = s.type === 'paid' ? ` — ${formatCurrency(s.amount, s.currency)}` : '';
       return `<p style="color:#e2e8f0;font-size:14px;margin:4px 0;">&bull; <strong>${s._studentName}${typeLabel}</strong> — ${dateLabel}${valueLabel}</p>`;
     }).join('');
@@ -108,8 +102,9 @@ module.exports = functions.pubsub
   .schedule('0 11 * * *') // 11:00 UTC = 08:00 BRT
   .timeZone('America/Sao_Paulo')
   .onRun(async () => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    // Issue #266: usa calendar day BRT em vez de UTC midnight (que produzia
+    // subject com data D-1 e comparações com TZ inconsistente).
+    const today = getBrazilToday();
 
     try {
       // Busca todos os students
@@ -134,6 +129,10 @@ module.exports = functions.pubsub
       // o loop, processados após o batch.commit (admin.auth não é batcheável).
       const authDisableQueue = [];
 
+      // Issue #266: students cuja sub recuperou-se de overdue → reenable Auth
+      // se loginBlockedReason==='auto'.
+      const authEnableQueue = [];
+
       // Itera por cada student
       for (const studentDoc of studentsSnap.docs) {
         const student = studentDoc.data();
@@ -152,7 +151,7 @@ module.exports = functions.pubsub
           if (sub.type === 'trial' && sub.status === 'active') {
             const trialEnd = toDate(sub.trialEndsAt);
             if (trialEnd) {
-              const daysLeft = daysBetween(today, trialEnd);
+              const daysLeft = daysBetweenSigned(today, trialEnd);
               if (daysLeft < 0) {
                 // Trial expirou → marcar expired
                 batch.update(subDoc.ref, {
@@ -181,7 +180,7 @@ module.exports = functions.pubsub
           if (sub.type !== 'trial' && sub.status === 'active') {
             const renewalDate = toDate(sub.renewalDate);
             if (renewalDate) {
-              const daysToRenewal = daysBetween(today, renewalDate);
+              const daysToRenewal = daysBetweenSigned(today, renewalDate);
               const graceDays = sub.gracePeriodDays ?? 5;
 
               if (daysToRenewal < -graceDays) {
@@ -227,8 +226,50 @@ module.exports = functions.pubsub
             continue;
           }
 
-          // ── Paid: overdue (já existente) ──
+          // ── Paid: overdue (com auto-recovery — issue #266) ──
           if (sub.status === 'overdue') {
+            const renewalDate = toDate(sub.renewalDate);
+            const decision = classifyOverdueSub(
+              { renewalDate, gracePeriodDays: sub.gracePeriodDays },
+              today,
+            );
+
+            if (decision.action === 'recover') {
+              // renewalDate voltou pro futuro (ou está dentro do grace) — restaura.
+              batch.update(subDoc.ref, {
+                status: 'active',
+                updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+              });
+              batchCount++;
+
+              // Mirror do autobloqueio: se foi auto-bloqueado, libera.
+              if (student.loginBlocked === true && student.loginBlockedReason === 'auto') {
+                batch.update(studentDoc.ref, {
+                  loginBlocked: false,
+                  loginBlockedAt: admin.firestore.FieldValue.delete(),
+                  loginBlockedBy: admin.firestore.FieldValue.delete(),
+                  loginBlockedReason: admin.firestore.FieldValue.delete(),
+                });
+                batchCount++;
+                authEnableQueue.push(studentDoc.id);
+              }
+
+              // Roteia no email pela urgência da renovação atual.
+              const recoveredSub = { ...subWithMeta, status: 'active' };
+              if (decision.urgency === 'today') {
+                sections.expiringToday.push(recoveredSub);
+              } else if (decision.urgency === 'soon') {
+                sections.expiringSoon.push(recoveredSub);
+              }
+              // urgency='silent' → não aparece em seção (só conta no resumo).
+              totalActive++;
+              monthlyRevenue += sub.amount ?? 0;
+              const tier = resolveAccessTier({ ...sub, status: 'active' });
+              if (tier !== 'none') bestTier = tier;
+              continue;
+            }
+
+            // keep_overdue → comportamento original.
             sections.existingOverdue.push(subWithMeta);
             totalOverdue++;
             const tier = resolveAccessTier(sub);
@@ -274,6 +315,20 @@ module.exports = functions.pubsub
         }
       }
 
+      // Issue #266: re-habilita Auth para students recuperados de overdue.
+      for (const uid of authEnableQueue) {
+        try {
+          await admin.auth().updateUser(uid, { disabled: false });
+          console.log(`[checkSubscriptions] Auth re-enabled (recovery): ${uid}`);
+        } catch (e) {
+          if (e.code === 'auth/user-not-found') {
+            console.log(`[checkSubscriptions] Auth user ${uid} não existe — student doc desbloqueado mesmo assim`);
+          } else {
+            console.error(`[checkSubscriptions] Falha ao re-habilitar Auth ${uid}:`, e);
+          }
+        }
+      }
+
       // Envia email se houver ocorrências
       const hasOccurrences = Object.values(sections).some(arr => arr.length > 0);
 
@@ -291,7 +346,7 @@ module.exports = functions.pubsub
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
         });
 
-        console.log(`[checkSubscriptions] Email enviado. Hoje: ${sections.expiringToday.length}, 7d: ${sections.expiringSoon.length}, trials: ${sections.trialsExpiring.length}, novos overdue: ${sections.newOverdue.length}, overdue: ${sections.existingOverdue.length}`);
+        console.log(`[checkSubscriptions] Email enviado. Hoje: ${sections.expiringToday.length}, 7d: ${sections.expiringSoon.length}, trials: ${sections.trialsExpiring.length}, novos overdue: ${sections.newOverdue.length}, overdue: ${sections.existingOverdue.length}, recuperados: ${authEnableQueue.length}`);
       } else {
         console.log('[checkSubscriptions] Sem ocorrencias — email nao enviado');
       }

--- a/functions/subscriptions/helpers.js
+++ b/functions/subscriptions/helpers.js
@@ -1,0 +1,146 @@
+/**
+ * helpers.js — pure helpers para checkSubscriptions CF
+ *
+ * Extraídos para permitir testes unitários (vitest em functions/__tests__/).
+ *
+ * Issue: #266
+ */
+
+// ── Date helpers ─────────────────────────────────────────
+
+/**
+ * Retorna a "data de hoje" em BRT (UTC-3, fixo desde 2019) como instante
+ * absoluto de BRT-midnight = UTC 03:00 do calendar day BRT.
+ *
+ * Bug histórico: `new Date(); setHours(0,0,0,0)` no servidor UTC dá UTC midnight,
+ * que ao formatar em BRT volta 21:00 do dia anterior → email mostrava data errada
+ * no subject (e.g. "10/05/2026" quando hoje era 11). Esta função usa Intl para
+ * obter o calendar day em BRT e devolve um Date BRT-midnight estável.
+ */
+const getBrazilToday = (nowDate = new Date()) => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Sao_Paulo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(nowDate);
+  const get = (t) => parts.find((p) => p.type === t).value;
+  const y = parseInt(get('year'), 10);
+  const m = parseInt(get('month'), 10);
+  const d = parseInt(get('day'), 10);
+  // BRT midnight = UTC 03:00 do calendar day BRT
+  return new Date(Date.UTC(y, m - 1, d, 3, 0, 0, 0));
+};
+
+/**
+ * Calcula diferença assinada em dias entre `from` e `to`, usando o calendar day
+ * em BRT (UTC-3 fixo). Robusto contra TZ do servidor (testes locais vs Cloud
+ * Functions em UTC).
+ *
+ * Positivo = to no futuro BRT, negativo = to no passado BRT.
+ */
+const daysBetweenSigned = (from, to) => {
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const brOffsetMs = 3 * 60 * 60 * 1000; // BRT = UTC-3
+  const calendarDayMs = (d) => {
+    const inst = d instanceof Date ? d : new Date(d);
+    // Desloca o instante para "BRT clock" e pega o dia UTC dessa data deslocada.
+    const brShifted = new Date(inst.getTime() - brOffsetMs);
+    return Date.UTC(brShifted.getUTCFullYear(), brShifted.getUTCMonth(), brShifted.getUTCDate());
+  };
+  return Math.round((calendarDayMs(to) - calendarDayMs(from)) / msPerDay);
+};
+
+const formatBrDate = (date) => {
+  if (!date) return '-';
+  const d = date instanceof Date ? date : date.toDate ? date.toDate() : new Date(date);
+  return d.toLocaleDateString('pt-BR', { timeZone: 'America/Sao_Paulo' });
+};
+
+// ── Label do email ───────────────────────────────────────
+
+/**
+ * Formata label de data para o email de assinaturas.
+ *
+ * - Futuro: "vence em N dias (DD/MM/YYYY)" ou "vence amanhã (DD/MM/YYYY)"
+ * - Hoje: "vence hoje (DD/MM/YYYY)"
+ * - Passado: "venceu há N dias (DD/MM/YYYY)" ou "venceu ontem (DD/MM/YYYY)"
+ *
+ * Issue #266 — antes o label sempre dizia "venceu" para qualquer sub em
+ * existingOverdue, mesmo quando a data era futura (bug do Math.abs).
+ */
+const formatDateLabel = (today, date) => {
+  const dateStr = formatBrDate(date);
+  const diff = daysBetweenSigned(today, date);
+  if (diff < 0) {
+    const n = Math.abs(diff);
+    if (n === 1) return `venceu ontem (${dateStr})`;
+    return `venceu há ${n} dias (${dateStr})`;
+  }
+  if (diff === 0) return `vence hoje (${dateStr})`;
+  if (diff === 1) return `vence amanhã (${dateStr})`;
+  return `vence em ${diff} dias (${dateStr})`;
+};
+
+// ── Auto-recovery de subs overdue ────────────────────────
+
+/**
+ * Decide o que fazer com uma sub com `status === 'overdue'` no CF.
+ *
+ * Issue #266 — bug raiz: CF lia literal `sub.status` e empurrava para
+ * existingOverdue sem re-avaliar `renewalDate`. updateSubscription cego
+ * permitia bump de renewalDate pro futuro com status preso em 'overdue'.
+ *
+ * @param {object} sub - { renewalDate: Date|null, gracePeriodDays?: number }
+ * @param {Date} today - data do CF (00:00:00 BRT)
+ * @returns {object} {
+ *   action: 'recover' | 'keep_overdue',
+ *   urgency: 'today' | 'soon' | 'silent' | null,
+ *   daysToRenewal: number | null,
+ * }
+ *
+ * action='recover' significa:
+ *  - Firestore: batch update status: 'active'
+ *  - Student: se loginBlockedReason === 'auto', desbloqueia
+ *  - Email: rotear por urgency
+ *
+ * action='keep_overdue':
+ *  - Firestore: sem update
+ *  - Email: push em existingOverdue (comportamento original)
+ */
+const classifyOverdueSub = (sub, today) => {
+  const renewalDate = sub.renewalDate;
+  if (!renewalDate) {
+    return { action: 'keep_overdue', urgency: null, daysToRenewal: null };
+  }
+  const daysToRenewal = daysBetweenSigned(today, renewalDate);
+  const graceDays = sub.gracePeriodDays ?? 5;
+
+  // Passado além do grace → mantém overdue
+  if (daysToRenewal < -graceDays) {
+    return { action: 'keep_overdue', urgency: null, daysToRenewal };
+  }
+
+  // Dentro do grace OU futuro → recupera
+  let urgency;
+  if (daysToRenewal < 0) {
+    // dentro do grace (já vencida mas ainda dentro do prazo de tolerância)
+    urgency = 'today';
+  } else if (daysToRenewal === 0) {
+    urgency = 'today';
+  } else if (daysToRenewal <= 7) {
+    urgency = 'soon';
+  } else {
+    urgency = 'silent';
+  }
+
+  return { action: 'recover', urgency, daysToRenewal };
+};
+
+module.exports = {
+  getBrazilToday,
+  daysBetweenSigned,
+  formatBrDate,
+  formatDateLabel,
+  classifyOverdueSub,
+};

--- a/scripts/issue-266-diag-overdue.mjs
+++ b/scripts/issue-266-diag-overdue.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * issue-266-diag-overdue.mjs — diagnóstico READONLY
+ *
+ * Objetivo: medir escopo do bug do email diário de Assinaturas antes do fix.
+ *
+ * Lista todas as subs com `status === 'overdue'` agrupadas por:
+ *   1. RECOVERABLE — renewalDate >= today − graceDays (vão ser recuperadas
+ *      automaticamente pelo CF após deploy do fix #266)
+ *   2. LEGÍTIMAS — renewalDate ainda além do grace (continuam overdue)
+ *   3. SEM_RENEWAL — renewalDate ausente (excepção)
+ *
+ * Também sinaliza:
+ *   - student.loginBlocked === true + loginBlockedReason === 'auto' (auto-unlock
+ *     será aplicado no recovery)
+ *   - amount === 0 ou ausente (caso Gizele)
+ *   - type === 'vip' marcado como overdue (anormal — VIPs não vencem)
+ *
+ * EXECUÇÃO (somente readonly, idempotente):
+ *   gcloud auth application-default login   # uma vez
+ *   node scripts/issue-266-diag-overdue.mjs
+ */
+
+import { createRequire } from 'node:module';
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..');
+const LOGS_DIR = join(PROJECT_ROOT, 'scripts', 'logs');
+const PROJECT_ID = 'acompanhamento-20';
+
+const require = createRequire(import.meta.url);
+const admin = require(join(PROJECT_ROOT, 'functions', 'node_modules', 'firebase-admin'));
+if (!admin.apps.length) admin.initializeApp({ projectId: PROJECT_ID });
+const db = admin.firestore();
+
+// Helpers (mirror de functions/subscriptions/helpers.js, BRT-aware).
+const getBrazilToday = () => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Sao_Paulo',
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).formatToParts(new Date());
+  const get = (t) => parts.find((p) => p.type === t).value;
+  return new Date(Date.UTC(+get('year'), +get('month') - 1, +get('day'), 3, 0, 0, 0));
+};
+
+const daysBetween = (from, to) => {
+  const msPerDay = 1000 * 60 * 60 * 24;
+  const brOffsetMs = 3 * 60 * 60 * 1000;
+  const calendarDayMs = (d) => {
+    const shifted = new Date(d.getTime() - brOffsetMs);
+    return Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate());
+  };
+  return Math.round((calendarDayMs(to) - calendarDayMs(from)) / msPerDay);
+};
+
+const formatBR = (d) => d ? d.toLocaleDateString('pt-BR', { timeZone: 'America/Sao_Paulo' }) : '-';
+
+async function main() {
+  const today = getBrazilToday();
+  console.log(`\n📊 issue-266 — diagnóstico overdue subs [${formatBR(today)}]\n`);
+
+  const studentsSnap = await db.collection('students').get();
+  console.log(`   students lidos: ${studentsSnap.size}\n`);
+
+  const recoverable = [];
+  const legit = [];
+  const noRenewal = [];
+  const anomalies = []; // amount=0, type=vip overdue, etc.
+
+  for (const studentDoc of studentsSnap.docs) {
+    const student = studentDoc.data();
+    const studentName = student.name ?? student.email ?? studentDoc.id;
+
+    const subsSnap = await studentDoc.ref.collection('subscriptions').get();
+    for (const subDoc of subsSnap.docs) {
+      const sub = subDoc.data();
+      if (sub.status !== 'overdue') continue;
+
+      const renewalDate = sub.renewalDate?.toDate?.() ?? null;
+      const grace = sub.gracePeriodDays ?? 5;
+      const daysToRenewal = renewalDate ? daysBetween(today, renewalDate) : null;
+      const willRecover = renewalDate && daysToRenewal >= -grace;
+
+      const entry = {
+        studentId: studentDoc.id,
+        studentName,
+        subId: subDoc.id,
+        type: sub.type,
+        plan: sub.plan,
+        amount: sub.amount,
+        currency: sub.currency,
+        renewalDate: renewalDate ? formatBR(renewalDate) : null,
+        daysToRenewal,
+        grace,
+        loginBlocked: student.loginBlocked === true,
+        loginBlockedReason: student.loginBlockedReason ?? null,
+        willAutoUnlock: student.loginBlocked === true && student.loginBlockedReason === 'auto',
+      };
+
+      // Sinalizadores de anomalias.
+      const flags = [];
+      if (!sub.amount || sub.amount === 0) flags.push('amount_zero');
+      if (sub.type === 'vip') flags.push('vip_overdue_inesperado');
+      if (sub.type === 'trial') flags.push('trial_overdue_inesperado');
+      if (flags.length) {
+        entry.flags = flags;
+        anomalies.push(entry);
+      }
+
+      if (!renewalDate) {
+        noRenewal.push(entry);
+      } else if (willRecover) {
+        recoverable.push(entry);
+      } else {
+        legit.push(entry);
+      }
+    }
+  }
+
+  // ── Output ──
+  console.log(`── RECUPERÁVEIS (renewalDate >= today − grace) ── ${recoverable.length}\n`);
+  for (const r of recoverable) {
+    const unlock = r.willAutoUnlock ? ' [+auto-unlock]' : '';
+    console.log(`  ${r.studentName} (${r.studentId})`);
+    console.log(`    sub: ${r.subId} · type=${r.type} · plan=${r.plan} · amount=${r.amount} ${r.currency}`);
+    console.log(`    renewalDate=${r.renewalDate} (${r.daysToRenewal} dias) · grace=${r.grace}${unlock}`);
+  }
+
+  console.log(`\n── LEGÍTIMOS (renewalDate < today − grace) ── ${legit.length}\n`);
+  for (const r of legit) {
+    console.log(`  ${r.studentName} — renewalDate=${r.renewalDate} (${r.daysToRenewal} dias)`);
+  }
+
+  console.log(`\n── SEM RENEWAL_DATE ── ${noRenewal.length}\n`);
+  for (const r of noRenewal) {
+    console.log(`  ${r.studentName} (${r.subId}) — type=${r.type} plan=${r.plan}`);
+  }
+
+  console.log(`\n── ANOMALIAS (independente de categoria) ── ${anomalies.length}\n`);
+  for (const r of anomalies) {
+    console.log(`  ${r.studentName} — flags=[${r.flags.join(',')}] · type=${r.type} · amount=${r.amount}`);
+  }
+
+  // Persiste log.
+  if (!existsSync(LOGS_DIR)) mkdirSync(LOGS_DIR, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const path = join(LOGS_DIR, `issue-266-diag-${ts}.json`);
+  writeFileSync(path, JSON.stringify({
+    today: formatBR(today),
+    counts: {
+      recoverable: recoverable.length,
+      legit: legit.length,
+      noRenewal: noRenewal.length,
+      anomalies: anomalies.length,
+    },
+    recoverable, legit, noRenewal, anomalies,
+  }, null, 2));
+  console.log(`\n📝 Log: ${path}\n`);
+}
+
+main().catch((err) => {
+  console.error('\n💥 erro:', err);
+  process.exit(1);
+});

--- a/src/__tests__/utils/subscriptions.test.js
+++ b/src/__tests__/utils/subscriptions.test.js
@@ -225,6 +225,61 @@ describe('Subscription Business Logic (DEC-055/DEC-056)', () => {
     });
   });
 
+  describe('defensive auto-reset em updateSubscription (issue #266)', () => {
+    // Espelha a lógica em useSubscriptions.js: se renewalDate é updated para
+    // futuro/dentro-do-grace e status atual é 'overdue', reset para 'active'.
+    // Issue #266 — previne email diário caso mentor renove via UI sem registrar
+    // payment (que é o único path que setava status=active explicitamente).
+    //
+    // Testes usam Date com constructor local-time (Y,M-1,D) para isolar da TZ
+    // do shell que roda vitest (em BRT, ISO 'YYYY-MM-DD' é UTC e shifta o dia).
+    const shouldAutoReset = (sub, updates) => {
+      if (!('renewalDate' in updates) || !updates.renewalDate) return false;
+      if (sub.status !== 'overdue') return false;
+      if ('status' in updates) return false;
+      const renewalDate = updates.renewalDate instanceof Date
+        ? updates.renewalDate
+        : new Date(updates.renewalDate);
+      const now = new Date(2026, 4, 11); // 11/05/2026 local
+      const grace = sub.gracePeriodDays ?? 5;
+      const daysToRenewal = Math.ceil((renewalDate - now) / (1000 * 60 * 60 * 24));
+      return daysToRenewal >= -grace;
+    };
+
+    it('reseta para active quando overdue + renewalDate futuro', () => {
+      const sub = makePaidSub({ status: 'overdue' });
+      expect(shouldAutoReset(sub, { renewalDate: new Date(2026, 4, 21) })).toBe(true);
+    });
+
+    it('reseta para active quando overdue + renewalDate dentro do grace', () => {
+      const sub = makePaidSub({ status: 'overdue', gracePeriodDays: 5 });
+      // 08/05 = -3 dias está dentro do grace
+      expect(shouldAutoReset(sub, { renewalDate: new Date(2026, 4, 8) })).toBe(true);
+    });
+
+    it('NÃO reseta quando overdue + renewalDate ainda além do grace', () => {
+      const sub = makePaidSub({ status: 'overdue', gracePeriodDays: 5 });
+      // 05/05 = -6 dias além do grace
+      expect(shouldAutoReset(sub, { renewalDate: new Date(2026, 4, 5) })).toBe(false);
+    });
+
+    it('NÃO reseta se status atual não é overdue (sub já active)', () => {
+      const sub = makePaidSub({ status: 'active' });
+      expect(shouldAutoReset(sub, { renewalDate: new Date(2026, 4, 21) })).toBe(false);
+    });
+
+    it('NÃO reseta se renewalDate não está em updates', () => {
+      const sub = makePaidSub({ status: 'overdue' });
+      expect(shouldAutoReset(sub, { amount: 1500 })).toBe(false);
+    });
+
+    it('NÃO sobrescreve status explicitamente passado em updates', () => {
+      const sub = makePaidSub({ status: 'overdue' });
+      // Mentor explicitamente quer status='paused' — não pode virar 'active'
+      expect(shouldAutoReset(sub, { renewalDate: new Date(2026, 4, 21), status: 'paused' })).toBe(false);
+    });
+  });
+
   describe('calculateSummary', () => {
     it('calcula summary com mix trial/paid', () => {
       const now = new Date('2026-04-04');

--- a/src/hooks/useSubscriptions.js
+++ b/src/hooks/useSubscriptions.js
@@ -285,12 +285,34 @@ export const useSubscriptions = () => {
       }
     }
 
+    // Issue #266 — defensive: se renewalDate está sendo atualizado para
+    // futuro/dentro-do-grace e o status atual é 'overdue', reseta para 'active'
+    // no mesmo update. Evita reincidência: até hoje o CF reads literal status e
+    // mostrava no email diário como inadimplente mesmo após renovação manual.
+    // (status explicitamente passado em updates tem precedência — não sobrescreve.)
+    if (
+      'renewalDate' in cleanUpdates &&
+      cleanUpdates.renewalDate &&
+      sub.status === 'overdue' &&
+      !('status' in updates)
+    ) {
+      const renewalDate = cleanUpdates.renewalDate.toDate
+        ? cleanUpdates.renewalDate.toDate()
+        : new Date(cleanUpdates.renewalDate);
+      const now = new Date(); now.setHours(0, 0, 0, 0);
+      const grace = sub.gracePeriodDays ?? 5;
+      const daysToRenewal = Math.ceil((renewalDate - now) / (1000 * 60 * 60 * 24));
+      if (daysToRenewal >= -grace) {
+        cleanUpdates.status = 'active';
+      }
+    }
+
     await updateDoc(ref, cleanUpdates);
 
-    // Sincroniza accessTier se plan/status/type mudaram. Caso típico: upgrade
-    // espelho → alpha (issue #263). Sem isso o doc do student fica defasado.
-    if ('plan' in updates || 'status' in updates || 'type' in updates) {
-      const updatedSub = { ...sub, ...updates };
+    // Sincroniza accessTier se plan/status/type mudaram (inclui o auto-reset
+    // de status acima — usa cleanUpdates, não updates).
+    if ('plan' in cleanUpdates || 'status' in cleanUpdates || 'type' in cleanUpdates) {
+      const updatedSub = { ...sub, ...updates, ...(cleanUpdates.status ? { status: cleanUpdates.status } : {}) };
       const otherSubs = subscriptions.filter(s => s.studentId === sub.studentId && s.id !== sub.id);
       const activeSub = [updatedSub, ...otherSubs]
         .find(s => s.status === 'active' && s.type !== 'vip');

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.61.1: [RESERVADA — issue #266] fix relatório diário de Assinaturas: auto-recovery no CF checkSubscriptions (sub overdue com renewalDate futuro/dentro do grace volta para active + desbloqueio quando autobloqueio era 'auto') + label cosmético do email (vence em N dias / venceu há N dias) + defensive em updateSubscription (renewalDate futuro com status=overdue reseta para active). Entrada definitiva no encerramento.
  * - 1.61.0: feat filtro Alpha/Espelho na tela de Alunos + click → dashboard (View As). StudentsManagement passa a abranger plan ∈ {alpha, self_service}; chips de filtro de plano; row clicável; limpeza N+1 de trades + perfil emocional inline removido (vai pro dashboard). Pula 1.59.0/1.60.0 (implícitas para #260/#261). Entrada definitiva no encerramento.
  * - 1.58.0: [RESERVADA — issue #259] feat ritual completo de fechamento de ciclo (wizard 8 etapas + Kelly real + Monte Carlo + IA stub heurístico + camada mentor: inbox, comment panel, modo demonstração). Entrada definitiva no encerramento.
  * - 1.57.2: balão whatsappState volta para a coluna Ações (não fica mais junto do nome) — coerente com os outros botões de ação por linha (05/05/2026, hot-patch direto em main)


### PR DESCRIPTION
## Summary

3 bugs no email diário de Assinaturas:

1. **Auto-recovery no CF (raiz)** — subs com `status='overdue'` mas `renewalDate` voltado pro futuro (renovação manual via `updateSubscription`) ficavam presas em "Inadimplentes em Aberto" indefinidamente. Agora CF re-avalia: se `renewalDate >= today − grace`, batch update `status:'active'` + desbloqueio condicional do Auth user (mirror simétrico do autobloqueio G1 #263, só se `loginBlockedReason==='auto'`).

2. **Label cosmético** — `Math.abs(daysBetween)` dizia "venceu 21/05/2026 (10 dias)" para data **futura**. Agora: `vence em N dias` / `vence hoje` / `vence amanhã` / `venceu ontem` / `venceu há N dias` com plural correto.

3. **Subject com data D-1** — `new Date(); setHours(0,0,0,0)` no servidor UTC = 21:00 BRT do dia anterior. Agora `getBrazilToday()` via `Intl.DateTimeFormat` + `Date.UTC` retorna BRT-midnight estável. `daysBetweenSigned` reescrito pra usar calendar day BRT (UTC-3 fixo desde 2019), robusto contra TZ do servidor.

**Defensive no UI** — `useSubscriptions.updateSubscription`: se `renewalDate` é updated pro futuro/dentro-do-grace e status atual é `'overdue'`, reset `'active'` no mesmo update (preserva status explícito em `updates`).

## Diagnóstico em prod (readonly)

Script `scripts/issue-266-diag-overdue.mjs` rodado em 11/05/2026 — confirma escopo:
- **4 recuperáveis**: Wilson Fu (21/05, +10d), Yoaquim (03/12, +206d), Rodrigo Caio (31/05, +20d), Gizele (31/05, +20d, amount=0 = saldo de aulas a cumprir, dado correto).
- **5 legítimos** (ficam overdue): Rafael "Sael", João Paulo Silva, German Hartenstein, Renato, Jurandyr.

## Validação pós-deploy

Deploy manual `firebase deploy --only functions:checkSubscriptions` + trigger via `gcloud scheduler jobs run`:
```
Batch: 4 operacoes
overdue: 5, recuperados: 0   ← era overdue: 9 antes do fix
```
Os 4 batch updates batem exatos com o diagnóstico (Wilson, Yoaquim, Rodrigo, Gizele moved from overdue → active). Email recebido com layout correto.

## Test plan

- [x] `npm test` (root) — 3023 passed (190 files)
- [x] `npm test` (functions) — 108 passed (7 files), inclui 24 novos em `__tests__/subscriptions/helpers.test.js`
- [x] `npm run lint src/hooks/useSubscriptions.js` — zero erros, zero warnings novos
- [x] Diagnóstico readonly em prod confirma 4 recuperáveis + 5 legítimos
- [x] Deploy + trigger manual da CF: batch=4, overdue 9→5, email enviado com subject `11/05/2026` correto
- [ ] Email D+1 (12/05 08:00 BRT) sem regressão

## Decisões

- **DEC-AUTO-266-01** — auto-recovery no CF é safe-by-default: status overdue só é mantido quando `renewalDate < today − graceDays`. Reconcilia divergência entre UI (computa on-the-fly) e CF (lê literal Firestore).
- **DEC-AUTO-266-02** — desbloqueio de Auth fica condicional a `loginBlockedReason === 'auto'`. Bloqueios manuais (mentor) não são revertidos automaticamente. Mirror simétrico do autobloqueio em G1 #263.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)