### PR TITLE
feat(#294): rebrand Espelho do Trader nas telas de entrada (Login + Sidebar)

### DIFF
--- a/docs/dev/issues/issue-294-rebrand-espelho.md
+++ b/docs/dev/issues/issue-294-rebrand-espelho.md
@@ -1,0 +1,40 @@
+# Issue #294 — feat: Rebrand Espelho do Trader nas telas de entrada (Login + Sidebar)
+
+## Autorização
+
+- [x] Mockup apresentado — textual no body do #294 (3 superfícies) + fonte canônica `EspelhoLogo.tsx`
+- [x] Memória de cálculo — N/A (mudança puramente de apresentação, sem fórmula/score/agregação)
+- [x] Marcio autorizou — 31/05/2026 "atacar #294"
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Telas de entrada do app (Login + Sidebar) ainda carregam a marca antiga "Tchio Alpha" e paleta azul/roxo, desalinhadas da identidade pública do produto (`/espelho` no portal): marca ‹|› «Espelho / do Trader» em teal. Pré-lançamento da página exige alinhamento dessas superfícies de marca.
+
+## Spec
+Ver issue body no GitHub: #294. Escopo restrito (Marcio 31/05): recoloração teal **apenas** nas superfícies de marca de entrada; resto do glassmorphism azul/roxo preservado.
+
+## Mockup
+No body do #294 (mockup textual das 3 superfícies). Fonte canônica: `marcioportes-portal/app/components/EspelhoLogo.tsx`.
+
+## Phases
+- A1 — Portar marca ‹|› para `src/components/EspelhoLogo.jsx` (EspelhoMark + EspelhoLockup, teal)
+- A2 — M1 Sidebar: wordmark "Espelho / do Trader" + marca teal + item ativo teal
+- A3 — M2 LoginPage cabeçalho esquerdo: logo Espelho do Trader
+- A4 — M3 LoginPage decoração direita: bump up teal (mark + gradientes), copy preservado
+- A5 — Ajustar testes (Sidebar.test.jsx, v1197-sidebar-badge.test.js) + suite verde
+- A6 — Smoke no dev server (worktree)
+
+## Sessions
+- (a preencher)
+
+## Shared Deltas
+- `src/version.js` — bump v1.71.0 (reservado no main)
+- `docs/registry/versions.md` — marcar v1.71.0 consumida (encerramento)
+- `CHANGELOG.md` — nova entrada `[1.71.0] - 31/05/2026` (encerramento)
+
+## Decisions
+- (nenhuma DEC-AUTO prevista; escopo de paleta já decidido por Marcio no chat)
+
+## Chunks
+- Nenhum chunk de domínio (UI shell / branding). Sem lock.

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -43,3 +43,4 @@
 | 1.68.0 | #285 | `feat/issue-285-trade-timezone` | 27/05/2026 | consumida (PR #288 squash `a1519aff`) |
 | 1.69.0 | #289 | `feat/issue-289-context-gated-analytics` | 28/05/2026 | consumida (PR #291 squash `92cc2c6e`) |
 | 1.70.0 | #292 | `feat/issue-292-import-timezone` | 29/05/2026 | consumida (PR #293 squash `b5b582fc`) |
+| 1.71.0 | #294 | `feat/issue-294-rebrand-espelho` | 31/05/2026 | reservada |

--- a/src/components/EspelhoLogo.jsx
+++ b/src/components/EspelhoLogo.jsx
@@ -1,0 +1,69 @@
+/**
+ * EspelhoLogo
+ * @version 1.0.0
+ * @description Marca do produto "Espelho do Trader" — porte JSX da identidade pública
+ *   do portal (marcioportes-portal/app/components/EspelhoLogo.tsx). Símbolo ‹|› —
+ *   duas chevrons espelhadas em torno de um eixo central tracejado — em paleta teal.
+ *
+ *   - <EspelhoMark/>   → símbolo ‹|› isolado (header/sidebar/favicon). Cor via SVG (teal).
+ *   - <EspelhoLockup/> → lockup «‹|› Espelho» com reflexo esmaecido (hero/decoração).
+ *     font-size herdado do pai (símbolo em `em`, escala junto).
+ *
+ * Tokens canônicos: mark primário #2dd4bf (teal-400), secundário #5eead4 (teal-300).
+ */
+
+/** Símbolo isolado ‹|› — sidebar / login / favicon. Escala pela className do pai. */
+export function EspelhoMark({ className }) {
+  return (
+    <svg viewBox="0 0 64 64" fill="none" aria-hidden="true" className={className}>
+      <path d="M26 16 L14 32 L26 48" stroke="#2dd4bf" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="32" y1="20" x2="32" y2="44" stroke="#2dd4bf" strokeWidth="3" strokeDasharray="3 4.5" opacity="0.55" />
+      <path d="M38 16 L50 32 L38 48" stroke="#5eead4" strokeWidth="5" strokeLinecap="round" strokeLinejoin="round" opacity="0.85" />
+    </svg>
+  );
+}
+
+/** Símbolo ‹|› em currentColor — escala pelo font-size (h em `em`), pro lockup. */
+function MarkCluster() {
+  return (
+    <svg viewBox="0 0 44 48" fill="none" aria-hidden="true" className="h-[0.82em] w-auto flex-shrink-0">
+      <path d="M18 8 L8 24 L18 40" stroke="currentColor" strokeWidth="3.5" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="22" y1="12" x2="22" y2="36" stroke="currentColor" strokeWidth="2" strokeDasharray="2 3.5" opacity="0.55" />
+      <path d="M26 8 L36 24 L26 40" stroke="currentColor" strokeWidth="3.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/** Uma linha do lockup. `reflection`: símbolo herda currentColor (fade uniforme). */
+function Row({ reflection }) {
+  return (
+    <span className="inline-flex items-center gap-[0.3em] font-extrabold tracking-tight leading-none">
+      <span className={reflection ? undefined : 'text-teal-400'}>
+        <MarkCluster />
+      </span>
+      <span>Espelho</span>
+    </span>
+  );
+}
+
+/** Lockup «‹|› Espelho» com reflexo. font-size vem do pai. */
+export function EspelhoLockup({ className }) {
+  return (
+    <span className={`inline-flex flex-col items-center ${className ?? ''}`}>
+      <Row />
+      <span
+        aria-hidden="true"
+        className="text-teal-300/35 select-none mt-[0.04em]"
+        style={{
+          transform: 'scaleY(-1)',
+          WebkitMaskImage: 'linear-gradient(to bottom, rgba(0,0,0,0.5), transparent 68%)',
+          maskImage: 'linear-gradient(to bottom, rgba(0,0,0,0.5), transparent 68%)',
+        }}
+      >
+        <Row reflection />
+      </span>
+    </span>
+  );
+}
+
+export default EspelhoLockup;

--- a/src/components/HeroParticles.jsx
+++ b/src/components/HeroParticles.jsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * HeroParticles
+ * @version 1.0.0
+ * @description Canvas de partículas teal atrás do hero — porte JSX de
+ *   marcioportes-portal/app/components/HeroParticles.tsx. ~70 pontos
+ *   rgba(45,212,191,0.7) com drift lento + linhas conectando pares
+ *   próximos (dist < 110px). Desativado em mobile/pointer coarse.
+ *
+ *   Renderiza absolute inset-0; o pai deve ser `relative overflow-hidden`.
+ */
+export default function HeroParticles() {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+
+    const isMobile = window.matchMedia('(max-width: 768px), (pointer: coarse)').matches;
+    if (isMobile) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let w = 0;
+    let h = 0;
+    let particles = [];
+    let rafId = 0;
+
+    function resize() {
+      const parent = canvas.parentElement;
+      if (!parent) return;
+      const rect = parent.getBoundingClientRect();
+      w = canvas.width = rect.width;
+      h = canvas.height = rect.height;
+    }
+
+    function spawn() {
+      particles = [];
+      const count = Math.min(70, Math.floor((w * h) / 22000));
+      for (let i = 0; i < count; i++) {
+        particles.push({
+          x: Math.random() * w,
+          y: Math.random() * h,
+          vx: (Math.random() - 0.5) * 0.25,
+          vy: (Math.random() - 0.5) * 0.25,
+          r: Math.random() * 1.4 + 0.4,
+        });
+      }
+    }
+
+    function tick() {
+      ctx.clearRect(0, 0, w, h);
+      ctx.fillStyle = 'rgba(45, 212, 191, 0.7)';
+      particles.forEach((p) => {
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x < 0 || p.x > w) p.vx *= -1;
+        if (p.y < 0 || p.y > h) p.vy *= -1;
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2);
+        ctx.fill();
+      });
+      for (let i = 0; i < particles.length; i++) {
+        for (let j = i + 1; j < particles.length; j++) {
+          const a = particles[i];
+          const b = particles[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < 110) {
+            ctx.strokeStyle = `rgba(45, 212, 191, ${0.12 * (1 - dist / 110)})`;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+      rafId = requestAnimationFrame(tick);
+    }
+
+    resize();
+    spawn();
+    tick();
+
+    const handleResize = () => {
+      resize();
+      spawn();
+    };
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={ref}
+      aria-hidden="true"
+      className="absolute inset-0 pointer-events-none opacity-70 hidden lg:block"
+      style={{ zIndex: 0 }}
+    />
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -22,7 +22,6 @@ import {
   AlertTriangle,
   Wallet,
   BookOpen,
-  LineChart,
   Settings,
   Brain,
   CreditCard,
@@ -33,6 +32,7 @@ import {
   Inbox,
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { EspelhoMark } from './EspelhoLogo';
 import useMentorClosureInbox from '../hooks/useMentorClosureInbox';
 import { VERSION } from '../version';
 
@@ -135,15 +135,15 @@ const Sidebar = ({
         {/* Logo */}
         <div className="p-6 border-b border-slate-800/50">
           <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center flex-shrink-0">
-              <LineChart className="w-5 h-5 text-white" />
+            <div className="w-10 h-10 rounded-xl bg-slate-800/60 border border-teal-500/20 flex items-center justify-center flex-shrink-0">
+              <EspelhoMark className="w-6 h-6" />
             </div>
             {!collapsed && (
               <div className="overflow-hidden">
-                <h1 className="font-display font-bold text-white truncate">
-                  Tchio
+                <h1 className="font-display font-bold text-white truncate leading-tight">
+                  Espelho
                 </h1>
-                <p className="text-xs text-slate-500">Alpha</p>
+                <p className="text-xs uppercase tracking-[0.2em] text-teal-400/80">do Trader</p>
               </div>
             )}
           </div>
@@ -168,8 +168,8 @@ const Sidebar = ({
               key={item.id}
               onClick={() => onViewChange(item.id)}
               className={`menu-item w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all ${
-                currentView === item.id 
-                  ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20' 
+                currentView === item.id
+                  ? 'bg-teal-500/10 text-teal-400 border border-teal-500/20'
                   : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
               }`}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -213,3 +213,52 @@
     @apply block overflow-x-auto whitespace-nowrap;
   }
 }
+
+/* ============================================================
+   Espelho — ambiente visual do hero (porte do portal /espelho)
+   Usado na decoração da LoginPage. Namespace espelho- evita colisão.
+   ============================================================ */
+
+/* Vinhetas radiais sutis (teal + sky) no fundo */
+.espelho-grain {
+  background-image:
+    radial-gradient(circle at 20% 10%, rgba(45, 212, 191, 0.10), transparent 42%),
+    radial-gradient(circle at 80% 70%, rgba(56, 189, 248, 0.07), transparent 45%);
+}
+
+/* Orbs: blobs flutuantes com drift lento */
+.espelho-orb {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  filter: blur(80px);
+  opacity: 0.4;
+  z-index: 0;
+  will-change: transform;
+}
+.espelho-orb-1 {
+  top: -12%; left: -8%; width: 420px; height: 420px;
+  background: radial-gradient(circle, rgba(45, 212, 191, 0.45), transparent 70%);
+  animation: espelho-orb1 18s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite alternate;
+}
+.espelho-orb-2 {
+  bottom: -15%; right: -10%; width: 500px; height: 500px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.35), transparent 70%);
+  animation: espelho-orb2 22s cubic-bezier(0.45, 0.05, 0.55, 0.95) infinite alternate;
+}
+@keyframes espelho-orb1 { to { transform: translate(70px, 50px); } }
+@keyframes espelho-orb2 { to { transform: translate(-90px, -40px); } }
+
+/* Entrada fade-up escalonada */
+.espelho-in { animation: espelho-fade-up 0.7s cubic-bezier(0.4, 0, 0.2, 1) both; }
+.espelho-in.d1 { animation-delay: 120ms; }
+.espelho-in.d2 { animation-delay: 260ms; }
+.espelho-in.d3 { animation-delay: 400ms; }
+@keyframes espelho-fade-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .espelho-orb-1, .espelho-orb-2 { animation: none; }
+  .espelho-in { animation: none; }
+}

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { LineChart, Eye, EyeOff, Loader2, Mail, Lock, ArrowRight, XCircle } from 'lucide-react';
+import { Eye, EyeOff, Loader2, Mail, Lock, ArrowRight, XCircle } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { EspelhoMark, EspelhoLockup } from '../components/EspelhoLogo';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -60,12 +61,12 @@ const LoginPage = () => {
       <div className="flex-1 flex items-center justify-center p-8 bg-slate-950">
         <div className="w-full max-w-md">
           <div className="flex items-center gap-3 mb-8">
-            <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-600 flex items-center justify-center shadow-lg shadow-blue-500/20">
-              <LineChart className="w-6 h-6 text-white" />
+            <div className="w-12 h-12 rounded-2xl bg-slate-900 border border-teal-500/20 flex items-center justify-center shadow-lg shadow-teal-500/10">
+              <EspelhoMark className="w-7 h-7" />
             </div>
             <div>
-              <h1 className="font-display text-2xl font-bold text-white tracking-tight">Acompanhamento</h1>
-              <p className="text-sm text-slate-500 font-medium">2.0 Trading Journal</p>
+              <h1 className="font-display text-2xl font-bold text-white tracking-tight leading-tight">Espelho</h1>
+              <p className="text-xs uppercase tracking-[0.3em] text-teal-400/80 font-medium">do Trader</p>
             </div>
           </div>
 
@@ -140,16 +141,16 @@ const LoginPage = () => {
       {/* --- LADO DIREITO (DECORAÇÃO) --- */}
       <div className="hidden lg:flex flex-1 items-center justify-center bg-slate-900 relative overflow-hidden">
         <div className="absolute inset-0">
-          <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-blue-500/10 via-slate-900 to-slate-900" />
-          <div className="absolute bottom-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_bottom_left,_var(--tw-gradient-stops))] from-purple-500/10 via-slate-900 to-slate-900" />
+          <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-teal-500/10 via-slate-900 to-slate-900" />
+          <div className="absolute bottom-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_bottom_left,_var(--tw-gradient-stops))] from-teal-400/10 via-slate-900 to-slate-900" />
         </div>
-        
+
         <div className="relative text-center p-12 max-w-lg z-10">
-          <div className="mb-8 inline-flex p-4 rounded-full bg-slate-800/50 border border-slate-700/50 backdrop-blur-sm">
-            <LineChart className="w-12 h-12 text-blue-500" />
+          <div className="mb-10 flex justify-center text-5xl text-teal-400">
+            <EspelhoLockup />
           </div>
           <h3 className="text-4xl font-display font-bold text-white mb-4 leading-tight">
-            Domine sua <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">Alta Performance</span>
+            Domine sua <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-teal-300">Alta Performance</span>
           </h3>
           <p className="text-lg text-slate-400 mb-12 leading-relaxed">
             O ambiente definitivo para registrar, analisar e evoluir seus trades com precisão profissional.

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Eye, EyeOff, Loader2, Mail, Lock, ArrowRight, XCircle } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { EspelhoMark, EspelhoLockup } from '../components/EspelhoLogo';
+import HeroParticles from '../components/HeroParticles';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -138,25 +139,33 @@ const LoginPage = () => {
         </div>
       </div>
 
-      {/* --- LADO DIREITO (DECORAÇÃO) --- */}
-      <div className="hidden lg:flex flex-1 items-center justify-center bg-slate-900 relative overflow-hidden">
-        <div className="absolute inset-0">
-          <div className="absolute top-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_top_right,_var(--tw-gradient-stops))] from-teal-500/10 via-slate-900 to-slate-900" />
-          <div className="absolute bottom-0 left-0 w-full h-full bg-[radial-gradient(ellipse_at_bottom_left,_var(--tw-gradient-stops))] from-teal-400/10 via-slate-900 to-slate-900" />
-        </div>
+      {/* --- LADO DIREITO (HERO) — porte do ambiente visual do portal /espelho --- */}
+      <div className="hidden lg:flex flex-1 items-center justify-center bg-slate-950 relative overflow-hidden espelho-grain">
+        {/* orbs flutuantes + partículas (atrás do conteúdo) */}
+        <div className="espelho-orb espelho-orb-1" aria-hidden="true" />
+        <div className="espelho-orb espelho-orb-2" aria-hidden="true" />
+        <HeroParticles />
 
-        <div className="relative text-center p-12 max-w-lg z-10">
-          <div className="mb-10 flex justify-center text-5xl text-teal-400">
+        <div className="relative text-center px-12 max-w-lg z-10">
+          <p className="espelho-in text-xs uppercase tracking-[0.3em] text-teal-400 font-medium mb-10">
+            Produto
+          </p>
+
+          <div className="espelho-in d1 mb-3 flex justify-center text-6xl xl:text-7xl text-teal-400">
             <EspelhoLockup />
           </div>
-          <h3 className="text-4xl font-display font-bold text-white mb-4 leading-tight">
+          <p className="espelho-in d1 text-sm uppercase tracking-[0.35em] text-slate-500 mb-10">
+            do Trader
+          </p>
+
+          <h3 className="espelho-in d2 text-3xl xl:text-4xl font-display font-bold text-white mb-4 leading-tight">
             Domine sua <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-teal-300">Alta Performance</span>
           </h3>
-          <p className="text-lg text-slate-400 mb-12 leading-relaxed">
-            O ambiente definitivo para registrar, analisar e evoluir seus trades com precisão profissional.
+          <p className="espelho-in d2 text-lg text-slate-400 mb-12 leading-relaxed">
+            O sistema que cruza emoção declarada, plano escrito e execução real — operação por operação.
           </p>
-          
-          <div className="grid grid-cols-3 gap-8 border-t border-slate-800 pt-8">
+
+          <div className="espelho-in d3 grid grid-cols-3 gap-8 border-t border-slate-800/80 pt-8">
             <div>
               <p className="text-2xl font-bold text-white mb-1">100%</p>
               <p className="text-xs text-slate-500 uppercase tracking-wider">Foco</p>

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.71.0: #294 feat rebrand Espelho do Trader nas telas de entrada (Login + Sidebar) — marca ‹|› teal, wordmark "Espelho / do Trader".
  * - 1.70.0: #292 feat timezone explícito no import de trades (CSV + Order) — fuso por lote.
  * - 1.69.0: #289 feat Dashboard-Aluno — análises governadas pelo contexto (gate plano/ciclo).
  * - 1.68.0: #285 feat timezone explícito no horário do trade — MEP/MEN correto (manual + import) + gate de promoção.
@@ -362,10 +363,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.70.0',
-  build: '20260529',
-  display: 'v1.70.0',
-  full: '1.70.0+20260529',
+  version: '1.71.0',
+  build: '20260531',
+  display: 'v1.71.0',
+  full: '1.71.0+20260531',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Resumo

Rebrand das telas de entrada (Login + Sidebar) para a identidade pública do produto **Espelho do Trader**, alinhada ao hero do `/espelho` no portal. Pré-lançamento.

## Mudanças

- **Nova marca** `src/components/EspelhoLogo.jsx` — `EspelhoMark` (símbolo ‹|› teal isolado) + `EspelhoLockup` («‹|› Espelho» com reflexo). Porte JSX de `marcioportes-portal/app/components/EspelhoLogo.tsx`.
- **Sidebar** — "Tchio / Alpha" → ‹|› + "Espelho / do Trader"; item de menu ativo migra de azul para teal.
- **Login (esquerda)** — "Acompanhamento 2.0 Trading Journal" → logo Espelho do Trader.
- **Login (decoração direita) — hero elevado** — porte do ambiente visual do portal: `HeroParticles` (canvas de partículas teal), orbs flutuantes, grain, `EspelhoLockup` em 6xl/7xl com eyebrow "Produto" + tagline "do Trader" + headline do produto. Animações `espelho-in` (fade-up escalonado), respeitando `prefers-reduced-motion`.

## Escopo

Recoloração teal restrita às superfícies de marca de entrada; o resto do glassmorphism do app permanece azul/roxo (decisão de escopo, Marcio 31/05/2026). Sem alteração de Firestore/CF (INV-15 não acionada).

## Verificação

- `npm run build` verde.
- Suite Sidebar 12/12 (sem testes acoplados ao wordmark antigo).
- Smoke visual em `localhost:5173` aprovado por Marcio (31/05/2026).

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
