### PR TITLE
feat(#289): SWOT e Maturidade escopados ao ciclo (Fase 2, PR 2/2)

### DIFF
--- a/src/__tests__/components/SwotAnalysis.test.jsx
+++ b/src/__tests__/components/SwotAnalysis.test.jsx
@@ -1,20 +1,14 @@
 /**
  * SwotAnalysis.test.jsx
- * @description Testes do SwotAnalysis refatorado para consumir review.swot
- *              (issue #164 — E1: SWOT vem da última review CLOSED).
+ * @description Testes do SwotAnalysis. A partir do #289 (Fase 2) o componente é
+ *              presentacional: recebe `review`/`loading` como props (o fetch com
+ *              filtro de ciclo foi elevado ao StudentDashboard e compartilhado
+ *              com o card de Maturidade).
  * @see src/components/SwotAnalysis.jsx
- * @see src/hooks/useLatestClosedReview.js
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-
-const mockHookReturn = { review: null, loading: false, error: null };
-
-vi.mock('../../hooks/useLatestClosedReview', () => ({
-  __esModule: true,
-  default: () => mockHookReturn,
-}));
 
 vi.mock('../../components/DebugBadge', () => ({
   __esModule: true,
@@ -23,25 +17,15 @@ vi.mock('../../components/DebugBadge', () => ({
 
 import SwotAnalysis from '../../components/SwotAnalysis';
 
-const setHook = (overrides) => {
-  Object.assign(mockHookReturn, { review: null, loading: false, error: null }, overrides);
-};
-
 describe('SwotAnalysis', () => {
-  beforeEach(() => {
-    setHook({});
-  });
-
   it('estado loading mostra skeleton/placeholder discreto', () => {
-    setHook({ loading: true });
-    render(<SwotAnalysis studentId="s1" />);
+    render(<SwotAnalysis loading review={null} />);
     expect(screen.getByTestId('swot-loading')).toBeInTheDocument();
   });
 
   it('estado vazio: sem review CLOSED mostra mensagem e CTA "Ver Revisão Semanal"', () => {
     const onNavigate = vi.fn();
-    setHook({ review: null, loading: false });
-    render(<SwotAnalysis studentId="s1" onNavigateToReview={onNavigate} />);
+    render(<SwotAnalysis review={null} loading={false} onNavigateToReview={onNavigate} />);
     expect(screen.getByText(/Aguardando primeira Revisão Semanal/i)).toBeInTheDocument();
     const btn = screen.getByRole('button', { name: /Ver Revisão Semanal/i });
     expect(btn).toBeInTheDocument();
@@ -50,30 +34,27 @@ describe('SwotAnalysis', () => {
   });
 
   it('estado vazio sem onNavigateToReview: botão não aparece', () => {
-    setHook({ review: null, loading: false });
-    render(<SwotAnalysis studentId="s1" />);
+    render(<SwotAnalysis review={null} loading={false} />);
     expect(screen.getByText(/Aguardando primeira Revisão Semanal/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Ver Revisão Semanal/i })).toBeNull();
   });
 
   it('review com swot completo renderiza os 4 quadrantes com itens', () => {
-    setHook({
-      review: {
-        id: 'r1',
-        weekStart: '2026-04-13',
-        swot: {
-          strengths: ['Respeitou stops', 'WR 66% em MNQ'],
-          weaknesses: ['Overtrading após 15h'],
-          opportunities: ['Explorar setups de abertura'],
-          threats: ['Concentração em MNQ'],
-          aiUnavailable: false,
-          modelVersion: 'claude-sonnet-4-6',
-          generatedAt: { seconds: 1712937600, nanoseconds: 0 },
-          generationCount: 1,
-        },
+    const review = {
+      id: 'r1',
+      weekStart: '2026-04-13',
+      swot: {
+        strengths: ['Respeitou stops', 'WR 66% em MNQ'],
+        weaknesses: ['Overtrading após 15h'],
+        opportunities: ['Explorar setups de abertura'],
+        threats: ['Concentração em MNQ'],
+        aiUnavailable: false,
+        modelVersion: 'claude-sonnet-4-6',
+        generatedAt: { seconds: 1712937600, nanoseconds: 0 },
+        generationCount: 1,
       },
-    });
-    render(<SwotAnalysis studentId="s1" />);
+    };
+    render(<SwotAnalysis review={review} loading={false} />);
     expect(screen.getByText('Respeitou stops')).toBeInTheDocument();
     expect(screen.getByText('WR 66% em MNQ')).toBeInTheDocument();
     expect(screen.getByText('Overtrading após 15h')).toBeInTheDocument();
@@ -86,65 +67,47 @@ describe('SwotAnalysis', () => {
   });
 
   it('aiUnavailable=false: badge verde com modelVersion', () => {
-    setHook({
-      review: {
-        id: 'r1',
-        swot: {
-          strengths: ['ok'],
-          weaknesses: [],
-          opportunities: [],
-          threats: [],
-          aiUnavailable: false,
-          modelVersion: 'claude-sonnet-4-6',
-        },
+    const review = {
+      id: 'r1',
+      swot: {
+        strengths: ['ok'], weaknesses: [], opportunities: [], threats: [],
+        aiUnavailable: false, modelVersion: 'claude-sonnet-4-6',
       },
-    });
-    render(<SwotAnalysis studentId="s1" />);
+    };
+    render(<SwotAnalysis review={review} loading={false} />);
     const badge = screen.getByTestId('swot-source-badge');
     expect(badge).toHaveTextContent(/IA/);
     expect(badge).toHaveTextContent(/claude-sonnet-4-6/);
   });
 
   it('aiUnavailable=true: badge amber "Fallback determinístico"', () => {
-    setHook({
-      review: {
-        id: 'r1',
-        swot: {
-          strengths: ['ok'],
-          weaknesses: [],
-          opportunities: [],
-          threats: [],
-          aiUnavailable: true,
-        },
+    const review = {
+      id: 'r1',
+      swot: {
+        strengths: ['ok'], weaknesses: [], opportunities: [], threats: [],
+        aiUnavailable: true,
       },
-    });
-    render(<SwotAnalysis studentId="s1" />);
+    };
+    render(<SwotAnalysis review={review} loading={false} />);
     const badge = screen.getByTestId('swot-source-badge');
     expect(badge).toHaveTextContent(/Fallback determinístico/i);
   });
 
   it('quadrante com array vazio renderiza mensagem "Sem itens"', () => {
-    setHook({
-      review: {
-        id: 'r1',
-        swot: {
-          strengths: ['força única'],
-          weaknesses: [],
-          opportunities: [],
-          threats: [],
-          aiUnavailable: false,
-          modelVersion: 'x',
-        },
+    const review = {
+      id: 'r1',
+      swot: {
+        strengths: ['força única'], weaknesses: [], opportunities: [], threats: [],
+        aiUnavailable: false, modelVersion: 'x',
       },
-    });
-    render(<SwotAnalysis studentId="s1" />);
+    };
+    render(<SwotAnalysis review={review} loading={false} />);
     const semItens = screen.getAllByText(/Sem itens/i);
     expect(semItens.length).toBeGreaterThanOrEqual(3); // weaknesses, opportunities, threats
   });
 
   it('renderiza DebugBadge com component="SwotAnalysis"', () => {
-    setHook({ review: null });
-    render(<SwotAnalysis studentId="s1" />);
+    render(<SwotAnalysis review={null} loading={false} />);
     expect(screen.getByTestId('debug-badge')).toHaveTextContent('SwotAnalysis');
   });
 });

--- a/src/__tests__/hooks/useLatestClosedReview.test.jsx
+++ b/src/__tests__/hooks/useLatestClosedReview.test.jsx
@@ -113,6 +113,61 @@ describe('useLatestClosedReview', () => {
     expect(result.current.review?.id).toBe('r1');
   });
 
+  it('filtra por cycleKey (top-level) quando fornecido (#289)', async () => {
+    const { result } = renderHook(() => useLatestClosedReview('student-1', null, '2026-04'));
+    const [, onNext] = mockOnSnapshot.mock.calls[0];
+    act(() => {
+      onNext({
+        empty: false,
+        docs: [
+          { id: 'r-may', data: () => ({ cycleKey: '2026-05', weekStart: '2026-05-04', swot: {} }) },
+          { id: 'r-apr', data: () => ({ cycleKey: '2026-04', weekStart: '2026-04-13', swot: { strengths: ['x'] } }) },
+        ],
+      });
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.review?.id).toBe('r-apr');
+  });
+
+  it('filtra por cycleKey via frozenSnapshot.planContext.cycleKey (#289)', async () => {
+    const { result } = renderHook(() => useLatestClosedReview('student-1', null, '2026-04'));
+    const [, onNext] = mockOnSnapshot.mock.calls[0];
+    act(() => {
+      onNext({
+        empty: false,
+        docs: [
+          { id: 'r1', data: () => ({ frozenSnapshot: { planContext: { cycleKey: '2026-04' } }, weekStart: '2026-04-13', swot: {} }) },
+        ],
+      });
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.review?.id).toBe('r1');
+  });
+
+  it('cycleKey null não filtra ciclo (última review CLOSED) (#289)', async () => {
+    const { result } = renderHook(() => useLatestClosedReview('student-1', null, null));
+    const [, onNext] = mockOnSnapshot.mock.calls[0];
+    act(() => {
+      onNext({
+        empty: false,
+        docs: [
+          { id: 'r-latest', data: () => ({ cycleKey: '2026-05', weekStart: '2026-05-04', swot: {} }) },
+        ],
+      });
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.review?.id).toBe('r-latest');
+  });
+
+  it('recria o listener quando cycleKey muda (#289)', () => {
+    const { rerender } = renderHook(({ ck }) => useLatestClosedReview('student-1', null, ck), {
+      initialProps: { ck: '2026-04' },
+    });
+    expect(mockOnSnapshot).toHaveBeenCalledTimes(1);
+    rerender({ ck: '2026-05' });
+    expect(mockOnSnapshot).toHaveBeenCalledTimes(2);
+  });
+
   it('popula review com o primeiro doc do snapshot', async () => {
     const { result } = renderHook(() => useLatestClosedReview('student-1'));
     const [, onNext] = mockOnSnapshot.mock.calls[0];

--- a/src/__tests__/invariants/studentDashboardPlanGating.test.js
+++ b/src/__tests__/invariants/studentDashboardPlanGating.test.js
@@ -30,12 +30,22 @@ describe('StudentDashboard.jsx — gate de análises por plano (#289)', () => {
     expect(/const planSelected = selectedPlanId != null/.test(src)).toBe(true);
   });
 
-  it('gateia MetricsCards, SetupAnalysis, EmotionAnalysis e TradingCalendar por planSelected', () => {
-    // cada analytic que soma result aparece sob um guard planSelected &&
+  it('gateia MetricsCards, EmotionAnalysis, TradingCalendar e a linha SWOT/Setup por planSelected', () => {
+    // cada analytic que soma result / é relativo ao plano aparece sob planSelected &&
     expect(/planSelected && \(\s*<MetricsCards/.test(src)).toBe(true);
-    expect(/planSelected && <SetupAnalysis/.test(src)).toBe(true);
     expect(/planSelected && \(\s*<div[^>]*>\s*<EmotionAnalysis/.test(src)).toBe(true);
     expect(/planSelected && \(\s*<div className="lg:col-span-1">\s*<TradingCalendar/.test(src)).toBe(true);
+    // Fase 2: SWOT e Setup vivem juntos numa linha grid gated por plano
+    expect(/planSelected && \(\s*<div className="grid[^"]*">\s*<SwotAnalysis/.test(src)).toBe(true);
+    expect(/<SetupAnalysis/.test(src)).toBe(true);
+  });
+
+  it('SWOT recebe a review do ciclo (cycleReview) e a Maturidade segue o ciclo (#289 Fase 2)', () => {
+    // SWOT consome a review elevada (filtrada por cycleKey), não fetch próprio
+    expect(/<SwotAnalysis\s+review=\{cycleReview\}/.test(src)).toBe(true);
+    // Maturidade exibida = frozen (ciclo passado) vs viva (ciclo ativo)
+    expect(/const displayMaturity = isPastCycle/.test(src)).toBe(true);
+    expect(/maturity=\{displayMaturity\}/.test(src)).toBe(true);
   });
 
   it('NÃO gateia a Curva de Patrimônio (EquityCurve sempre visível)', () => {

--- a/src/components/SwotAnalysis.jsx
+++ b/src/components/SwotAnalysis.jsx
@@ -14,7 +14,6 @@ import {
   CheckCircle2, Loader2,
 } from 'lucide-react';
 import DebugBadge from './DebugBadge';
-import useLatestClosedReview from '../hooks/useLatestClosedReview';
 import { formatDate } from '../utils/calculations';
 
 const QUADRANTS = [
@@ -77,11 +76,10 @@ const SourceBadge = ({ swot }) => {
   );
 };
 
-const SwotAnalysis = ({ studentId, planId = null, accountPlanIds = null, onNavigateToReview }) => {
-  // Precedência: planId específico > accountPlanIds (conta sem plano) > null (global)
-  const planFilter = planId || accountPlanIds || null;
-  const { review, loading } = useLatestClosedReview(studentId || null, planFilter);
-
+// review/loading são fornecidos pelo StudentDashboard (#289): o fetch foi
+// elevado para uma fonte única (useLatestClosedReview com filtro de ciclo),
+// compartilhada com o card de Maturidade (snapshot congelado do ciclo).
+const SwotAnalysis = ({ review = null, loading = false, onNavigateToReview }) => {
   if (loading) {
     return (
       <div className="glass-card p-6" data-testid="swot-loading">

--- a/src/hooks/useLatestClosedReview.js
+++ b/src/hooks/useLatestClosedReview.js
@@ -9,6 +9,9 @@
  * @param {string|null} studentId - UID do aluno. Se null, não dispara listener.
  * @param {string|string[]|null} [planFilter=null] - string → where(planId ==);
  *   array → where(planId in) (máx 30); array vazio → sem review; null → sem filtro.
+ * @param {string|null} [cycleKey=null] - quando truthy, restringe à review daquele
+ *   ciclo (review.cycleKey ou frozenSnapshot.planContext.cycleKey). null → sem filtro
+ *   de ciclo (última review fechada). Passe null para "Todos os ciclos" (#289).
  * @returns {{ review: Object|null, loading: boolean, error: Error|null }}
  */
 
@@ -18,7 +21,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase';
 
-const useLatestClosedReview = (studentId, planFilter = null) => {
+const useLatestClosedReview = (studentId, planFilter = null, cycleKey = null) => {
   const [review, setReview] = useState(null);
   const [loading, setLoading] = useState(Boolean(studentId));
   const [error, setError] = useState(null);
@@ -26,6 +29,7 @@ const useLatestClosedReview = (studentId, planFilter = null) => {
   const planFilterKey = Array.isArray(planFilter)
     ? `arr:${planFilter.join(',')}`
     : (planFilter || '');
+  const cycleKeyDep = cycleKey || '';
 
   useEffect(() => {
     if (!studentId) {
@@ -63,12 +67,23 @@ const useLatestClosedReview = (studentId, planFilter = null) => {
       return null; // null = sem filtro
     })();
 
-    const matches = (data) => {
+    const matchesPlan = (data) => {
       if (!allowedSet) return true;
       const top = data?.planId;
       const frozen = data?.frozenSnapshot?.planContext?.planId;
       return (top && allowedSet.has(top)) || (frozen && allowedSet.has(frozen));
     };
+
+    // Filtro de ciclo (#289): só quando cycleKey truthy. Aceita match no topo
+    // ou no snapshot congelado (planContext.cycleKey).
+    const matchesCycle = (data) => {
+      if (!cycleKey) return true;
+      const top = data?.cycleKey;
+      const frozen = data?.frozenSnapshot?.planContext?.cycleKey;
+      return top === cycleKey || frozen === cycleKey;
+    };
+
+    const matches = (data) => matchesPlan(data) && matchesCycle(data);
 
     const unsub = onSnapshot(
       q,
@@ -89,7 +104,7 @@ const useLatestClosedReview = (studentId, planFilter = null) => {
     );
 
     return () => unsub();
-  }, [studentId, planFilterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [studentId, planFilterKey, cycleKeyDep]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { review, loading, error };
 };

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -75,6 +75,8 @@ import useMasterData from '../hooks/useMasterData';
 import { useSetups } from '../hooks/useSetups';
 import { useMaturity } from '../hooks/useMaturity';
 import { useRecomputeStudentMaturity } from '../hooks/useRecomputeStudentMaturity';
+import useLatestClosedReview from '../hooks/useLatestClosedReview';
+import { ALL_CYCLES_KEY } from '../utils/cycleResolver';
 import { currentTrigger, shouldGenerateAI } from '../utils/maturityAITrigger';
 
 // Contexto unificado (issue #118 — DEC-047)
@@ -356,6 +358,20 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
   // aparecem com plano selecionado — garante escopo de moeda única + baseline.
   // Sem plano sobra só a Curva de Patrimônio (nível-conta, multi-moeda própria).
   const planSelected = selectedPlanId != null;
+
+  // Review do ciclo selecionado (#289 Fase 2): fonte única, compartilhada entre
+  // SWOT e o card de Maturidade. Filtra por plano + cycleKey (null em "Todos os
+  // ciclos" → última review). Ciclo passado (read-only) usa o maturitySnapshot
+  // congelado desta review; ciclo ativo usa a maturidade viva (maturity/current).
+  const swotPlanFilter = selectedPlanId || swotAccountPlanIds || null;
+  const cycleFilter = studentCtx.cycleKey === ALL_CYCLES_KEY ? null : (studentCtx.cycleKey || null);
+  const { review: cycleReview, loading: cycleReviewLoading } = useLatestClosedReview(
+    maturityStudentId, swotPlanFilter, cycleFilter,
+  );
+  const isPastCycle = Boolean(studentCtx.isReadOnlyCycle);
+  const displayMaturity = isPastCycle
+    ? (cycleReview?.frozenSnapshot?.maturitySnapshot ?? null)
+    : maturity;
 
   // === Handlers ===
   const handleViewFeedbackHistory = (trade) => {
@@ -726,23 +742,25 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         );
       })()}
 
-      {/* Análises */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <SwotAnalysis
-          studentId={overrideStudentId || user?.uid}
-          planId={selectedPlanId}
-          accountPlanIds={swotAccountPlanIds}
-          /* TODO(#164): onNavigateToReview — aguardando rota aluno para Revisão Semanal
-             (hoje 'weekly-review' é restrita a mentor em App.jsx). */
-        />
-        {planSelected && <SetupAnalysis trades={filteredTrades} setupsMeta={setups} currency={dominantCurrency || 'BRL'} />}
-      </div>
+      {/* Análises — gated por plano (#289). SWOT segue o ciclo selecionado via
+          cycleReview (Fase 2). */}
+      {planSelected && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+          <SwotAnalysis
+            review={cycleReview}
+            loading={cycleReviewLoading}
+            /* TODO(#164): onNavigateToReview — aguardando rota aluno para Revisão Semanal
+               (hoje 'weekly-review' é restrita a mentor em App.jsx). */
+          />
+          <SetupAnalysis trades={filteredTrades} setupsMeta={setups} currency={dominantCurrency || 'BRL'} />
+        </div>
+      )}
       {planSelected && (
         <div className="mb-6">
           <EmotionAnalysis
             trades={filteredTrades}
             globalWR={stats?.winRate}
-            maturity={maturity}
+            maturity={displayMaturity}
             currency={dominantCurrency || 'BRL'}
           />
         </div>
@@ -751,21 +769,35 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
       {/* Progressão de Maturidade (issue #119 D13) — posicionado logo após a
           Matriz Emocional 4D para manter a ligação visual "depois da matriz".
           PendingTakeaways permanece antes. INV-17 consolidação: quadrante
-          Maturidade da Matriz 4D foi reduzido a teaser. */}
-      <div className="mb-6">
-        <MaturityProgressionCard
-          maturity={maturity}
-          loading={maturityLoading}
-          error={maturityError}
-          aiGenerating={aiGenerating}
-          aiError={aiError}
-          onRefresh={handleRefreshMaturity}
-          refreshing={recomputeLoading}
-          refreshThrottled={recomputeThrottled}
-          refreshNextAllowedAt={recomputeNextAllowedAt}
-          refreshError={recomputeError}
-        />
-      </div>
+          Maturidade da Matriz 4D foi reduzido a teaser.
+          #289 Fase 2: gated por plano. Ciclo passado (read-only) mostra o
+          maturitySnapshot congelado da review do ciclo, sem refresh/IA; ciclo
+          ativo mostra a maturidade viva. */}
+      {planSelected && (
+        <div className="mb-6">
+          {isPastCycle && !displayMaturity ? (
+            <div className="glass-card p-6 text-center">
+              <h3 className="font-bold text-white text-sm mb-1">Progressão de Maturidade</h3>
+              <p className="text-slate-400 text-sm">
+                Sem revisão fechada neste ciclo — maturidade histórica indisponível.
+              </p>
+            </div>
+          ) : (
+            <MaturityProgressionCard
+              maturity={displayMaturity}
+              loading={isPastCycle ? cycleReviewLoading : maturityLoading}
+              error={isPastCycle ? null : maturityError}
+              aiGenerating={isPastCycle ? false : aiGenerating}
+              aiError={isPastCycle ? null : aiError}
+              onRefresh={isPastCycle ? null : handleRefreshMaturity}
+              refreshing={recomputeLoading}
+              refreshThrottled={recomputeThrottled}
+              refreshNextAllowedAt={recomputeNextAllowedAt}
+              refreshError={recomputeError}
+            />
+          )}
+        </div>
+      )}
 
       {/* Modais */}
       <AddTradeModal isOpen={showAddModal} onClose={() => { setShowAddModal(false); setEditingTrade(null); }} onSubmit={handleAddTrade} editTrade={editingTrade} loading={isSubmitting} plans={plans} />


### PR DESCRIPTION
**Parte 2/2 do #289 — encerra o issue.** Continua de #290 (Fase 1, mergeada).

## Solução (Fase 2)

Fecha a coerência de IA: o que vive em revisões semanais segue o **ciclo** selecionado na barra de contexto.

- **SWOT segue o ciclo**: `useLatestClosedReview` ganha filtro `cycleKey` (match no topo ou em `frozenSnapshot.planContext.cycleKey`); `null` = sem filtro ("Todos os ciclos" → última revisão).
- **Arquitetura**: fetch da review elevado para `StudentDashboard` (fonte única, compartilhada entre SWOT e Maturidade). `SwotAnalysis` vira presentacional (`review`/`loading` como props).
- **Maturidade segue o ciclo**:
  - Ciclo **passado** (`isReadOnlyCycle`) → `maturitySnapshot` **congelado** da revisão do ciclo, **read-only** (sem refresh/IA).
  - Ciclo **ativo** → maturidade **viva** (`maturity/current`).
  - Ciclo passado **sem revisão** → empty-state.
- **Gate**: SWOT + Maturidade agora atrás de `planSelected` (precisam de ciclo → plano). Convergência final: **sem plano = só Curva de Patrimônio + CTA.**

## Sem mudança de persistência
INV-15 não dispara — `cycleKey` e `maturitySnapshot` já existem nos docs de review (createWeeklyReview / clientSnapshotBuilder). Só reescopo de query + leitura.

## Testes
- `useLatestClosedReview`: +4 casos de `cycleKey` (14 total).
- `SwotAnalysis.test.jsx`: reescrito para props (8).
- Invariante de gate: +1 caso Fase 2 (5).
- Suíte **3324 verdes** (209 arquivos) + build.

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)