### PR TITLE
feat(#285): timezone explícito no horário do trade — MEP/MEN correto (manual + backend)

### DIFF
--- a/docs/dev/issues/issue-285-trade-timezone.md
+++ b/docs/dev/issues/issue-285-trade-timezone.md
@@ -1,0 +1,57 @@
+# Issue #285 — feat: timezone explícito no horário do trade (MEP/MEN manual+import + gate de promoção)
+
+> Template enxuto (R4). Spec completa no body do #285 (link, não duplicar).
+
+## Autorização (OBRIGATÓRIA — sem isto é PROIBIDO iniciar desenvolvimento)
+
+**Status: AUTORIZADO (27/05/2026, "go" do Marcio)**
+- [x] Mockup apresentado (seletor sticky no AddTradeModal + helper "Equivalente BRT" + botão "Recalcular MEP/MEN" no TradeDetail)
+- [x] Memória de cálculo apresentada (offset por data+tz com DST automático; ISO+offset gravado; enrich HAS_TZ já cobre)
+- [x] 4 decisões resolvidas: (a) sticky+default por instrumento, (b) legado como está, (c) manual+backend agora/import fast-follow, (INV-15) ISO+offset
+- [x] Marcio autorizou (27/05/2026, "go")
+- [x] Gate Pré-Código liberado
+
+## Context
+Horário de entrada/saída do trade é gravado naive (sem tz), manual e import. Enrich MEP/MEN assume Brasília fixo, mas o aluno lê ET/CT na plataforma → janela Yahoo desalinhada → MEP/MEN errado/`unavailable`. Corrompe o gate de promoção `advanced-metrics` (exige ≥80% trades com mep/men). Ambiguidade nasce no input.
+
+## Spec
+Ver issue body no GitHub: #285. (Link, não duplicar.)
+
+## Mockup
+_(a apresentar — seletor de fuso no campo de hora do AddTradeModal; campo de fuso por lote no wizard de import; ação "recalcular MEP/MEN")_
+
+## Memória de Cálculo
+_(a apresentar — `excursionWindow = [toAbsolute(entryTime, tz), toAbsolute(exitTime, tz)]` UTC → Yahoo 1m → LONG MEP=max(high)/MEN=min(low) rel. à entrada; ET com DST vs Brasília fixo)_
+
+## Decisões em aberto (Gate Pré-Código)
+- (a) Default do seletor de fuso manual.
+- (b) Tratamento do legado naive (Brasília-assumido vs backfill).
+- (c) Import: campo de fuso agora ou fast-follow.
+- (INV-15) Design do campo: instante absoluto (ISO+offset) vs naive + campo `timezone`.
+
+## Phases
+_(a definir após decisões)_
+- A1 — schema/storage do tz no trade (INV-15)
+- A2 — AddTradeModal: seletor de fuso + gravação do instante absoluto
+- A3 — enrich usa tz do trade (remove Brasília fixo)
+- A4 — enrich no update (onTradeUpdated) + ação "recalcular MEP/MEN" + guard idempotência
+- B* — import (CSV/Order): fuso por lote (condicional decisão c)
+- C* — legado (condicional decisão b)
+- testes em cada fase (INV-05)
+
+## Shared Deltas
+- `src/version.js` — bump v1.68.0 (reservada)
+- `docs/registry/versions.md` — marcar v1.68.0 consumida
+- `docs/registry/chunks.md` — liberar CHUNK-04 (+ CHUNK-07/10 se decisão c)
+- `CHANGELOG.md` — nova entrada `[1.68.0]`
+- `docs/firestore-schema.md` — campo novo do trade (tz) — INV-15
+- `docs/cloud-functions.md` — enrich no update (onTradeUpdated)
+
+## Decisions
+_(IDs — texto em docs/decisions.md no encerramento)_
+
+## Chunks
+- CHUNK-04 (escrita) — schema do trade + enrich + AddTradeModal
+- CHUNK-07 (escrita, condicional c) — wizard CSV import
+- CHUNK-10 (escrita, condicional c) — order import
+- CHUNK-06/maturity (leitura) — dependência do gate

--- a/functions/index.js
+++ b/functions/index.js
@@ -1437,8 +1437,13 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
       ? after.mentorClearedViolations : []).slice().sort());
     const clearedChanged = fpClearedBefore !== fpClearedAfter;
 
+    // Issue #285 — detectar mudança em entryTime/exitTime (re-enrich MEP/MEN com a
+    // nova janela) ou mepPrice zerado pela ação "Recalcular MEP/MEN" da UI.
+    const timeChanged = before.entryTime !== after.entryTime || before.exitTime !== after.exitTime;
+    const mepCleared = before.mepPrice != null && after.mepPrice == null;
+
     // Guard: se apenas riskPercent/rrRatio/compliance/redFlags mudaram, é loop da própria CF
-    if (!resultChanged && !planChanged && !complianceChanged && !clearedChanged) {
+    if (!resultChanged && !planChanged && !complianceChanged && !clearedChanged && !timeChanged && !mepCleared) {
       return null;
     }
     
@@ -1545,6 +1550,26 @@ exports.onTradeUpdated = functions.firestore.document('trades/{tradeId}').onUpda
         console.log(`[onTradeUpdated] Maturity recomputado por toggle de cleared (student=${after.studentId}, before=${fpClearedBefore}, after=${fpClearedAfter})`);
       } catch (recomputeErr) {
         console.error('[onTradeUpdated] Erro recompute maturity (cleared toggle):', recomputeErr);
+      }
+    }
+
+    // === ISSUE #285 — RE-ENRICH MEP/MEN POR MUDANÇA DE HORA/TZ OU RECALCULAR ===
+    // Hora/tz mudou OU aluno clicou "Recalcular MEP/MEN" (mepPrice virou null).
+    // O guard interno de `runEnrichment` faz no-op se mep/men já preenchidos,
+    // então o re-enrich só acontece quando a chamada faz sentido (mep null).
+    // Falha silenciosa por design (enrich é best-effort, não bloqueia o update).
+    // Loop guard: a própria escrita do enrich só muda mep/men/excursionSource, que
+    // não estão em nenhum dos detectores acima → próximo trigger early-return.
+    if (timeChanged || mepCleared) {
+      try {
+        const { runEnrichment } = require('./marketData/enrichTradeWithExcursions');
+        const tradeId = context.params.tradeId;
+        const result = await runEnrichment({ tradeId }, { db });
+        if (!result.ok && !result.skipped) {
+          console.log(`[onTradeUpdated] re-enrich (${timeChanged ? 'hora/tz' : 'recalcular'}): ${result.reason}`);
+        }
+      } catch (enrichErr) {
+        console.warn('[onTradeUpdated] erro re-enrich (suprimido):', enrichErr.message);
       }
     }
 

--- a/src/__tests__/functions/marketData/runEnrichment.test.js
+++ b/src/__tests__/functions/marketData/runEnrichment.test.js
@@ -297,3 +297,73 @@ describe('runEnrichment — bug 1 #267 (janela busca o horário de Brasília, n�
     );
   });
 });
+
+describe('runEnrichment — issue #285 (entryTime com offset explícito do fuso do trade)', () => {
+  it('entryTime ET 16:23 (EDT/-04:00) busca Yahoo na janela 20:23 UTC (não Brasília)', async () => {
+    // Cenário real: aluno lança NQ lendo TradingView em ET, app grava ISO+offset.
+    const trade = futuresTrade({
+      entryTime: '2026-05-27T16:23:00-04:00', // 16:23 ET = 20:23 UTC
+      exitTime: '2026-05-27T17:45:00-04:00',  // 17:45 ET = 21:45 UTC
+    });
+    const { db, updateFn } = makeMockDb(trade);
+
+    const expectedT1 = Math.floor(new Date('2026-05-27T20:23:00Z').getTime() / 1000);
+    const expectedT2 = Math.floor(new Date('2026-05-27T21:45:00Z').getTime() / 1000);
+    const wrongBrasiliaT1 = Math.floor(new Date('2026-05-27T19:23:00Z').getTime() / 1000);
+
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => ({
+        chart: { result: [{
+          timestamp: [expectedT1, expectedT1 + 60, expectedT2],
+          indicators: { quote: [{ high: [100, 110, 105], low: [98, 99, 95] }] },
+        }] },
+      }),
+    });
+
+    const result = await runEnrichment(
+      { tradeId: 't-1' },
+      { db, fetchFn, now: () => new Date('2026-05-27T22:00:00Z') }
+    );
+
+    const url = fetchFn.mock.calls[0][0];
+    expect(url).toContain(`period1=${expectedT1}`);
+    expect(url).toContain(`period2=${expectedT2}`);
+    // Confirma que NÃO usou Brasília (-3h) — usou o offset explícito do trade (-4h).
+    expect(url).not.toContain(`period1=${wrongBrasiliaT1}`);
+    expect(result.ok).toBe(true);
+    expect(result.mepPrice).toBe(110);
+    expect(result.menPrice).toBe(95);
+  });
+
+  it('entryTime ET dezembro (EST/-05:00) — switch DST captura offset diferente', async () => {
+    // Mesma hora de relógio (16:23 ET), mês diferente → offset diferente → janela UTC diferente.
+    const trade = futuresTrade({
+      entryTime: '2026-12-15T16:23:00-05:00', // 16:23 EST = 21:23 UTC (não 20:23)
+      exitTime: '2026-12-15T17:00:00-05:00',  // 17:00 EST = 22:00 UTC
+    });
+    const { db } = makeMockDb(trade);
+
+    const expectedT1 = Math.floor(new Date('2026-12-15T21:23:00Z').getTime() / 1000);
+    const expectedT2 = Math.floor(new Date('2026-12-15T22:00:00Z').getTime() / 1000);
+
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => ({
+        chart: { result: [{
+          timestamp: [expectedT1, expectedT2],
+          indicators: { quote: [{ high: [200, 201], low: [199, 198] }] },
+        }] },
+      }),
+    });
+
+    await runEnrichment(
+      { tradeId: 't-1' },
+      { db, fetchFn, now: () => new Date('2026-12-15T22:30:00Z') }
+    );
+
+    const url = fetchFn.mock.calls[0][0];
+    expect(url).toContain(`period1=${expectedT1}`);
+    expect(url).toContain(`period2=${expectedT2}`);
+  });
+});

--- a/src/__tests__/utils/tradeTimezone.test.js
+++ b/src/__tests__/utils/tradeTimezone.test.js
@@ -1,0 +1,167 @@
+/**
+ * tradeTimezone.test.js — issue #285
+ *
+ * Cobre helpers do seletor de fuso do AddTradeModal:
+ *  - isUSDST: regras de transição (2º domingo março, 1º domingo novembro).
+ *  - getOffset: BRT fixo, ET/CT com DST.
+ *  - isCMEFutureTicker / defaultTzForTicker: detecção CME → ET; resto → BRT.
+ *  - combineDateTimeWithTz: ISO+offset com DST correto pela DATA do trade.
+ *  - toBrasiliaDisplay: equivalente em Brasília a partir de qualquer offset.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isUSDST,
+  getOffset,
+  isCMEFutureTicker,
+  defaultTzForTicker,
+  combineDateTimeWithTz,
+  toBrasiliaDisplay,
+  TIMEZONES,
+} from '../../utils/tradeTimezone';
+
+describe('isUSDST', () => {
+  it('verão (maio, julho) → true', () => {
+    expect(isUSDST('2026-05-27')).toBe(true);
+    expect(isUSDST('2026-07-15')).toBe(true);
+  });
+
+  it('inverno (jan, dez) → false', () => {
+    expect(isUSDST('2026-01-15')).toBe(false);
+    expect(isUSDST('2026-12-25')).toBe(false);
+  });
+
+  it('início do DST: 2º domingo de março 2026 = dia 8', () => {
+    expect(isUSDST('2026-03-07')).toBe(false); // sábado, ainda EST
+    expect(isUSDST('2026-03-08')).toBe(true);  // 2º domingo, vira EDT
+    expect(isUSDST('2026-03-09')).toBe(true);
+  });
+
+  it('fim do DST: 1º domingo de novembro 2026 = dia 1', () => {
+    expect(isUSDST('2026-10-31')).toBe(true);  // último dia EDT
+    expect(isUSDST('2026-11-01')).toBe(false); // 1º domingo, vira EST
+    expect(isUSDST('2026-11-15')).toBe(false);
+  });
+
+  it('entrada inválida → false', () => {
+    expect(isUSDST(null)).toBe(false);
+    expect(isUSDST('')).toBe(false);
+    expect(isUSDST('lixo')).toBe(false);
+  });
+});
+
+describe('getOffset', () => {
+  it('Brasília fixo -03:00 (sem DST)', () => {
+    expect(getOffset('2026-07-15', TIMEZONES.BRT.id)).toBe('-03:00');
+    expect(getOffset('2026-12-25', TIMEZONES.BRT.id)).toBe('-03:00');
+  });
+
+  it('ET: -04:00 no verão (EDT), -05:00 no inverno (EST)', () => {
+    expect(getOffset('2026-05-27', TIMEZONES.ET.id)).toBe('-04:00');
+    expect(getOffset('2026-12-25', TIMEZONES.ET.id)).toBe('-05:00');
+  });
+
+  it('CT: -05:00 no verão (CDT), -06:00 no inverno (CST)', () => {
+    expect(getOffset('2026-05-27', TIMEZONES.CT.id)).toBe('-05:00');
+    expect(getOffset('2026-12-25', TIMEZONES.CT.id)).toBe('-06:00');
+  });
+
+  it('tz desconhecido → fallback BRT', () => {
+    expect(getOffset('2026-05-27', 'Europe/London')).toBe('-03:00');
+  });
+
+  it('switch DST captura corretamente pelo lado da data', () => {
+    // 2026-03-07 sábado: ainda EST
+    expect(getOffset('2026-03-07', TIMEZONES.ET.id)).toBe('-05:00');
+    // 2026-03-08 domingo: vira EDT
+    expect(getOffset('2026-03-08', TIMEZONES.ET.id)).toBe('-04:00');
+  });
+});
+
+describe('isCMEFutureTicker', () => {
+  it('reconhece micros e cheios CME', () => {
+    expect(isCMEFutureTicker('NQ')).toBe(true);
+    expect(isCMEFutureTicker('MNQH6')).toBe(true);
+    expect(isCMEFutureTicker('ES')).toBe(true);
+    expect(isCMEFutureTicker('MES')).toBe(true);
+    expect(isCMEFutureTicker('GC')).toBe(true);
+    expect(isCMEFutureTicker('CL')).toBe(true);
+  });
+
+  it('B3 e desconhecidos → false', () => {
+    expect(isCMEFutureTicker('WINFUT')).toBe(false);
+    expect(isCMEFutureTicker('WDOFUT')).toBe(false);
+    expect(isCMEFutureTicker('PETR4')).toBe(false);
+    expect(isCMEFutureTicker('')).toBe(false);
+    expect(isCMEFutureTicker(null)).toBe(false);
+  });
+});
+
+describe('defaultTzForTicker', () => {
+  it('CME → ET', () => {
+    expect(defaultTzForTicker('NQ')).toBe(TIMEZONES.ET.id);
+    expect(defaultTzForTicker('mnqh6')).toBe(TIMEZONES.ET.id); // case-insensitive
+  });
+
+  it('B3 e resto → BRT', () => {
+    expect(defaultTzForTicker('WINFUT')).toBe(TIMEZONES.BRT.id);
+    expect(defaultTzForTicker('PETR4')).toBe(TIMEZONES.BRT.id);
+    expect(defaultTzForTicker('')).toBe(TIMEZONES.BRT.id);
+  });
+});
+
+describe('combineDateTimeWithTz', () => {
+  it('NQ 16:23 ET em maio → ISO com -04:00 (EDT)', () => {
+    expect(combineDateTimeWithTz('2026-05-27', '16:23', TIMEZONES.ET.id))
+      .toBe('2026-05-27T16:23:00-04:00');
+  });
+
+  it('NQ 16:23 ET em dezembro → ISO com -05:00 (EST)', () => {
+    expect(combineDateTimeWithTz('2026-12-15', '16:23', TIMEZONES.ET.id))
+      .toBe('2026-12-15T16:23:00-05:00');
+  });
+
+  it('Brasília 09:30 → ISO com -03:00 fixo', () => {
+    expect(combineDateTimeWithTz('2026-05-27', '09:30', TIMEZONES.BRT.id))
+      .toBe('2026-05-27T09:30:00-03:00');
+  });
+
+  it('preserva segundos quando fornecidos', () => {
+    expect(combineDateTimeWithTz('2026-05-27', '16:23:45', TIMEZONES.BRT.id))
+      .toBe('2026-05-27T16:23:45-03:00');
+  });
+
+  it('inputs incompletos → null', () => {
+    expect(combineDateTimeWithTz('', '16:23', TIMEZONES.ET.id)).toBe(null);
+    expect(combineDateTimeWithTz('2026-05-27', '', TIMEZONES.ET.id)).toBe(null);
+    expect(combineDateTimeWithTz('2026-05-27', '16:23', '')).toBe(null);
+  });
+});
+
+describe('toBrasiliaDisplay', () => {
+  it('NQ 16:23 ET (EDT, -04) → 17:23 BRT (gap = 1h)', () => {
+    expect(toBrasiliaDisplay('2026-05-27T16:23:00-04:00')).toBe('17:23');
+  });
+
+  it('NQ 16:23 ET (EST, -05) → 18:23 BRT (gap = 2h)', () => {
+    expect(toBrasiliaDisplay('2026-12-15T16:23:00-05:00')).toBe('18:23');
+  });
+
+  it('Brasília 16:23 → 16:23 (mesmo fuso)', () => {
+    expect(toBrasiliaDisplay('2026-05-27T16:23:00-03:00')).toBe('16:23');
+  });
+
+  it('CT 16:23 (CDT, -05) → 18:23 BRT', () => {
+    expect(toBrasiliaDisplay('2026-05-27T16:23:00-05:00')).toBe('18:23');
+  });
+
+  it('atravessa meia-noite corretamente (ET 22:30 EDT → 23:30 BRT)', () => {
+    expect(toBrasiliaDisplay('2026-05-27T22:30:00-04:00')).toBe('23:30');
+  });
+
+  it('inválido → string vazia', () => {
+    expect(toBrasiliaDisplay(null)).toBe('');
+    expect(toBrasiliaDisplay('')).toBe('');
+    expect(toBrasiliaDisplay('lixo')).toBe('');
+  });
+});

--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { 
   X, 
   Upload, 
@@ -21,6 +21,14 @@ import { useToast } from '../contexts/ToastContext';
 import { calculateFromPartials } from '../utils/tradeCalculations';
 import { validateExcursionPrices } from '../utils/tradeGateway';
 import { detectInstrumentType, convertExcursionRawToPrice, derivePtsFromPrice } from '../utils/excursionParsing';
+import useLocalStorage from '../hooks/useLocalStorage';
+import {
+  TIMEZONE_LIST,
+  defaultTzForTicker,
+  combineDateTimeWithTz,
+  toBrasiliaDisplay,
+  TIMEZONES,
+} from '../utils/tradeTimezone';
 
 const SIDES = ['LONG', 'SHORT'];
 
@@ -97,6 +105,14 @@ const AddTradeModal = ({
   // --- SISTEMA DE PARCIAIS (SEMPRE ATIVO) ---
   const [partials, setPartials] = useState([]);
   const [resultOverride, setResultOverride] = useState(null);
+
+  // #285 — fuso de referência do horário do trade (sticky por aluno via localStorage).
+  // Default inicial = ET pra futuros CME, BRT pro resto. Após a 1ª escolha do aluno,
+  // sticky prevalece (last-used). Gravado em `entryTime`/`exitTime` como ISO+offset.
+  const [selectedTz, setSelectedTz] = useLocalStorage(
+    'addTradeLastTimezone',
+    defaultTzForTicker(editTrade?.ticker || ''),
+  );
 
   const htfInputRef = useRef(null);
   const ltfInputRef = useRef(null);
@@ -190,15 +206,29 @@ const AddTradeModal = ({
     return timePart.substring(0, 5);
   };
 
-  /** Combina data BR (DD/MM/AAAA) + hora (HH:MM ou HH:MM:SS) em ISO string */
+  /** Combina data BR (DD/MM/AAAA) + hora (HH:MM ou HH:MM:SS) em ISO + offset.
+   *  #285: grava instante absoluto com offset do fuso selecionado. Enrich
+   *  (HAS_TZ) passa direto sem aplicar Brasília fixo. DST automático pela data. */
   const combineDateTimeISO = (dateBr, time) => {
     if (!dateBr || dateBr.length !== 10 || !time || time.length < 5) return '';
     const isoDate = brToIso(dateBr);
     if (!isoDate) return '';
-    // Se já tem segundos (HH:MM:SS), usar direto; senão, adicionar :00
-    const timePart = time.length >= 8 ? time : `${time}:00`;
-    return `${isoDate}T${timePart}`;
+    return combineDateTimeWithTz(isoDate, time, selectedTz) || '';
   };
+
+  /** Helper "Equivalente em Brasília" — preview do horário gravado em BRT, pro
+   *  aluno conferir mentalmente que não trocou de fuso sem perceber. */
+  const brtEntryPreview = useMemo(() => {
+    if (!formData.entryDate || !formData.entryTime || !selectedTz) return '';
+    const iso = combineDateTimeWithTz(formData.entryDate, formData.entryTime, selectedTz);
+    return toBrasiliaDisplay(iso);
+  }, [formData.entryDate, formData.entryTime, selectedTz]);
+
+  const brtExitPreview = useMemo(() => {
+    if (!formData.exitDate || !formData.exitTime || !selectedTz) return '';
+    const iso = combineDateTimeWithTz(formData.exitDate, formData.exitTime, selectedTz);
+    return toBrasiliaDisplay(iso);
+  }, [formData.exitDate, formData.exitTime, selectedTz]);
 
   // --- HELPER: Formato moeda para exibição ---
   const formatResultDisplay = (value) => {
@@ -928,7 +958,27 @@ const AddTradeModal = ({
                       <Plus className="w-3 h-3" /> Adicionar
                     </button>
                   </div>
-                  
+
+                  {/* #285 — Fuso de referência (sticky, default por instrumento; grava ISO+offset) */}
+                  <div className="flex items-center gap-2 px-2 py-1.5 bg-slate-900/40 rounded-md border border-slate-700/30 mb-1">
+                    <span className="text-[10px] text-slate-500 uppercase tracking-wider whitespace-nowrap">Fuso</span>
+                    <select
+                      value={selectedTz}
+                      onChange={(e) => setSelectedTz(e.target.value)}
+                      className="input-dark text-xs py-1 px-2"
+                      aria-label="Fuso de referência do horário do trade"
+                    >
+                      {TIMEZONE_LIST.map((tz) => (
+                        <option key={tz.id} value={tz.id}>{tz.label}</option>
+                      ))}
+                    </select>
+                    {selectedTz !== TIMEZONES.BRT.id && (brtEntryPreview || brtExitPreview) && (
+                      <span className="text-[10px] text-slate-500 ml-auto whitespace-nowrap">
+                        ≈ Brasília: {brtEntryPreview || '—'}{brtExitPreview ? ` → ${brtExitPreview}` : ''}
+                      </span>
+                    )}
+                  </div>
+
                   {/* Header — Item 1: "Tipo" ao invés de "Ponta" + Item 2: Data e Hora separados */}
                   <div className="grid grid-cols-[80px_1fr_70px_100px_95px_28px] gap-2 text-[10px] text-slate-500 uppercase tracking-wider px-1">
                     <span>Tipo</span>

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -36,6 +36,7 @@ import TradeStatusBadges from './TradeStatusBadges';
 import ShadowBehaviorPanel from './Trades/ShadowBehaviorPanel';
 import ExecutionPatternsPanel from './Trades/ExecutionPatternsPanel';
 import ExcursionDisplay from './ExcursionDisplay';
+import { isCMEFutureTicker } from '../utils/tradeTimezone';
 
 // Helpers locais para evitar dependências quebradas
 
@@ -134,6 +135,7 @@ const TradeDetailModal = ({
   onAddFeedback,
   feedbackLoading = false,
   onViewFeedbackHistory,
+  onRecalcMepMen,  // #285: handler async (tradeId) => Promise — quando definido, mostra "Recalcular MEP/MEN"
   getPartials,  // LEGADO — mantido para compatibilidade, mas parciais vêm do campo _partials do trade
 }) => {
   const [fullscreenImage, setFullscreenImage] = useState(null);
@@ -366,7 +368,22 @@ const TradeDetailModal = ({
             </div>
 
             {/* MEP/MEN — issue #187. Display em pts (futures) ou % (equity), derivado do storage em preço. */}
-            <ExcursionDisplay trade={trade} variant="full" className="mb-6" />
+            <ExcursionDisplay trade={trade} variant="full" className="mb-2" />
+
+            {/* #285 — Recalcular MEP/MEN: zera os valores e o trigger onTradeUpdated re-enriquece
+                com a janela do entryTime/exitTime atuais. Útil após corrigir hora ou fuso. */}
+            {onRecalcMepMen && trade.excursionSource && isCMEFutureTicker(trade.ticker) && (
+              <div className="mb-6 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => onRecalcMepMen(trade.id)}
+                  className="text-xs px-3 py-1.5 rounded-md bg-slate-800/60 hover:bg-slate-700/60 border border-slate-700/50 text-slate-300 hover:text-white transition-colors flex items-center gap-1.5"
+                  title="Zera MEP/MEN e busca os candles novamente para a janela atual"
+                >
+                  🔄 Recalcular MEP/MEN
+                </button>
+              </div>
+            )}
 
 
             {/* Resultado editado vs calculado */}

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -358,6 +358,24 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     if (onNavigateToFeedback) onNavigateToFeedback(trade);
   };
 
+  // #285 — "Recalcular MEP/MEN": zera mep/men/excursionSource → onTradeUpdated
+  // detecta `mepCleared`, dispara runEnrichment com a janela do entryTime/exitTime atuais.
+  const handleRecalcMepMen = async (tradeId) => {
+    const ok = await confirm({
+      title: 'Recalcular MEP/MEN?',
+      message: 'Os valores atuais serão zerados e o sistema buscará os candles novamente para a janela do trade. Use após corrigir hora ou fuso.',
+      confirmLabel: 'Recalcular',
+      variant: 'default',
+    });
+    if (!ok) return;
+    try {
+      await updateTrade(tradeId, { mepPrice: null, menPrice: null, excursionSource: null });
+      toast.success('Recalculando MEP/MEN…');
+    } catch (err) {
+      toast.error(`Falha ao zerar: ${err.message || err}`);
+    }
+  };
+
   /** Wrapper para activateTrade que injeta addTrade + trades do plano (dedup + enrich #240).
    *  Retorna o resultado bruto do hook — UI de feedback fica com o CsvImportManager/Modal. */
   const handleActivateStagingTrade = async (stagingTrade) => {
@@ -726,7 +744,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
 
       {/* Modais */}
       <AddTradeModal isOpen={showAddModal} onClose={() => { setShowAddModal(false); setEditingTrade(null); }} onSubmit={handleAddTrade} editTrade={editingTrade} loading={isSubmitting} plans={plans} />
-      <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} orders={orders} allTrades={trades} onViewFeedbackHistory={handleViewFeedbackHistory} getPartials={getPartials} />
+      <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} orders={orders} allTrades={trades} onViewFeedbackHistory={handleViewFeedbackHistory} onRecalcMepMen={handleRecalcMepMen} getPartials={getPartials} />
       <PlanManagementModal isOpen={showPlanModal} onClose={() => { setShowPlanModal(false); setEditingPlan(null); }} onSubmit={handleSavePlan} editingPlan={editingPlan} isSubmitting={isSubmitting} defaultAccountId={filters.accountId !== 'all' ? filters.accountId : undefined} />
       {extractPlan && (<PlanExtractModal isOpen={!!extractPlan} onClose={() => setExtractPlan(null)} plan={extractPlan} trades={trades.filter(t => t.planId === extractPlan.id)} />)}
       {/* PlanLedgerExtract: ledger agora é currentView no App.jsx (#102 Fase 0), não modal aqui */}

--- a/src/utils/tradeTimezone.js
+++ b/src/utils/tradeTimezone.js
@@ -1,0 +1,117 @@
+/**
+ * tradeTimezone.js — issue #285
+ *
+ * Helpers puros para o seletor de fuso no `AddTradeModal`. Calcula o offset UTC
+ * pra uma data + fuso, considerando DST automaticamente (US Eastern/Central têm
+ * horário de verão; Brasília é UTC-3 fixo desde 2019).
+ *
+ * O fuso é gravado no `entryTime`/`exitTime` do trade como **ISO + offset**
+ * (ex.: `"2026-05-27T16:23:00-04:00"`) — instante absoluto, sem ambiguidade.
+ * O enrichment (que já reconhece `HAS_TZ`) passa direto sem aplicar Brasília.
+ *
+ * @see functions/marketData/enrichTradeWithExcursions.js — toBrasiliaISO/HAS_TZ
+ */
+
+export const TIMEZONES = {
+  ET:  { id: 'America/New_York',  label: 'Nova York (ET)' },
+  CT:  { id: 'America/Chicago',   label: 'Chicago (CT)' },
+  BRT: { id: 'America/Sao_Paulo', label: 'Brasília (BRT)' },
+};
+
+export const TIMEZONE_LIST = [TIMEZONES.ET, TIMEZONES.CT, TIMEZONES.BRT];
+
+// Prefixos de futuros CME (US) — MANTER SINCRONIZADO com
+// functions/marketData/symbolMapper.js MAPPINGS. Ordem-sensível: micros antes
+// dos cheios pra não bater MNQ em NQ.
+const CME_PREFIXES = ['MNQ', 'MES', 'MGC', 'MCL', 'MYM', 'M2K', 'NQ', 'ES', 'GC', 'CL', 'YM', 'RTY'];
+
+/** Dia do mês do N-ésimo domingo (year, monthOneBased, n). */
+function nthSundayOfMonth(year, monthOneBased, n) {
+  const first = new Date(Date.UTC(year, monthOneBased - 1, 1));
+  const dow = first.getUTCDay(); // 0=Sun
+  const firstSunday = dow === 0 ? 1 : 1 + (7 - dow);
+  return firstSunday + 7 * (n - 1);
+}
+
+/**
+ * True se a data está em DST nos EUA (regra atual: 2º domingo de março a
+ * 1º domingo de novembro). Granularidade de data — ignora o switch às 2h
+ * local (irrelevante pra entrada de trade).
+ *
+ * @param {string} dateISO — 'YYYY-MM-DD' (sufixo extra ignorado)
+ * @returns {boolean}
+ */
+export function isUSDST(dateISO) {
+  if (typeof dateISO !== 'string' || !/^\d{4}-\d{2}-\d{2}/.test(dateISO)) return false;
+  const [y, m, d] = dateISO.slice(0, 10).split('-').map(Number);
+  if (m < 3 || m > 11) return false;
+  if (m > 3 && m < 11) return true;
+  if (m === 3) return d >= nthSundayOfMonth(y, 3, 2);
+  if (m === 11) return d < nthSundayOfMonth(y, 11, 1);
+  return false;
+}
+
+/**
+ * Offset UTC (`'-HH:MM'`) pra uma data + fuso. DST automático em ET/CT;
+ * BRT é fixo `-03:00`.
+ *
+ * @param {string} dateISO — 'YYYY-MM-DD'
+ * @param {string} tz — id IANA
+ * @returns {string}
+ */
+export function getOffset(dateISO, tz) {
+  if (tz === TIMEZONES.BRT.id) return '-03:00';
+  const dst = isUSDST(dateISO);
+  if (tz === TIMEZONES.ET.id) return dst ? '-04:00' : '-05:00';
+  if (tz === TIMEZONES.CT.id) return dst ? '-05:00' : '-06:00';
+  return '-03:00'; // fallback defensivo
+}
+
+/**
+ * True se o ticker é um futuro CME (mapeável no Yahoo). Espelha o predicado
+ * de `symbolMapper.mapToYahoo` sem depender do CJS server-side.
+ */
+export function isCMEFutureTicker(ticker) {
+  if (!ticker || typeof ticker !== 'string') return false;
+  const upper = ticker.toUpperCase().trim();
+  return CME_PREFIXES.some((p) => upper.startsWith(p));
+}
+
+/**
+ * Default inicial de fuso pra um ticker — ET pra futuros CME, BRT pro resto.
+ * Sticky (último escolhido pelo aluno) sobrescreve via localStorage no caller.
+ */
+export function defaultTzForTicker(ticker) {
+  return isCMEFutureTicker(ticker) ? TIMEZONES.ET.id : TIMEZONES.BRT.id;
+}
+
+/**
+ * Combina data (YYYY-MM-DD) + hora (HH:MM ou HH:MM:SS) + fuso → ISO + offset.
+ * Offset é calculado pra DATA do trade (não "hoje") — DST correto pro instante.
+ *
+ * @returns {string|null} ex.: `'2026-05-27T16:23:00-04:00'`
+ */
+export function combineDateTimeWithTz(dateISO, time, tz) {
+  if (!dateISO || !time || !tz) return null;
+  const timePart = time.length >= 8 ? time : `${time}:00`;
+  return `${dateISO}T${timePart}${getOffset(dateISO, tz)}`;
+}
+
+/**
+ * Equivalente em Brasília (`'HH:MM'`) de um ISO com offset — usado no helper
+ * embaixo do campo pro aluno conferir mentalmente.
+ *
+ * Funciona pra ISO+offset (instante absoluto) e pra naive (assume Brasília,
+ * legado) — nos dois casos retorna a hora local de Brasília.
+ */
+export function toBrasiliaDisplay(isoWithOffset) {
+  if (!isoWithOffset || typeof isoWithOffset !== 'string') return '';
+  const d = new Date(isoWithOffset);
+  if (isNaN(d.getTime())) return '';
+  // Pega componentes da hora local de Brasília (UTC-3) sem depender da TZ do JS env.
+  const brtMs = d.getTime() - 3 * 3600 * 1000;
+  const brt = new Date(brtMs);
+  const hh = String(brt.getUTCHours()).padStart(2, '0');
+  const mm = String(brt.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}


### PR DESCRIPTION
## Contexto

O aluno lê o horário do trade em ET/CT na plataforma, mas o app gravava `entryTime`/`exitTime` **naive** (Brasília-assumido). Isso desalinhava a janela do Yahoo no enrich → MEP/MEN errado ou `unavailable` → corrompia o gate de promoção `advanced-metrics` (exige ≥80% trades com mep/men). A ambiguidade nascia no input.

## Escopo — Fase A (manual + backend)

> B/C (import CSV/Order com fuso por lote) = fast-follow.

- **AddTradeModal**: seletor **Fuso** sticky (`useLocalStorage`), default **ET** pra CME, **BRT** pro resto; helper **"≈ Brasília"** pro aluno conferir mentalmente.
- **`combineDateTimeWithTz`**: grava `entryTime`/`exitTime` como **ISO+offset** (ex.: `2026-05-27T16:23:00-04:00`) — instante absoluto.
- **TradeDetailModal**: botão **"🔄 Recalcular MEP/MEN"** (CME futures + `excursionSource`), zera mep/men → `onTradeUpdated` re-enriquece.
- **`onTradeUpdated`**: detecta `timeChanged || mepCleared`, dispara `runEnrichment` idempotente; loop guard (enrich só toca mep/men/excursionSource).
- **`enrichTradeWithExcursions`**: reconhece `HAS_TZ` → ISO+offset passa direto sem aplicar Brasília fixo; legado naive segue Brasília-assumido.
- **`utils/tradeTimezone`**: `isUSDST` (2º dom março / 1º dom novembro), `getOffset` com DST automático ET/CT, BRT fixo -03:00, `defaultTzForTicker`.

## Decisões resolvidas (27/05/2026)

- (a) Seletor sticky + default por instrumento.
- (b) Legado naive mantido como está (Brasília-assumido).
- (c) Manual + backend agora; import fast-follow.
- (INV-15) Instante absoluto via ISO+offset (sem campo `timezone` separado).

## Testes

- `tradeTimezone.test.js` — 30+ casos (transições DST, ET/CT/BRT, edge).
- `runEnrichment` — +2 casos (ET maio EDT → period1 20:23 UTC vs ET dez EST → 21:23 UTC; offset explícito vence Brasília fixo).
- **3315 testes verdes** (208 arquivos).

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)