### PR TITLE
fix(#271): regra Firestore bloqueia activateStudent — accessStatus fora da allowlist (v1.61.3)

### DIFF
--- a/docs/dev/issues/issue-271-firestore-rules-accessstatus.md
+++ b/docs/dev/issues/issue-271-firestore-rules-accessstatus.md
@@ -1,0 +1,50 @@
+# Issue #271 — fix: regra Firestore bloqueia activateStudent — accessStatus fora da allowlist
+
+## Autorização
+
+- [x] Mockup — exceção (fix de regra/auth, sem UI nova)
+- [x] Memória de cálculo — exceção (sem fórmula, mudança de allowlist + idempotência)
+- [x] Marcio autorizou — "siga" (12/05/2026, após diagnóstico apresentado em chat)
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Continuação do #270 (v1.61.2). Hotfix reordenou `getAccessStatus` priorizando `firstLoginAt`, mas o sintoma persistiu em prod porque os docs estão com `firstLoginAt: null` mesmo após login real.
+
+Causa raiz real: a regra do Firestore em `firestore.rules:42-47` permite ao aluno (`isOwner`) atualizar apenas `['status', 'firstLoginAt', 'onboardingStatus']`. `AuthContext.activateStudent` tenta escrever 3 campos incluindo `accessStatus: 'active'` — fora da allowlist. Regra rejeita o update inteiro; o `catch` faz `console.error` e engole. Nada é gravado.
+
+Regressão silenciosa do DEC-AUTO-263-07 — campo `accessStatus` adicionado no cliente sem propagar para a regra.
+
+## Spec
+
+Ver issue body no GitHub: #271.
+
+## Phases
+
+- A1 — `firestore.rules` adicionar `'accessStatus'` na allowlist (linha 45)
+- A2 — `AuthContext.activateStudent` guard idempotente (`accessStatus !== 'active'` em vez de `status === 'pending'`) nos dois callers
+- A3 — teste de regressão (mock do `updateDoc` confirmando os 3 campos enviados)
+- B1 — `functions/scripts/sync-access-from-auth.js` (backfill via service account)
+- C1 — bump v1.61.3 + CHANGELOG
+- D1 — PR + merge + deploy rules + run backfill em prod
+
+## Sessions
+
+_(preencher conforme avança)_
+
+## Shared Deltas
+
+- `src/version.js` — bump v1.61.3
+- `docs/registry/versions.md` — marcar v1.61.3 consumida (no encerramento)
+- `docs/registry/chunks.md` — liberar CHUNK-01 + CHUNK-02 (no encerramento)
+- `CHANGELOG.md` — nova entrada `[1.61.3] - 12/05/2026 · #271`
+
+## Decisions
+
+- DEC-AUTO-271-01 — allowlist do `isOwner` em `firestore.rules` inclui `accessStatus` (propaga DEC-AUTO-263-07 para a regra)
+- DEC-AUTO-271-02 — `activateStudent` idempotente baseado em `accessStatus !== 'active'` (não em `status === 'pending'`)
+
+## Chunks
+
+- CHUNK-01 (Auth) — ESCRITA: `firestore.rules` + `AuthContext.activateStudent`
+- CHUNK-02 (Student) — ESCRITA: data shape via rules + backfill em `/students`

--- a/firestore.rules
+++ b/firestore.rules
@@ -39,10 +39,14 @@ service cloud.firestore {
       allow create, delete: if isMentor();
       // Mentor pode tudo; aluno pode atualizar campos do seu próprio doc
       // DEC-024: onboardingStatus é do aluno (progressão no assessment)
+      // DEC-AUTO-271-01 (#271): accessStatus incluído — AuthContext.activateStudent
+      // escreve {status, accessStatus, firstLoginAt} no 1º login do aluno.
+      // Antes disto, regra rejeitava o update inteiro (allowlist hasOnly), nada era
+      // gravado e badge "aguardando 1º login" persistia. Regressão de DEC-AUTO-263-07.
       allow update: if isMentor() || (
         isOwner(studentId) &&
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(
-          ['status', 'firstLoginAt', 'onboardingStatus']
+          ['status', 'firstLoginAt', 'onboardingStatus', 'accessStatus']
         )
       );
 

--- a/functions/scripts/sync-access-from-auth.js
+++ b/functions/scripts/sync-access-from-auth.js
@@ -1,0 +1,128 @@
+/**
+ * sync-access-from-auth.js
+ * @description Backfill manual de /students após fix do firestore.rules (#271).
+ *
+ * Para cada doc com `accessStatus !== 'active'` cujo email tem Auth user e
+ * `metadata.lastSignInTime`, escreve no doc:
+ *   { status: 'active', accessStatus: 'active', firstLoginAt: lastSignInTime }
+ *
+ * Cenário coberto: alunos cuja escrita do AuthContext.activateStudent falhou
+ * silenciosamente entre DEC-AUTO-263-07 e #271 (regra do Firestore rejeitava
+ * accessStatus). Sem o backfill, esses só voltam ao state correto na próxima
+ * vez que reabrirem a app (onAuthStateChanged dispara activateStudent — que
+ * agora passa pela regra).
+ *
+ * Idempotente: docs já active são pulados.
+ *
+ * Modos:
+ *   `node sync-access-from-auth.js`            → dry-run, lista o que faria
+ *   `node sync-access-from-auth.js --apply`    → aplica as escritas
+ *
+ * Service account: usar credentials default do gcloud (ADC) ou
+ * GOOGLE_APPLICATION_CREDENTIALS apontando para chave JSON.
+ */
+
+const admin = require('firebase-admin');
+admin.initializeApp({ projectId: 'acompanhamento-20' });
+const db = admin.firestore();
+const auth = admin.auth();
+
+const APPLY = process.argv.includes('--apply');
+
+(async () => {
+  const mode = APPLY ? 'APPLY (write)' : 'DRY-RUN (no write)';
+  console.log(`\n== sync-access-from-auth — ${mode} ==\n`);
+
+  const snap = await db.collection('students').get();
+  const counts = {
+    total: snap.size,
+    skipped_active: 0,
+    skipped_no_email: 0,
+    skipped_no_auth: 0,
+    skipped_never_signed_in: 0,
+    candidate: 0,
+    applied: 0,
+    errors: 0,
+  };
+  const candidates = [];
+
+  for (const docSnap of snap.docs) {
+    const data = docSnap.data();
+
+    if (data.accessStatus === 'active') {
+      counts.skipped_active += 1;
+      continue;
+    }
+    if (!data.email) {
+      counts.skipped_no_email += 1;
+      continue;
+    }
+
+    let user;
+    try {
+      user = await auth.getUserByEmail(data.email);
+    } catch (e) {
+      if (e.code === 'auth/user-not-found') {
+        counts.skipped_no_auth += 1;
+        continue;
+      }
+      console.error(`[${docSnap.id}] erro getUserByEmail:`, e.code || e.message);
+      counts.errors += 1;
+      continue;
+    }
+
+    const lastSignInISO = user.metadata?.lastSignInTime;
+    if (!lastSignInISO) {
+      counts.skipped_never_signed_in += 1;
+      continue;
+    }
+
+    const firstLoginAt = admin.firestore.Timestamp.fromDate(new Date(lastSignInISO));
+
+    counts.candidate += 1;
+    candidates.push({
+      id: docSnap.id,
+      name: data.name,
+      email: data.email,
+      curStatus: data.status ?? '(undef)',
+      curAccess: data.accessStatus ?? '(undef)',
+      curFirstLogin: data.firstLoginAt ? 'set' : 'null',
+      lastSignIn: lastSignInISO,
+    });
+
+    if (APPLY) {
+      try {
+        await docSnap.ref.update({
+          status: 'active',
+          accessStatus: 'active',
+          firstLoginAt,
+        });
+        counts.applied += 1;
+      } catch (e) {
+        console.error(`[${docSnap.id}] erro update:`, e.message);
+        counts.errors += 1;
+      }
+    }
+  }
+
+  console.log('\n--- candidatos ---');
+  candidates.forEach((c) => {
+    console.log(
+      `  ${c.id.slice(0, 8)}… | ${c.name ?? '(sem nome)'} | ${c.email}\n` +
+      `    status=${c.curStatus} accessStatus=${c.curAccess} firstLoginAt=${c.curFirstLogin}\n` +
+      `    lastSignIn (Auth) = ${c.lastSignIn}`,
+    );
+  });
+
+  console.log('\n--- contagens ---');
+  Object.entries(counts).forEach(([k, v]) => console.log(`  ${k}: ${v}`));
+
+  if (!APPLY && counts.candidate > 0) {
+    console.log('\nDry-run completo. Para aplicar: node sync-access-from-auth.js --apply');
+  }
+
+  process.exit(counts.errors > 0 ? 1 : 0);
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/__tests__/utils/studentActivation.test.js
+++ b/src/__tests__/utils/studentActivation.test.js
@@ -1,0 +1,69 @@
+/**
+ * studentActivation.test.js
+ * @description Política de ativação no 1º login do aluno — issue #271.
+ * @see src/utils/studentActivation.js
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldActivateStudent, buildActivatePayload } from '../../utils/studentActivation';
+
+describe('shouldActivateStudent', () => {
+  it('aluno já ativo (accessStatus="active") → false (idempotente)', () => {
+    expect(shouldActivateStudent({ id: 'u1', accessStatus: 'active' })).toBe(false);
+  });
+
+  it('issue #271 — accessStatus="pending" + status="active" (doc inconsistente) → true', () => {
+    // Regressão central: antes do #271 o guard era status === 'pending'.
+    // Alunos com status='active' (legado, ou createInlineStudent → promote) mas
+    // accessStatus='pending' (porque rules bloqueou a escrita no 1º login)
+    // ficavam fora da auto-recuperação. Agora o guard usa accessStatus.
+    expect(shouldActivateStudent({ id: 'u1', accessStatus: 'pending', status: 'active' })).toBe(true);
+  });
+
+  it('aluno novo (accessStatus="pending" + status="pending") → true', () => {
+    expect(shouldActivateStudent({ id: 'u1', accessStatus: 'pending', status: 'pending' })).toBe(true);
+  });
+
+  it('aluno sem accessStatus (doc legado pré-DEC-AUTO-263-07) → true', () => {
+    expect(shouldActivateStudent({ id: 'u1', status: 'pending' })).toBe(true);
+    expect(shouldActivateStudent({ id: 'u1' })).toBe(true);
+  });
+
+  it('accessStatus="none" (criado via createInlineStudent, sem Auth ainda) → true', () => {
+    // Cobertura: se o doc foi promovido (createInlineStudent → createStudent
+    // modo PROMOTE) o accessStatus vira 'pending'. Mas se algum caminho der
+    // login ao aluno antes (improvável), com accessStatus='none', ainda assim
+    // queremos que activate dispare. Política: !== 'active' ativa.
+    expect(shouldActivateStudent({ id: 'u1', accessStatus: 'none' })).toBe(true);
+  });
+
+  it('student null/undefined/sem id → false (defesa contra input inválido)', () => {
+    expect(shouldActivateStudent(null)).toBe(false);
+    expect(shouldActivateStudent(undefined)).toBe(false);
+    expect(shouldActivateStudent({})).toBe(false);
+    expect(shouldActivateStudent({ accessStatus: 'pending' })).toBe(false);
+  });
+});
+
+describe('buildActivatePayload', () => {
+  it('payload contém exatamente os 3 campos da allowlist em firestore.rules', () => {
+    const sentinel = Symbol('serverTimestamp');
+    const payload = buildActivatePayload(sentinel);
+    expect(Object.keys(payload).sort()).toEqual(['accessStatus', 'firstLoginAt', 'status']);
+    expect(payload.status).toBe('active');
+    expect(payload.accessStatus).toBe('active');
+    expect(payload.firstLoginAt).toBe(sentinel);
+  });
+
+  it('regression — payload NÃO inclui campos fora da allowlist (rules quebraria)', () => {
+    // Allowlist em firestore.rules:45 (após #271): status, firstLoginAt,
+    // onboardingStatus, accessStatus. Se alguém adicionar um 4º campo aqui
+    // sem propagar para a regra, repete o bug do DEC-AUTO-263-07. Esse teste
+    // protege a invariante.
+    const ALLOWED_FIELDS = new Set(['status', 'firstLoginAt', 'onboardingStatus', 'accessStatus']);
+    const payload = buildActivatePayload(null);
+    Object.keys(payload).forEach((k) => {
+      expect(ALLOWED_FIELDS.has(k)).toBe(true);
+    });
+  });
+});

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -15,6 +15,7 @@ import {
 } from 'firebase/auth';
 import { collection, query, where, getDocs, updateDoc, doc, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '../firebase';
+import { shouldActivateStudent, buildActivatePayload } from '../utils/studentActivation';
 
 const AuthContext = createContext(null);
 
@@ -55,17 +56,15 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  // Atualizar status do aluno para ativo (1º login na plataforma)
-  // DEC-AUTO-263-07: marca accessStatus='active' — esse é o sinal canônico
-  // de que passou pelo ritual completo (convite + 1º login).
-  const activateStudent = async (studentId) => {
+  // Ativa aluno no 1º login (idempotente — política em studentActivation).
+  // DEC-AUTO-263-07: accessStatus='active' é o sinal canônico do ritual completo.
+  // DEC-AUTO-271-02 (#271): callers passam o student inteiro; decisão e
+  // payload moram em src/utils/studentActivation.js (testáveis).
+  const activateStudent = async (student) => {
+    if (!shouldActivateStudent(student)) return;
     try {
-      await updateDoc(doc(db, 'students', studentId), {
-        status: 'active',
-        accessStatus: 'active',
-        firstLoginAt: serverTimestamp()
-      });
-      console.log('[AuthContext] Aluno ativado:', studentId);
+      await updateDoc(doc(db, 'students', student.id), buildActivatePayload(serverTimestamp()));
+      console.log('[AuthContext] Aluno ativado:', student.id);
     } catch (err) {
       console.error('[AuthContext] Erro ao ativar:', err);
     }
@@ -83,12 +82,10 @@ export const AuthProvider = ({ children }) => {
         });
         setUserRole(role);
 
-        // Se é aluno, verificar e ativar se pending
+        // Se é aluno, verificar e ativar (idempotente — só escreve se accessStatus !== 'active').
         if (role === 'student') {
           const student = await checkStudentWhitelist(firebaseUser.email);
-          if (student && student.status === 'pending') {
-            await activateStudent(student.id);
-          }
+          if (student) await activateStudent(student);
         }
       } else {
         setUser(null);
@@ -120,10 +117,8 @@ export const AuthProvider = ({ children }) => {
           throw { code: 'auth/not-authorized', message: 'Email não autorizado. Contate seu mentor.' };
         }
 
-        // Se é aluno novo (pending), ativa
-        if (student.status === 'pending') {
-          await activateStudent(student.id);
-        }
+        // Ativa (idempotente — só escreve se accessStatus !== 'active')
+        await activateStudent(student);
       }
 
       setUserRole(role);

--- a/src/utils/studentActivation.js
+++ b/src/utils/studentActivation.js
@@ -1,0 +1,34 @@
+/**
+ * studentActivation
+ * @description Helpers puros para o fluxo "1º login do aluno → marca doc como
+ *              ativo". A política de quando escrever vive aqui (testável); o
+ *              side-effect (updateDoc) fica no AuthContext.
+ *
+ *              DEC-AUTO-271-02 (#271): a decisão de ativar baseia-se em
+ *              `accessStatus !== 'active'`, não em `status === 'pending'`.
+ *              Antes, alunos com doc inconsistente (status='active' por outro
+ *              caminho, accessStatus='pending') ficavam fora da auto-recuperação.
+ */
+
+/**
+ * @param {Object|null} student  doc real-time do Firestore com {id, accessStatus, ...}
+ * @returns {boolean}            true → o caller deve disparar o update
+ */
+export const shouldActivateStudent = (student) => {
+  if (!student?.id) return false;
+  return student.accessStatus !== 'active';
+};
+
+/**
+ * Payload exato escrito em /students/{id} no 1º login.
+ * Os 3 campos coincidem com a allowlist do `isOwner` em firestore.rules
+ * (DEC-AUTO-271-01). Mudar a lista aqui = atualizar a regra junto.
+ *
+ * @param {*} serverTimestampValue  resultado de `serverTimestamp()` do SDK
+ * @returns {Object}
+ */
+export const buildActivatePayload = (serverTimestampValue) => ({
+  status: 'active',
+  accessStatus: 'active',
+  firstLoginAt: serverTimestampValue,
+});

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.61.3: #271 fix causa raiz do badge "aguardando 1º login" — regra Firestore bloqueava activateStudent. firestore.rules:45 allowlist do isOwner não incluía 'accessStatus' (regressão silenciosa do DEC-AUTO-263-07 que adicionou esse campo ao update no cliente sem propagar para a regra); update inteiro era rejeitado, catch engolia o erro e nada era escrito — firstLoginAt ficava null mesmo após login. Fix em 4 frentes: (A1) firestore.rules adiciona 'accessStatus' na allowlist; (A2) AuthContext.activateStudent extraída para src/utils/studentActivation.js (shouldActivateStudent + buildActivatePayload puros) com guard idempotente `accessStatus !== 'active'` (substitui status === 'pending', cobre docs com status='active' inconsistente); (A3) 8 testes novos protegendo invariante allowlist↔payload; (B1) functions/scripts/sync-access-from-auth.js backfilla docs em prod com lastSignInTime do Firebase Auth (idempotente; dry-run default; --apply para escrever). Auto-recovery sem backfill: sessão Firebase Auth válida + reabrir app → onAuthStateChanged dispara activateStudent → regra agora passa → doc fica certo. Suite 3037/3037. Entrada definitiva no encerramento.
  * - 1.61.2: #270 fix badge "aguardando 1º login" persistia após login real. getAccessStatus em studentClassify.js priorizava o campo declarativo accessStatus antes da evidência firstLoginAt — reordem coloca firstLoginAt como sinal de maior precedência. Alunos com doc inconsistente (accessStatus='pending' + firstLoginAt populado, comum em legados pré-DEC-AUTO-263-07 e em alunos onde AuthContext.activateStudent não disparou por status !== 'pending') voltam a aparecer como "ativo". Mudança puramente derivada (sem deploy de CF, sem migração de dados). 6 testes novos no describe getAccessStatus cobrindo regressão + precedências. Suite 3029/3029. Hotfix direto em main (12/05/2026).
  * - 1.61.1: fix relatório diário de Assinaturas: auto-recovery no CF checkSubscriptions (sub overdue com renewalDate futuro/dentro do grace volta para active + desbloqueio quando autobloqueio era 'auto') + label cosmético do email (vence em N dias / venceu há N dias) + defensive em updateSubscription (renewalDate futuro com status=overdue reseta para active). Entrada definitiva no encerramento.
  * - 1.61.0: feat filtro Alpha/Espelho na tela de Alunos + click → dashboard (View As). StudentsManagement passa a abranger plan ∈ {alpha, self_service}; chips de filtro de plano; row clicável; limpeza N+1 de trades + perfil emocional inline removido (vai pro dashboard). Pula 1.59.0/1.60.0 (implícitas para #260/#261). Entrada definitiva no encerramento.
@@ -353,10 +354,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.61.2',
+  version: '1.61.3',
   build: '20260512',
-  display: 'v1.61.2',
-  full: '1.61.2+20260512',
+  display: 'v1.61.3',
+  full: '1.61.3+20260512',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Summary

- **Causa raiz** descoberta após #270 (v1.61.2): `firestore.rules:45` não incluía `'accessStatus'` na allowlist do `isOwner`. `AuthContext.activateStudent` tentava escrever esse campo no 1º login, regra rejeitava o update inteiro, catch engolia. Resultado: `firstLoginAt` ficava `null` e badge "aguardando" persistia. Regressão silenciosa do DEC-AUTO-263-07.
- **Fix em 4 frentes**: (A1) rules ganham `'accessStatus'`; (A2) política de `activateStudent` extraída para `src/utils/studentActivation.js` com guard idempotente baseado em `accessStatus !== 'active'`; (A3) 8 testes incluindo invariante `payload ⊆ allowlist`; (B1) script `sync-access-from-auth.js` para backfillar docs em prod usando `lastSignInTime` do Firebase Auth.
- **Auto-recovery sem backfill**: alunos com sessão Firebase Auth válida se autorrecuperam ao reabrir a app.

## Test plan

- [x] `npx vitest run` — 3037/3037 verde (8 novos em `studentActivation.test.js`)
- [x] `npm run build` — verde
- [ ] Após merge: `firebase deploy --only firestore:rules` (deploy de regra, ~30s)
- [ ] Após deploy: `node functions/scripts/sync-access-from-auth.js` (dry-run em prod)
- [ ] Validar lista de candidatos com Marcio; depois `--apply`
- [ ] Confirmar badge muda para "ativo" na tela Acompanhamento

## Risk

- Rules: mudança restrita à allowlist do `isOwner` em `/students/{id}`. `isMentor` segue podendo tudo. Não afeta nenhuma outra collection.
- AuthContext: idempotência preservada por `shouldActivateStudent`; chamadas extras não escrevem. Teste de invariante `payload ⊆ allowlist` protege contra repetir DEC-AUTO-263-07.
- Script: dry-run por padrão; `--apply` exige flag explícita.

## Related

- #270 (v1.61.2 — hotfix do lado de leitura — `getAccessStatus`)
- DEC-AUTO-263-07 (introdução do `accessStatus`)
- DEC-AUTO-271-01 / DEC-AUTO-271-02 (decisões deste PR)

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)