### PR TITLE
fix(#296): correlator op↔trade compara wall-clock (offset-neutro)

### DIFF
--- a/docs/dev/issues/issue-296-correlator-wallclock.md
+++ b/docs/dev/issues/issue-296-correlator-wallclock.md
@@ -1,0 +1,34 @@
+# Issue #296 — fix: correlator tz-cego (import de ordens pede plano retroativo / duplica)
+
+## Autorização
+- [x] Mockup — N/A (sem UI; lógica de correlação)
+- [x] Memória de cálculo — N/A (sem fórmula nova; comparação de tempo wall-clock)
+- [x] Marcio autorizou — 31/05/2026 "resolve o bug"
+- [x] Gate Pré-Código liberado
+
+## Context
+Orders.csv de trades já existentes (criados via Performance.csv) dispara "Criar plano retroativo" + duplica. Correlator compara naive (ordem) vs absoluto (trade c/ offset desde #285/#292); janela 5min; trades em ET ficam 1h fora → não casam → toCreate → gate.
+
+## Spec
+Ver #296. Fix = comparar wall-clock vs wall-clock no correlator.
+
+## Phases
+- A1 — helper `toWallMs` em orderCorrelation.js (extrai YYYY-MM-DDTHH:MM:SS, parseia UTC; fallback toMs)
+- A2 — aplicar em correlateOrder / correlateOrders / correlateCancelledOrders (só comparações de tempo)
+- A3 — teste de regressão (fixture Elza ou sintético): 59/59 com trades ET
+- A4 — suite correlator verde + build
+
+## Sessions
+- (a preencher)
+
+## Shared Deltas
+- src/version.js — v1.71.1 (reservada no main)
+- docs/registry/versions.md — consumir v1.71.1 (encerramento)
+- docs/registry/chunks.md — liberar CHUNK-10 (encerramento)
+- CHANGELOG.md — entrada [1.71.1] (encerramento)
+
+## Decisions
+- (nenhuma DEC-AUTO prevista)
+
+## Chunks
+- CHUNK-10 (escrita) — orderCorrelation.js

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-10 | #296 | `fix/issue-296-correlator-wallclock` | 31/05/2026 | correlator tz-cego (wall-clock) |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -44,3 +44,4 @@
 | 1.69.0 | #289 | `feat/issue-289-context-gated-analytics` | 28/05/2026 | consumida (PR #291 squash `92cc2c6e`) |
 | 1.70.0 | #292 | `feat/issue-292-import-timezone` | 29/05/2026 | consumida (PR #293 squash `b5b582fc`) |
 | 1.71.0 | #294 | `feat/issue-294-rebrand-espelho` | 31/05/2026 | consumida (PR #295 squash `29a669de`) |
+| 1.71.1 | #296 | `fix/issue-296-correlator-wallclock` | 31/05/2026 | reservada |

--- a/src/__tests__/utils/orderCorrelation.test.js
+++ b/src/__tests__/utils/orderCorrelation.test.js
@@ -332,3 +332,44 @@ describe('correlateCancelledOrders', () => {
     expect(result[0].tradeId).toBe('T2');
   });
 });
+
+// ============================================
+// Issue #296 — correlação wall-clock (offset-neutra)
+// Regressão: ordem com horário NAIVE (CSV da corretora) deve casar com trade
+// gravado em fuso explícito (ET/BRT) — mesma hora-de-parede, mesma corretora.
+// Antes do fix, trade em ET ficava 1h fora da janela de 5min → ghost → "nova".
+// ============================================
+describe('correlateOrder — wall-clock tz-neutro (#296)', () => {
+  const naiveOrder = () => makeOrder({
+    instrument: 'MNQM6', side: 'BUY', quantity: 1,
+    submittedAt: '2026-05-01T11:30:49',
+    filledAt: '2026-05-01T11:30:49',
+  });
+  const tradeWithTz = (off) => makeTrade({
+    id: 'tradeMNQ', ticker: 'MNQM6', side: 'LONG', qty: 1,
+    entryTime: `2026-05-01T11:30:49${off}`,
+    exitTime: `2026-05-01T11:37:05${off}`,
+  });
+
+  it.each([
+    ['naive', ''],
+    ['BRT -03:00', '-03:00'],
+    ['ET -04:00', '-04:00'],
+    ['CT -05:00', '-05:00'],
+  ])('casa ordem naive com trade gravado em %s', (_label, off) => {
+    const result = correlateOrder(naiveOrder(), [tradeWithTz(off)]);
+    expect(result.tradeId).toBe('tradeMNQ');
+    expect(result.matchType).not.toBe('ghost');
+  });
+
+  it('correlateOrders: lote inteiro casa com trades em ET (sem órfãs)', () => {
+    const orders = [
+      makeOrder({ _rowIndex: 1, externalOrderId: 'O1', instrument: 'MNQM6', side: 'SELL',
+        submittedAt: '2026-05-01T11:30:49', filledAt: '2026-05-01T11:30:49' }),
+      makeOrder({ _rowIndex: 2, externalOrderId: 'O2', instrument: 'MNQM6', side: 'BUY',
+        submittedAt: '2026-05-01T11:37:05', filledAt: '2026-05-01T11:37:05' }),
+    ];
+    const { correlations } = correlateOrders(orders, [tradeWithTz('-04:00')]);
+    expect(correlations.filter(c => c.tradeId).length).toBe(2);
+  });
+});

--- a/src/utils/orderCorrelation.js
+++ b/src/utils/orderCorrelation.js
@@ -54,6 +54,33 @@ const toMs = (value) => {
 };
 
 /**
+ * Timestamp em ms para COMPARAÇÃO DE PROXIMIDADE op↔trade — hora-de-parede
+ * (wall-clock), offset-neutro (issue #296).
+ *
+ * O horário da ordem chega naive (`2026-05-01T11:30:49`, do CSV da corretora),
+ * enquanto `trade.entryTime` desde #285/#292 é instante absoluto com offset
+ * (`...-04:00`). Comparar naive vs absoluto desloca os dois lados quando os trades
+ * foram gravados em fuso ≠ ambiente (ex.: ET em futuros CME) → 1h de gap → fora da
+ * janela de 5min → falso "operação nova". Como ordem e trade vêm da MESMA corretora
+ * no MESMO fuso de exibição, a hora-de-parede é a chave de junção robusta: extrai
+ * `YYYY-MM-DDTHH:MM:SS` (descarta offset/Z) e parseia como UTC. Sem componente de
+ * hora (data pura, Timestamp Firestore, Date) → fallback `toMs`.
+ *
+ * @param {*} value
+ * @returns {number|null}
+ */
+const toWallMs = (value) => {
+  if (typeof value === 'string') {
+    const m = value.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2})?)/);
+    if (m) {
+      const t = new Date(`${m[1]}T${m[2]}Z`);
+      if (!isNaN(t.getTime())) return t.getTime();
+    }
+  }
+  return toMs(value);
+};
+
+/**
  * Checa se um timestamp de trade tem componente de hora (vs. apenas data).
  * Trades importados por CSV podem ter só data (YYYY-MM-DD ou DD/MM/YYYY sem hora).
  * @param {*} value
@@ -117,7 +144,7 @@ export const correlateOrder = (order, trades) => {
     return { tradeId: null, confidence: 0, matchType: 'ghost', details: 'Sem trades para correlação' };
   }
 
-  const orderTs = toMs(order.filledAt || order.submittedAt);
+  const orderTs = toWallMs(order.filledAt || order.submittedAt);
   if (!orderTs) {
     return { tradeId: null, confidence: 0, matchType: 'ghost', details: 'Ordem sem timestamp' };
   }
@@ -131,8 +158,9 @@ export const correlateOrder = (order, trades) => {
     if (orderInstrument && tradeInstrument && orderInstrument !== tradeInstrument) continue;
 
     // Filtro 2: timestamp — usar entryTime para ordens de abertura, exitTime para fechamento
-    const tradeEntryTs = toMs(trade.entryTime || trade.openedAt);
-    const tradeExitTs = toMs(trade.exitTime || trade.closedAt);
+    // Comparação wall-clock (offset-neutro, #296): ordem naive vs trade absoluto.
+    const tradeEntryTs = toWallMs(trade.entryTime || trade.openedAt);
+    const tradeExitTs = toWallMs(trade.exitTime || trade.closedAt);
 
     // Determinar se a trade tem hora ou só data
     const tradeHasTime = hasTimeComponent(trade.entryTime) || hasTimeComponent(trade.exitTime);
@@ -303,7 +331,7 @@ export const correlateOrders = (orders, trades) => {
   let matchedCount = 0;
 
   for (const order of sortedOrders) {
-    const orderTs = toMs(order.filledAt || order.submittedAt);
+    const orderTs = toWallMs(order.filledAt || order.submittedAt);
 
     if (!orderTs) {
       correlations.push({
@@ -329,8 +357,8 @@ export const correlateOrders = (orders, trades) => {
       const tradeInstrument = (trade.ticker || '').toUpperCase();
       if (orderInstrument && tradeInstrument && orderInstrument !== tradeInstrument) continue;
 
-      const tradeEntryTs = toMs(trade.entryTime || trade.openedAt);
-      const tradeExitTs = toMs(trade.exitTime || trade.closedAt);
+      const tradeEntryTs = toWallMs(trade.entryTime || trade.openedAt);
+      const tradeExitTs = toWallMs(trade.exitTime || trade.closedAt);
       const tradeHasTime = hasTimeComponent(trade.entryTime) || hasTimeComponent(trade.exitTime);
       const window = tradeHasTime ? CORRELATION_WINDOW_MS : CORRELATION_WINDOW_DAY_MS;
 
@@ -456,8 +484,8 @@ export const correlateCancelledOrders = (cancelledOrders, trades) => {
     const status = order?.status;
     if (status !== 'CANCELLED' && status !== 'REJECTED' && status !== 'EXPIRED') continue;
 
-    const submittedTs = toMs(order.submittedAt);
-    const cancelledTs = toMs(order.cancelledAt) || toMs(order.filledAt) || submittedTs;
+    const submittedTs = toWallMs(order.submittedAt);
+    const cancelledTs = toWallMs(order.cancelledAt) || toWallMs(order.filledAt) || submittedTs;
     if (!submittedTs && !cancelledTs) continue;
 
     const orderStart = submittedTs ?? cancelledTs;
@@ -471,8 +499,8 @@ export const correlateCancelledOrders = (cancelledOrders, trades) => {
       const tradeInstrument = (trade.ticker || trade.instrument || '').toUpperCase();
       if (orderInstrument && tradeInstrument && orderInstrument !== tradeInstrument) continue;
 
-      const entryTs = toMs(trade.entryTime || trade.openedAt);
-      const exitTs = toMs(trade.exitTime || trade.closedAt);
+      const entryTs = toWallMs(trade.entryTime || trade.openedAt);
+      const exitTs = toWallMs(trade.exitTime || trade.closedAt);
       if (!entryTs) continue;
 
       const tradeStart = entryTs - CANCEL_TRADE_PADDING_MS;

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.71.1: #296 fix import de ordens pedia plano retroativo / duplicava trades existentes — correlator comparava naive (ordem) vs absoluto (trade); wall-clock neutraliza offset.
  * - 1.71.0: #294 feat rebrand Espelho do Trader nas telas de entrada (Login + Sidebar) (PR #295, 31/05/2026)
  * - 1.70.0: #292 feat timezone explícito no import de trades (CSV + Order) — fuso por lote.
  * - 1.69.0: #289 feat Dashboard-Aluno — análises governadas pelo contexto (gate plano/ciclo).
@@ -363,10 +364,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.71.0',
+  version: '1.71.1',
   build: '20260531',
-  display: 'v1.71.0',
-  full: '1.71.0+20260531',
+  display: 'v1.71.1',
+  full: '1.71.1+20260531',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Problema

Importar **Orders.csv** (Tradovate) de trades que **já existem no plano** (criados antes via Performance.csv) dispara "Criar plano retroativo" e **duplica** as operações. Massa da Elza, MNQ/MYM CME, 01–29/05/2026.

## Causa raiz

O correlator op↔trade (`orderCorrelation.js`) comparava o horário **naive** da ordem (`order.filledAt`, interpretado no fuso do ambiente) contra `trade.entryTime`, que desde #285/#292 é **instante absoluto com offset**. Janela de match = 5 min. Trades gravados em **ET** (default de futuros CME desde #285) ficavam 1h fora da janela → não casavam → operações viravam "novas" (`toCreate`) → gate de cobertura + duplicação.

| Trades gravados em | Antes | Depois |
|---|---|---|
| naive / BRT | 59/59 | 59/59 |
| **ET / CT** | **3/59** | **59/59** |

Não é o `planCoverage` (intacto, #240) nem o seletor de fuso do #292.

## Correção

Helper `toWallMs` — compara **hora-de-parede** (extrai `YYYY-MM-DDTHH:MM:SS`, descarta offset/Z, parseia UTC; fallback `toMs`). Ordem e trade vêm da mesma corretora no mesmo fuso de exibição → wall-clock é a chave de junção tz-proof. Aplicado nas 3 comparações de tempo (`correlateOrder`, `correlateOrders`, `correlateCancelledOrders`).

## Verificação

- Massa real: **59/59** ordens casam em qualquer fuso (naive/BRT/ET/CT). Era 3/59 em ET.
- +5 testes de regressão; suite correlator 31/31; suites order/csv/reconstruction 111/111; build verde.
- Sem alteração de Firestore/CF.

## Follow-ups (fora de escopo, registrados no #296)
- Vigência de plano = fim do período do ciclo (cobertura de trades genuinamente novos; hoje ancora em `plan.createdAt`).
- Default de fuso do order import = BRT fixo (vs ET no CSV/manual) → instante absoluto errado em trades novos do order import.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)
