### PR TITLE
feat(#289): gate de análises por plano + contexto no card (Fase 1, PR 1/2)

### DIFF
--- a/docs/dev/issues/issue-289-context-gated-analytics.md
+++ b/docs/dev/issues/issue-289-context-gated-analytics.md
@@ -1,0 +1,46 @@
+# Issue #289 — feat: Dashboard-Aluno — análises governadas pelo contexto (gate plano/ciclo)
+
+> Template enxuto (R4). Spec completa no body do #289 (link, não duplicar).
+
+## Autorização (OBRIGATÓRIA)
+
+**Status: AUTORIZADO (28/05/2026, "dois PRs, pode abrir a issue" do Marcio).**
+- [x] Mockup/abordagem revisados (plano de implementação aprovado via ExitPlanMode em 28/05)
+- [x] Memória de cálculo: N/A — não há fórmula nova (gate de visibilidade + reescopo de query existente). Exceção implícita: o plano aprovado detalha a lógica.
+- [x] Marcio autorizou (28/05/2026, "dois PRs, pode abrir a issue")
+- [x] Gate Pré-Código liberado
+
+## Context
+Dashboard do aluno mostra todas as análises sem respeitar plano/ciclo. (1) Analytics que somam `result` ignoram `account.currency` → em escopo multi-conta misturam R$+US$ e carimbam R$. (2) Incoerência de IA: Setup/Emocional/Financeiro/Calendário aparecem sem plano; SWOT/Maturidade aparecem fora do ciclo. Objetivo: dashboard vira lente governada pela barra de contexto — sem plano sobra só a Curva de Patrimônio.
+
+## Spec
+Ver issue body no GitHub: #289. (Link, não duplicar.)
+
+## Mockup
+Sem plano selecionado: header + ContextBar + PlanCardGrid + guards + Curva de Patrimônio (full-width) + CTA "Selecione um plano para ver as análises". Com plano: layout atual intacto. Ciclo passado vs ativo muda a versão de SWOT/Maturidade exibida.
+
+## Memória de Cálculo
+N/A — sem fórmula nova. Gate boolean (`selectedPlanId != null`) + filtro de query por `cycleKey`.
+
+## Phases
+- **Fase 1 (PR 1)** — gate por plano dos analytics que somam moeda + re-aplicar label de moeda (#1) + curva sempre visível + reflow grid + empty-state CTA
+- **Fase 2 (PR 2)** — SWOT escopado ao ciclo (`useLatestClosedReview` filtra por `cycleKey`) + Maturidade frozen (ciclo passado) vs viva (ciclo ativo) + empty states
+- testes em cada fase (INV-05)
+
+## Sessions
+_(log linear)_
+
+## Shared Deltas
+- `src/version.js` — bump v1.69.0 (reservada)
+- `docs/registry/versions.md` — marcar v1.69.0 consumida
+- `docs/registry/chunks.md` — liberar CHUNK-04/08/13
+- `CHANGELOG.md` — nova entrada `[1.69.0]`
+- `docs/decisions.md` — DEC-AUTO-289-* (regra de IA: analytics que somam moeda exigem plano; SWOT/Maturidade seguem ciclo; curva é nível-conta sempre visível)
+
+## Decisions
+_(IDs — texto em docs/decisions.md no encerramento)_
+
+## Chunks
+- CHUNK-13 (escrita) — gate governado pela barra de contexto
+- CHUNK-04 (escrita) — analytics do dashboard (calculateStats/setup/emotion, TradingCalendar)
+- CHUNK-08 (escrita) — SWOT/reviews + maturidade frozen nas revisões (Fase 2)

--- a/src/__tests__/invariants/studentDashboardPlanGating.test.js
+++ b/src/__tests__/invariants/studentDashboardPlanGating.test.js
@@ -1,0 +1,54 @@
+/**
+ * studentDashboardPlanGating.test.js — invariante de IA (issue #289 Fase 1).
+ *
+ * Regra: análises que somam `trade.result` / são relativas ao plano só renderizam
+ * com plano selecionado (`planSelected = selectedPlanId != null`). Em escopo
+ * multi-conta a soma cross-currency é inválida; gate por plano garante moeda única.
+ * A Curva de Patrimônio (EquityCurve) é nível-conta (abas por moeda própria) e
+ * NUNCA pode ser gated — fica sempre visível.
+ *
+ * Cerca de fonte (estilo studentDashboardReferences.test.js): barata, sem mount,
+ * guarda a regra enquanto não há teste de render page-level.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const STUDENT_DASHBOARD = path.resolve(
+  __dirname,
+  '../../pages/StudentDashboard.jsx',
+);
+
+describe('StudentDashboard.jsx — gate de análises por plano (#289)', () => {
+  const src = fs.readFileSync(STUDENT_DASHBOARD, 'utf8');
+
+  it('declara o booleano planSelected derivado de selectedPlanId', () => {
+    expect(/const planSelected = selectedPlanId != null/.test(src)).toBe(true);
+  });
+
+  it('gateia MetricsCards, SetupAnalysis, EmotionAnalysis e TradingCalendar por planSelected', () => {
+    // cada analytic que soma result aparece sob um guard planSelected &&
+    expect(/planSelected && \(\s*<MetricsCards/.test(src)).toBe(true);
+    expect(/planSelected && <SetupAnalysis/.test(src)).toBe(true);
+    expect(/planSelected && \(\s*<div[^>]*>\s*<EmotionAnalysis/.test(src)).toBe(true);
+    expect(/planSelected && \(\s*<div className="lg:col-span-1">\s*<TradingCalendar/.test(src)).toBe(true);
+  });
+
+  it('NÃO gateia a Curva de Patrimônio (EquityCurve sempre visível)', () => {
+    // a coluna da curva reflui para full-width quando sem plano, mas a div
+    // sempre renderiza (não há guard planSelected envolvendo a coluna). O
+    // ternário de col-span é a prova de que a curva aparece nos dois estados.
+    expect(/planSelected \? 'lg:col-span-2' : 'lg:col-span-3'/.test(src)).toBe(true);
+    // EquityCurve permanece sob o guard de dados, não sob o de plano
+    expect(/filteredTrades\.length > 0 \? \(\s*<EquityCurve/.test(src)).toBe(true);
+  });
+
+  it('mostra CTA de seleção de plano quando sem plano', () => {
+    expect(/!planSelected && \(/.test(src)).toBe(true);
+    expect(/Selecione um plano para ver as an[áa]lises/.test(src)).toBe(true);
+  });
+});

--- a/src/components/ContextBar.jsx
+++ b/src/components/ContextBar.jsx
@@ -9,13 +9,7 @@ import { useMemo, useState, useRef, useEffect } from 'react';
 import { ChevronDown, Lock, Calendar, Briefcase, Target, Clock } from 'lucide-react';
 import DebugBadge from './DebugBadge';
 import useStudentContext from '../hooks/useStudentContext';
-import { PERIOD_KIND, getCycleKey, ALL_CYCLES_KEY } from '../utils/cycleResolver';
-
-const PERIOD_LABELS = {
-  [PERIOD_KIND.CYCLE]: 'Ciclo completo',
-  [PERIOD_KIND.WEEK]: 'Semana atual',
-  [PERIOD_KIND.MONTH]: 'Mês atual'
-};
+import { PERIOD_KIND, PERIOD_LABELS, getCycleKey, ALL_CYCLES_KEY } from '../utils/cycleResolver';
 
 // ============================================
 // DROPDOWN GENÉRICO

--- a/src/components/EmotionAnalysis.jsx
+++ b/src/components/EmotionAnalysis.jsx
@@ -22,7 +22,7 @@ import { buildEmotionMatrix4D } from '../utils/emotionMatrix4D';
 import { STAGE_NAMES } from '../utils/maturityEngine/constants';
 import DebugBadge from './DebugBadge';
 
-const fmtSignedCurrency = (v) => (v >= 0 ? `+${formatCurrency(v)}` : formatCurrency(v));
+const fmtSignedCurrency = (v, currency = 'BRL') => (v >= 0 ? `+${formatCurrency(v, currency)}` : formatCurrency(v, currency));
 const fmtPct = (v, digits = 0) => `${v >= 0 ? '' : ''}${v.toFixed(digits)}%`;
 const fmtSignedPct = (v, digits = 0) => `${v >= 0 ? '+' : ''}${v.toFixed(digits)}%`;
 
@@ -204,7 +204,7 @@ const buildInsight = (cards) => {
   };
 };
 
-const EmotionAnalysis = ({ trades, globalWR, maturity = null }) => {
+const EmotionAnalysis = ({ trades, globalWR, maturity = null, currency = 'BRL' }) => {
   const cards = useMemo(
     () => buildEmotionMatrix4D(trades, { globalWR, sparklineWindow: 10 }),
     [trades, globalWR],
@@ -275,7 +275,7 @@ const EmotionAnalysis = ({ trades, globalWR, maturity = null }) => {
                   className={`font-mono font-bold text-sm ${totalColor} cursor-help`}
                   title={`Resultado acumulado das ${c.count} operação(ões) nesta emoção. Sinal e cor seguem o saldo final.`}
                 >
-                  {fmtSignedCurrency(c.totalPL)}
+                  {fmtSignedCurrency(c.totalPL, currency)}
                 </span>
               </div>
 
@@ -288,9 +288,9 @@ const EmotionAnalysis = ({ trades, globalWR, maturity = null }) => {
                 >
                   <KPI
                     label="Expect"
-                    value={fmtSignedCurrency(c.expectancy)}
+                    value={fmtSignedCurrency(c.expectancy, currency)}
                     valueClassName={c.expectancy >= 0 ? 'text-emerald-400' : 'text-red-400'}
-                    tooltip={`Expectancy = totalPL / count = ${fmtSignedCurrency(c.totalPL)} / ${c.count} = ${fmtSignedCurrency(c.expectancy)}. Resultado médio por trade nesta emoção. Positivo = edge a favor; negativo = sangria.`}
+                    tooltip={`Expectancy = totalPL / count = ${fmtSignedCurrency(c.totalPL, currency)} / ${c.count} = ${fmtSignedCurrency(c.expectancy, currency)}. Resultado médio por trade nesta emoção. Positivo = edge a favor; negativo = sangria.`}
                   />
                   <KPI
                     label="Payoff"

--- a/src/components/SetupAnalysis.jsx
+++ b/src/components/SetupAnalysis.jsx
@@ -23,7 +23,7 @@ import { formatCurrency } from '../utils/calculations';
 import { analyzeBySetupV2 } from '../utils/setupAnalysisV2';
 import DebugBadge from './DebugBadge';
 
-const fmtSignedCurrency = (v) => (v >= 0 ? `+${formatCurrency(v)}` : formatCurrency(v));
+const fmtSignedCurrency = (v, currency = 'BRL') => (v >= 0 ? `+${formatCurrency(v, currency)}` : formatCurrency(v, currency));
 const fmtPct = (v, digits = 0) => `${v.toFixed(digits)}%`;
 const fmtSignedPct = (v, digits = 0) => `${v >= 0 ? '+' : ''}${v.toFixed(digits)}%`;
 
@@ -178,7 +178,7 @@ const buildInsight = (cards) => {
   return null;
 };
 
-const SetupCard = ({ card }) => {
+const SetupCard = ({ card, currency = 'BRL' }) => {
   const profitable = card.totalPL >= 0;
   const borderClass = profitable ? 'border-emerald-500/20' : 'border-red-500/20';
   const bgClass = profitable ? 'bg-emerald-500/5' : 'bg-red-500/5';
@@ -201,7 +201,7 @@ const SetupCard = ({ card }) => {
         </div>
         <div className="flex items-baseline gap-2 mt-1">
           <span className={`font-mono font-bold text-sm whitespace-nowrap ${totalColor}`}>
-            {fmtSignedCurrency(card.totalPL)}
+            {fmtSignedCurrency(card.totalPL, currency)}
           </span>
           <span className="text-[10px] text-slate-500 whitespace-nowrap">WR {fmtPct(card.wr, 0)}</span>
         </div>
@@ -211,7 +211,7 @@ const SetupCard = ({ card }) => {
         <Quadrant label="Financial" sublabel="por trade">
           <KPI
             label="EV"
-            value={fmtSignedCurrency(card.ev)}
+            value={fmtSignedCurrency(card.ev, currency)}
             valueClassName={card.ev >= 0 ? 'text-emerald-400' : 'text-red-400'}
           />
           <KPI
@@ -307,7 +307,7 @@ const SetupCard = ({ card }) => {
   );
 };
 
-const SetupAnalysis = ({ trades, setupsMeta }) => {
+const SetupAnalysis = ({ trades, setupsMeta, currency = 'BRL' }) => {
   const cards = useMemo(
     () => analyzeBySetupV2(trades, { setupsMeta }),
     [trades, setupsMeta],
@@ -359,7 +359,7 @@ const SetupAnalysis = ({ trades, setupsMeta }) => {
       {regulars.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 content-start">
           {regulars.map((c) => (
-            <SetupCard key={c.setup} card={c} />
+            <SetupCard key={c.setup} card={c} currency={currency} />
           ))}
         </div>
       )}
@@ -380,7 +380,7 @@ const SetupAnalysis = ({ trades, setupsMeta }) => {
           {expanded && (
             <div className="mt-3 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3 content-start">
               {sporadics.map((c) => (
-                <SetupCard key={c.setup} card={c} />
+                <SetupCard key={c.setup} card={c} currency={currency} />
               ))}
             </div>
           )}

--- a/src/components/TradingCalendar.jsx
+++ b/src/components/TradingCalendar.jsx
@@ -1,16 +1,6 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { ChevronLeft, ChevronRight, XCircle } from 'lucide-react';
-
-/**
- * Utilitário local para formatação monetária compacta
- */
-const formatCurrency = (value) => 
-  new Intl.NumberFormat('pt-BR', { 
-    style: 'currency', 
-    currency: 'BRL',
-    minimumFractionDigits: 0, 
-    maximumFractionDigits: 2 
-  }).format(value);
+import { formatCurrencyCompact } from '../utils/currency';
 
 /**
  * TradingCalendar (Versão Interativa com Contador)
@@ -18,9 +8,25 @@ const formatCurrency = (value) =>
  * @param {Array} trades - Lista de trades para calcular P&L.
  * @param {string|null} selectedDate - Data atualmente selecionada (YYYY-MM-DD).
  * @param {Function} onSelectDate - Callback ao clicar em um dia.
+ * @param {string} currency - Moeda dominante do conjunto de trades (ex.: 'BRL', 'USD').
+ * @param {Date|string|null} focusDate - Mês inicial exibido; segue o período da barra
+ *   de contexto (#289). Navegação manual com as setas persiste até focusDate mudar.
  */
-const TradingCalendar = ({ trades = [], selectedDate, onSelectDate }) => {
-  const [currentDate, setCurrentDate] = useState(new Date());
+const TradingCalendar = ({ trades = [], selectedDate, onSelectDate, currency = 'BRL', focusDate = null }) => {
+  const formatCurrency = (value) => formatCurrencyCompact(value, currency);
+
+  const [currentDate, setCurrentDate] = useState(() => (focusDate ? new Date(focusDate) : new Date()));
+
+  // Sincroniza o mês exibido com o período selecionado na barra de contexto (#289).
+  // Depende de uma chave ano-mês (primitivo) para não disparar a cada render só
+  // porque o objeto Date trocou de identidade; navegação manual persiste até a
+  // troca real de ciclo/período.
+  const focusMonthKey = focusDate
+    ? (() => { const d = new Date(focusDate); return Number.isNaN(d.getTime()) ? null : d.getFullYear() * 12 + d.getMonth(); })()
+    : null;
+  useEffect(() => {
+    if (focusMonthKey != null) setCurrentDate(new Date(focusDate));
+  }, [focusMonthKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // --- ENGINE DE DADOS ---
   const dailyData = useMemo(() => {

--- a/src/components/dashboard/PlanCardGrid.jsx
+++ b/src/components/dashboard/PlanCardGrid.jsx
@@ -16,9 +16,10 @@
 import {
   PlusCircle, Check, Settings, Trash2, RefreshCw, Calendar, ScrollText,
   Skull, Trophy, TrendingUp, TrendingDown, Smile, Frown, Meh,
-  AlertTriangle, Activity, ShieldCheck
+  AlertTriangle, Activity, ShieldCheck, Clock, Lock
 } from 'lucide-react';
 import { formatCurrencyDynamic } from '../../utils/currency';
+import { PERIOD_LABELS, ALL_CYCLES_KEY } from '../../utils/cycleResolver';
 import { calculatePeriodPnL, calculateCyclePnL } from '../../utils/planCalculations';
 import { computePlanState, classifyPeriodBadge, getSentimentFromState } from '../../utils/planStateMachine';
 import { getOpenCycleStart } from '../../utils/planBalance';
@@ -82,6 +83,7 @@ const PlanCardGrid = ({
   accounts,
   trades,
   selectedPlanId,
+  contextSelection = null,
   viewAs,
   onSelectPlan,
   onOpenLedger,
@@ -161,6 +163,28 @@ const PlanCardGrid = ({
                 </div>
                 <h3 className={`font-bold truncate mb-1 pr-6 ${isSelected ? 'text-white' : 'text-slate-300'}`}>{plan.name}</h3>
                 <p className="text-xs text-slate-500 truncate max-w-[150px]">{planAccount?.name}</p>
+                {/* Contexto ativo da barra no card selecionado (#289): ciclo + período + estado */}
+                {isSelected && contextSelection && (
+                  <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+                    <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-blue-500/15 border border-blue-500/30 text-blue-300">
+                      <Calendar className="w-3 h-3" />
+                      {!contextSelection.cycleKey || contextSelection.cycleKey === ALL_CYCLES_KEY
+                        ? 'Todos os ciclos'
+                        : `Ciclo ${contextSelection.cycleKey}`}
+                    </span>
+                    {contextSelection.cycleKey && contextSelection.cycleKey !== ALL_CYCLES_KEY && (
+                      <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-slate-700/40 border border-slate-600/40 text-slate-300">
+                        <Clock className="w-3 h-3" />
+                        {PERIOD_LABELS[contextSelection.periodKind] || PERIOD_LABELS.CYCLE}
+                      </span>
+                    )}
+                    {contextSelection.isReadOnlyCycle && (
+                      <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-amber-500/10 border border-amber-500/30 text-amber-300">
+                        <Lock className="w-3 h-3" /> finalizado
+                      </span>
+                    )}
+                  </div>
+                )}
                 <div className="mt-3 mb-1 bg-slate-900/50 p-2 rounded-lg border border-slate-700/50">
                   <span className="text-[9px] text-slate-400 uppercase tracking-wider font-bold block mb-0.5">Saldo do Plano (PL)</span>
                   <div className="flex items-baseline gap-2">

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -352,6 +352,11 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
       .map(p => p.id);
   }, [plans, studentCtx.accountId, selectedPlanId]);
 
+  // Gate de IA (#289): análises que somam `result` / são relativas ao plano só
+  // aparecem com plano selecionado — garante escopo de moeda única + baseline.
+  // Sem plano sobra só a Curva de Patrimônio (nível-conta, multi-moeda própria).
+  const planSelected = selectedPlanId != null;
+
   // === Handlers ===
   const handleViewFeedbackHistory = (trade) => {
     setViewingTrade(null);
@@ -581,6 +586,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         accounts={accounts}
         trades={trades}
         selectedPlanId={selectedPlanId}
+        contextSelection={{ cycleKey: studentCtx.cycleKey, periodKind: studentCtx.period?.kind, isReadOnlyCycle: studentCtx.isReadOnlyCycle }}
         viewAs={viewAs}
         onSelectPlan={(id) => studentCtx.setPlan(id)}
         onOpenLedger={(plan) => onOpenLedger?.(plan?.id)}
@@ -596,7 +602,8 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         </div>
       )}
 
-      {/* Cards de Métricas */}
+      {/* Cards de Métricas — gated por plano (#289): somam result / relativos ao plano */}
+      {planSelected && (
       <MetricsCards
         stats={stats}
         aggregatedCurrentBalance={aggregatedCurrentBalance}
@@ -633,10 +640,12 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         durationDelta={durationDelta}
         mentorClassificationStats={computeMentorClassificationStats(filteredTrades)}
       />
+      )}
 
-      {/* Gráficos */}
+      {/* Gráficos — Curva de Patrimônio SEMPRE visível (nível-conta, multi-moeda própria).
+          Calendário gated por plano (#289): soma P&L/dia, mesmo defeito de moeda. */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-        <div className="lg:col-span-2">
+        <div className={planSelected ? 'lg:col-span-2' : 'lg:col-span-3'}>
           <div className="glass-card h-[400px] w-full relative p-4">
             {filteredTrades.length > 0 ? (
               <EquityCurve
@@ -656,13 +665,26 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
             )}
           </div>
         </div>
-        <div className="lg:col-span-1">
-          <TradingCalendar trades={filteredTrades} selectedDate={calendarSelectedDate} onSelectDate={(date) => { setCalendarSelectedDate(date === calendarSelectedDate ? null : date); if (date !== calendarSelectedDate) setTimeout(() => document.getElementById('daily-trades')?.scrollIntoView({ behavior: 'smooth' }), 100); }} />
-        </div>
+        {planSelected && (
+          <div className="lg:col-span-1">
+            <TradingCalendar trades={filteredTrades} currency={dominantCurrency || 'BRL'} focusDate={studentCtx.periodRange?.start || studentCtx.selectedCycle?.start || null} selectedDate={calendarSelectedDate} onSelectDate={(date) => { setCalendarSelectedDate(date === calendarSelectedDate ? null : date); if (date !== calendarSelectedDate) setTimeout(() => document.getElementById('daily-trades')?.scrollIntoView({ behavior: 'smooth' }), 100); }} />
+          </div>
+        )}
       </div>
 
-      {/* Trades do dia selecionado — totalização */}
-      {calendarSelectedDate && (() => {
+      {/* CTA quando sem plano — análises detalhadas exigem escopo de plano (#289) */}
+      {!planSelected && (
+        <div className="glass-card p-6 text-center mb-6">
+          <Activity className="w-12 h-12 mx-auto mb-3 text-slate-700" />
+          <h3 className="font-bold text-white mb-1">Selecione um plano para ver as análises</h3>
+          <p className="text-slate-400 text-sm max-w-xl mx-auto">
+            As análises detalhadas (Financeiro, Setups, Emocional, Calendário) somam resultados em uma única moeda e só fazem sentido no escopo de um plano. Escolha um plano nos cards acima.
+          </p>
+        </div>
+      )}
+
+      {/* Trades do dia selecionado — totalização (gated por plano via calendário) */}
+      {planSelected && calendarSelectedDate && (() => {
         const dayTrades = filteredTrades.filter(t => t.date === calendarSelectedDate);
         const dayGain = dayTrades.filter(t => (t.result || 0) > 0).reduce((s, t) => s + t.result, 0);
         const dayLoss = dayTrades.filter(t => (t.result || 0) < 0).reduce((s, t) => s + t.result, 0);
@@ -713,15 +735,18 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
           /* TODO(#164): onNavigateToReview — aguardando rota aluno para Revisão Semanal
              (hoje 'weekly-review' é restrita a mentor em App.jsx). */
         />
-        <SetupAnalysis trades={filteredTrades} setupsMeta={setups} />
+        {planSelected && <SetupAnalysis trades={filteredTrades} setupsMeta={setups} currency={dominantCurrency || 'BRL'} />}
       </div>
-      <div className="mb-6">
-        <EmotionAnalysis
-          trades={filteredTrades}
-          globalWR={stats?.winRate}
-          maturity={maturity}
-        />
-      </div>
+      {planSelected && (
+        <div className="mb-6">
+          <EmotionAnalysis
+            trades={filteredTrades}
+            globalWR={stats?.winRate}
+            maturity={maturity}
+            currency={dominantCurrency || 'BRL'}
+          />
+        </div>
+      )}
 
       {/* Progressão de Maturidade (issue #119 D13) — posicionado logo após a
           Matriz Emocional 4D para manter a ligação visual "depois da matriz".

--- a/src/utils/cycleResolver.js
+++ b/src/utils/cycleResolver.js
@@ -19,6 +19,13 @@ export const PERIOD_KIND = {
   MONTH: 'MONTH'
 };
 
+// Rótulos de exibição do período (SSoT — consumidos por ContextBar e PlanCardGrid, #289).
+export const PERIOD_LABELS = {
+  [PERIOD_KIND.CYCLE]: 'Ciclo completo',
+  [PERIOD_KIND.WEEK]: 'Semana atual',
+  [PERIOD_KIND.MONTH]: 'Mês atual'
+};
+
 export const CYCLE_STATUS = {
   ACTIVE: 'ACTIVE',       // now está dentro do range do ciclo
   FINALIZED: 'FINALIZED'  // now > cycleEnd → read-only


### PR DESCRIPTION
**Parte 1/2 do #289.** Não fecha o issue — a Fase 2 (SWOT/Maturidade por ciclo) encerra via PR 2.

## Problema

O dashboard do aluno renderiza todas as análises independente de plano. `calculateStats`, `analyzeBySetup`, `analyzeByEmotion` e o `TradingCalendar` somam `trade.result` ignorando `account.currency` → em escopo multi-conta misturam R$+US$ e carimbam R$ por fallback (Profit Factor / Expectativa sem sentido).

## Solução (Fase 1)

Dashboard vira lente governada pela barra de contexto (#118, INV-17):

- **Gate por plano** (`planSelected = selectedPlanId != null`): MetricsCards (Financeiro/Assimetria/EV/Consistência), SetupAnalysis, EmotionAnalysis, TradingCalendar e a totalização de trades do dia só renderizam com plano — garante moeda única (plano → 1 conta → 1 moeda).
- **Curva de Patrimônio sempre visível** (nível-conta, abas por moeda próprias); coluna reflui `col-span-2` → `col-span-3` sem plano.
- **CTA** "Selecione um plano para ver as análises" quando sem plano.
- **Label de moeda dinâmica**: TradingCalendar (`formatCurrencyCompact` → `US$ 1,2 mil`), Setup e Emocional recebem `currency={dominantCurrency}`.
- **Contexto no card do plano**: o card selecionado mostra ciclo + período + estado finalizado da barra. `PERIOD_LABELS` movido p/ `cycleResolver` (SSoT, consumido por ContextBar e PlanCardGrid).
- **Calendário segue o período**: abre no mês do período selecionado (`focusDate`); navegação manual persiste até troca de ciclo/período.

## Escopo da Fase 2 (PR 2)
SWOT e Maturidade escopados ao ciclo (filtro por `cycleKey` + snapshot congelado). Por isso seguem visíveis sem plano nesta fase.

## Testes
- Novo invariante `studentDashboardPlanGating.test.js` (4 casos: gate presente, curva não-gated, CTA presente).
- Suíte **3319 verdes** (209 arquivos) + build.

Relates to #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)