### PR TITLE
feat(CHUNK-11 Fase 0): baseline + taxonomia + mapa de pesos do framework

### DIFF
--- a/docs/chunks.md
+++ b/docs/chunks.md
@@ -45,7 +45,7 @@ Cada frente de desenvolvimento opera em um branch isolado. Arquivos transversais
 | CHUNK-08 | Mentor Feedback | Feedback do mentor por trade, chat, status de revisão | `Feedback/*`, `feedbackHelpers` | AVAILABLE |
 | CHUNK-09 | Student Onboarding | Assessment 4D, probing, baseline report, marco zero | `Onboarding/*`, `assessment` subcollection | AVAILABLE |
 | CHUNK-10 | Order Import | Import ordens, parse ProfitChart-Pro, criação automática, confronto enriquecido | `OrderImport/*`, `orders` collection, `tradeGateway` | AVAILABLE |
-| CHUNK-11 | Behavioral Detection | Motor de detecção comportamental em 4 camadas — FUTURO | `behavioralDetection` | BLOCKED |
+| CHUNK-11 | Behavioral Detection | Motor unificado de detecção comportamental em camadas (Epic #298) | `behavioralDetection` | AVAILABLE |
 | CHUNK-12 | Cycle Alerts | Monitoramento de ciclos, alertas automáticos — FUTURO | `cycleMonitoring` | BLOCKED |
 | CHUNK-13 | Context Bar | Barra de contexto unificado Conta>Plano>Ciclo>Período, provider, hook | `StudentContextProvider`, `ContextBar`, `useStudentContext` | AVAILABLE |
 | CHUNK-14 | Onboarding Auto | Pipeline CSV→indicadores→Kelly→plano sugerido, wizard de onboarding | `OnboardingWizard`, `kellyCalculator`, `planSuggester` | AVAILABLE |

--- a/docs/dev/behavioral-weight-map.md
+++ b/docs/dev/behavioral-weight-map.md
@@ -1,8 +1,8 @@
 # Mapa de Pesos Comportamentais — derivado do Framework Evolutivo
 
-> **Status: RASCUNHO — aguarda aprovação de Marcio (gate da Fase 0, antes de qualquer wiring na Fase 2).**
-> SSoT de origem: [`trader_evolution_framework.md`](trader_evolution_framework.md).
-> Este mapa substitui os `EVENT_PENALTIES` ad-hoc de `emotionalAnalysisV2.js:77`.
+> **Status: APROVADO por Marcio (01/06/2026)** — inclui as 3 decisões abertas (findings novos pesam em F/O; positivos como bônus; faixas `ruleViolationRate` §5.3 viram gates). Números finais por severidade calibram na Fase 2 sobre a baseline congelada.
+> SSoT de origem: [`trader_evolution_framework.md`](trader_evolution_framework.md). Encodado em `src/constants/behavioralTaxonomy.js`.
+> Este mapa substitui os `EVENT_PENALTIES` ad-hoc de `emotionalAnalysisV2.js:77` (wiring na Fase 2).
 
 ## Princípio
 

--- a/docs/dev/behavioral-weight-map.md
+++ b/docs/dev/behavioral-weight-map.md
@@ -1,0 +1,63 @@
+# Mapa de Pesos Comportamentais — derivado do Framework Evolutivo
+
+> **Status: RASCUNHO — aguarda aprovação de Marcio (gate da Fase 0, antes de qualquer wiring na Fase 2).**
+> SSoT de origem: [`trader_evolution_framework.md`](trader_evolution_framework.md).
+> Este mapa substitui os `EVENT_PENALTIES` ad-hoc de `emotionalAnalysisV2.js:77`.
+
+## Princípio
+
+Cada finding do motor unificado mapeia para **um viés nomeado no framework**, a **dimensão(ões)** 4D que ele informa (E/F/O), e o **efeito** no score/gate. O efeito deriva de:
+- **Vieses** — framework §2.2 (disposition, revenge, overconfidence), §3 Bloco C (FOMO, martingale), §2.3 (regulação/locus).
+- **Bottlenecks de progressão** — §7.1: *loss-aversion + overconfidence* travam o Emocional; *profit-taking/greed* trava o Financeiro; *triggers não-nomeados* travam o Operacional.
+- **Indicador quantitativo de estágio** — §5.3 "Rule Violations %": Stage1 >30% · Stage2 10-20% · Stage3 <5% · Stage4 <1% · Stage5 ~0%. → a **taxa de findings negativos por trade** é a métrica-ponte para os gates de estágio.
+- **Correlação de risco** — §6.2: "High Financial + Low Emotional = False Confidence → blow-up +50%"; martingale/averaging é sinal de blow-up.
+
+## Tabela mestre
+
+Severidade: **A**lta / **M**édia / **B**aixa. Efeito: `penalidade no score da dimensão` e/ou `gate count==0`.
+
+| Finding (família canônica) | Viés (framework §) | Dimensão | Sev | Efeito no score/gate |
+|---|---|---|---|---|
+| `TILT` | Reatividade / regulação baixa (§2.3-2; §7.1 emo) | **E** | A | penalidade E alta; entra na `rule-violation rate`; `tilt+revenge==0` gate 4→5 |
+| `LOSS_CHASING` (revenge + reentrada rápida pós-stop) | Revenge trading (§2.2 Q5) | **E** | A | penalidade E alta; rate; gate 4→5 |
+| `STOP_PANIC` (tampering + breakeven cedo) | Loss aversion / disposition (§2.2; §7.1) | **E** | A | penalidade E alta; `no-stop-tampering count==0` gate 3→4 |
+| `AVERAGING_DOWN` (martingale) | Martingale escalation / denial (§3 Bloco C) | **E+F** | A | penalidade E+F alta (sinal de blow-up §6.2) |
+| `HOLD_ASYMMETRY` | Disposition effect (§2.2 Q4) | **E+F** | M | penalidade E+F |
+| `LATE_EXIT` | Hope / loss aversion (§7.1) | **E+F** | M | penalidade E+F |
+| `EARLY_EXIT` | Disposition / fear (§2.2 Q4) | **E+F** | M | penalidade E+F |
+| `GREED_CLUSTER` | Profit-taking / greed (§3; §7.1 fin) | **F** | M | penalidade **F** (hoje vale zero) |
+| `SUB_SIZING` | Avoidance / subdimensionar (§2.2; UNDERSIZED #129) | **E+F** | M | penalidade; `disciplined-sizing count==0` gate 3→4 |
+| `CHASE_REENTRY` | Overconfidence / FOMO (§2.2 Q6) | **E+O** | M | penalidade; `no-chase count==0` gate 3→4 |
+| `FOMO_ENTRY` | FOMO trigger (§3 Bloco C) | **E+O** | M | penalidade |
+| `OVERTRADING` / `IMPULSE_CLUSTER` | Anxiety / impulsividade; rule violations (§5.3) | **E+O** | M | penalidade; conta como rule-violation |
+| `DIRECTION_FLIP` | Confusion / falta de sistema (§4 operacional) | **O** | B | penalidade O |
+| `HESITATION` | Indecisão / regulação (§2.3) | **E** | B | penalidade E baixa |
+| `CLEAN_EXECUTION` (positivo) | Disciplina — perfil SAGE (§2.4) | **E** | — | **bônus** (reforço positivo) |
+| `TARGET_HIT` (positivo) | Paciência / adesão ao plano (§5) | **E+O** | — | **bônus** |
+
+## Mudanças vs. hoje (o que passa a pesar)
+
+- **Novo no Financeiro (F):** GREED_CLUSTER, AVERAGING_DOWN, HOLD/EARLY/LATE_EXIT, SUB_SIZING — hoje valem zero; o framework os trata como disciplina de gestão de risco/profit-taking (§3, §7.1).
+- **Novo no Operacional (O):** DIRECTION_FLIP, FOMO_ENTRY, OVERTRADING — triggers/sistema (§4).
+- **Mantêm peso no Emocional (E):** TILT, LOSS_CHASING, STOP_PANIC (já pesavam).
+- **Positivos passam a contar como reforço:** CLEAN_EXECUTION, TARGET_HIT.
+
+## Métrica-ponte (gates de estágio)
+
+`ruleViolationRate = findings_negativos_que_contam / trades_na_janela`, comparada às faixas §5.3:
+| Estágio | Rule violations | (gate proposto) |
+|---|---|---|
+| 1→2 | sair de >30% | rate ≤ 0.30 |
+| 2→3 | 10-20% | rate ≤ 0.15 |
+| 3→4 | <5% | rate ≤ 0.05 + counts==0 (tampering/chase/sizing) |
+| 4→5 | ~0% | rate ≤ 0.01 + tilt+revenge==0 |
+
+## Exemplo numérico (massa Elza, 18/05 — dia de descontrole)
+Janela com 9 ops de 18/05, findings: 9×OVERTRADING, 8×IMPULSE, 1×REVENGE(→LOSS_CHASING), 2×reentrada-rápida(→LOSS_CHASING), 1×DIRECTION_FLIP.
+- `ruleViolationRate` do dia ≈ alto → puxa E e O pra baixo; LOSS_CHASING (3 ocorrências) bloqueia gate 4→5; DIRECTION_FLIP penaliza O.
+- (Pesos numéricos exatos por severidade A/M/B a calibrar na Fase 2, sobre a baseline congelada — esta tabela fixa o **mapeamento**, não os números finais.)
+
+## Decisões abertas para Marcio
+1. **OK os findings novos passarem a pesar em F e O** (não só E)? — é o que o framework sugere, mas muda o perfil 4D dos alunos prospectivamente.
+2. **Positivos (CLEAN_EXECUTION/TARGET_HIT) como bônus** no score, ou só informativos?
+3. **Faixas de `ruleViolationRate`** acima (derivadas de §5.3) — aprovar como gates ou manter só os `count==0` atuais?

--- a/docs/dev/issues/issue-299-chunk11-fase0.md
+++ b/docs/dev/issues/issue-299-chunk11-fase0.md
@@ -1,0 +1,30 @@
+# Issue #299 — feat: CHUNK-11 Fase 0 (baseline + taxonomia + mapa de pesos)
+
+## Autorização
+- [x] Plano do épico aprovado (sessão 01/06, arquivo valiant-doodling-sunrise)
+- [ ] **Mapa de pesos (`behavioral-weight-map.md`) aprovado por Marcio** ← gate desta fase
+- [x] Gate Pré-Código liberado (groundwork, zero mudança de produção)
+
+## Context
+Fundação do motor unificado (Epic #298): rede de segurança (snapshot dos score/gates atuais) + SSoT de taxonomia + mapa de pesos derivado do `trader_evolution_framework.md`. Nada plugado em produção nesta fase.
+
+## Spec
+Ver #299 + Epic #298. Plano: valiant-doodling-sunrise.
+
+## Phases (desta issue)
+- A1 — `docs/dev/behavioral-weight-map.md` (memória de cálculo, derivada do framework) → **aprovação Marcio**
+- A2 — `src/constants/behavioralTaxonomy.js` + mirror `functions/maturity/behavioralTaxonomyMirror.js` (encoda o mapa aprovado)
+- A3 — `behavioralBaseline.snapshot.test.js` (congela score/tilt/revenge/gates atuais sobre massa Elza)
+- A4 — `npm test` + build verdes; paridade taxonomia ESM≡CJS
+
+## Sessions
+- (a preencher)
+
+## Shared Deltas
+- src/version.js — v1.72.0 (reservada no main)
+- docs/registry/versions.md — consumir v1.72.0 (encerramento)
+- docs/registry/chunks.md — liberar CHUNK-11 (encerramento)
+- CHANGELOG.md — entrada [1.72.0]
+
+## Chunks
+- CHUNK-11 (escrita)

--- a/docs/dev/issues/issue-299-chunk11-fase0.md
+++ b/docs/dev/issues/issue-299-chunk11-fase0.md
@@ -2,7 +2,7 @@
 
 ## Autorização
 - [x] Plano do épico aprovado (sessão 01/06, arquivo valiant-doodling-sunrise)
-- [ ] **Mapa de pesos (`behavioral-weight-map.md`) aprovado por Marcio** ← gate desta fase
+- [x] **Mapa de pesos (`behavioral-weight-map.md`) aprovado por Marcio** (01/06 "aprovado" — inclui as 3 decisões: findings novos pesam em F/O, positivos como bônus, faixas ruleViolationRate como gates)
 - [x] Gate Pré-Código liberado (groundwork, zero mudança de produção)
 
 ## Context

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-11 | #299 | `feat/issue-299-chunk11-fase0` | 01/06/2026 | Epic #298 Fase 0 — baseline+taxonomia+mapa de pesos |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -45,3 +45,4 @@
 | 1.70.0 | #292 | `feat/issue-292-import-timezone` | 29/05/2026 | consumida (PR #293 squash `b5b582fc`) |
 | 1.71.0 | #294 | `feat/issue-294-rebrand-espelho` | 31/05/2026 | consumida (PR #295 squash `29a669de`) |
 | 1.71.1 | #296 | `fix/issue-296-correlator-wallclock` | 31/05/2026 | consumida (PR #297 squash `42fd3da2`) |
+| 1.72.0 | #299 | `feat/issue-299-chunk11-fase0` | 01/06/2026 | reservada |

--- a/functions/maturity/behavioralTaxonomyMirror.js
+++ b/functions/maturity/behavioralTaxonomyMirror.js
@@ -1,0 +1,170 @@
+// behavioralTaxonomyMirror.js — mirror CJS de src/constants/behavioralTaxonomy.js
+// (CHUNK-11 Epic #298 Fase 0 / issue #299).
+//
+// Paridade OBRIGATÓRIA com o source ESM: qualquer mudança aqui exige refletir
+// `src/constants/behavioralTaxonomy.js` e vice-versa. Teste de paridade em
+// `src/__tests__/constants/behavioralTaxonomy.parity.test.js`.
+//
+// Consumido server-side (maturity/CF) onde ESM não pode ser importado.
+
+const DIMENSIONS = Object.freeze({ E: 'emotional', F: 'financial', O: 'operational' });
+const SEVERITY = Object.freeze({ HIGH: 'HIGH', MEDIUM: 'MEDIUM', LOW: 'LOW' });
+const RESOLUTION = Object.freeze({ HIGH: 'HIGH', MEDIUM: 'MEDIUM', LOW: 'LOW' });
+
+const P = (o) => Object.freeze(o);
+
+const BEHAVIORAL_PATTERNS = Object.freeze({
+  TILT: P({
+    code: 'TILT', family: 'TILT', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Reatividade / regulação baixa (§2.3-2; §7.1 emo)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'ANXIETY',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: true,
+  }),
+  LOSS_CHASING: P({
+    code: 'LOSS_CHASING', family: 'LOSS_CHASING', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Revenge trading (§2.2 Q5)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'REVENGE',
+    resolutionLayer: RESOLUTION.MEDIUM, requires: ['trades'], feedsScore: true, feedsGates: true,
+  }),
+  STOP_PANIC: P({
+    code: 'STOP_PANIC', family: 'STOP_PANIC', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Loss aversion / disposition (§2.2; §7.1)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'PANIC',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: true,
+  }),
+  HESITATION: P({
+    code: 'HESITATION', family: 'HESITATION', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Indecisão / regulação (§2.3)',
+    severityDefault: SEVERITY.LOW, emotionMapping: 'FEAR',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  GREED_CLUSTER: P({
+    code: 'GREED_CLUSTER', family: 'GREED_CLUSTER', valence: 'negative', dimensao: ['F'],
+    viesFramework: 'Profit-taking / greed (§3; §7.1 fin)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'GREED',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  AVERAGING_DOWN: P({
+    code: 'AVERAGING_DOWN', family: 'AVERAGING_DOWN', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Martingale escalation / denial (§3 Bloco C; blow-up §6.2)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'DENIAL',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  HOLD_ASYMMETRY: P({
+    code: 'HOLD_ASYMMETRY', family: 'HOLD_ASYMMETRY', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Disposition effect (§2.2 Q4)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FEAR',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  EARLY_EXIT: P({
+    code: 'EARLY_EXIT', family: 'EARLY_EXIT', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Disposition / fear (§2.2 Q4)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FEAR',
+    resolutionLayer: RESOLUTION.MEDIUM, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  LATE_EXIT: P({
+    code: 'LATE_EXIT', family: 'LATE_EXIT', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Hope / loss aversion (§7.1)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'HOPE',
+    resolutionLayer: RESOLUTION.MEDIUM, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  SUB_SIZING: P({
+    code: 'SUB_SIZING', family: 'SUB_SIZING', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Avoidance / subdimensionar (§2.2; UNDERSIZED #129)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'AVOIDANCE',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders', 'plan'], feedsScore: true, feedsGates: true,
+  }),
+  CHASE_REENTRY: P({
+    code: 'CHASE_REENTRY', family: 'CHASE_REENTRY', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'Overconfidence / FOMO (§2.2 Q6)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FOMO',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: true,
+  }),
+  FOMO_ENTRY: P({
+    code: 'FOMO_ENTRY', family: 'FOMO_ENTRY', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'FOMO trigger (§3 Bloco C)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FOMO',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  OVERTRADING: P({
+    code: 'OVERTRADING', family: 'OVERTRADING', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'Anxiety / rule violations (§5.3)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'ANXIETY',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: true,
+  }),
+  IMPULSE_CLUSTER: P({
+    code: 'IMPULSE_CLUSTER', family: 'OVERTRADING', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'Impulsividade (§5.3) — sub-sinal de OVERTRADING',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'IMPULSIVITY',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  DIRECTION_FLIP: P({
+    code: 'DIRECTION_FLIP', family: 'DIRECTION_FLIP', valence: 'negative', dimensao: ['O'],
+    viesFramework: 'Confusion / falta de sistema (§4)',
+    severityDefault: SEVERITY.LOW, emotionMapping: 'CONFUSION',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  CLEAN_EXECUTION: P({
+    code: 'CLEAN_EXECUTION', family: 'CLEAN_EXECUTION', valence: 'positive', dimensao: ['E'],
+    viesFramework: 'Disciplina — perfil SAGE (§2.4)',
+    severityDefault: null, emotionMapping: 'DISCIPLINE',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  TARGET_HIT: P({
+    code: 'TARGET_HIT', family: 'TARGET_HIT', valence: 'positive', dimensao: ['E', 'O'],
+    viesFramework: 'Paciência / adesão ao plano (§5)',
+    severityDefault: null, emotionMapping: 'PATIENCE',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades', 'plan'], feedsScore: true, feedsGates: false,
+  }),
+});
+
+const LEGACY_CODE_ALIAS = Object.freeze({
+  STOP_TAMPERING: 'STOP_PANIC',
+  STOP_BREAKEVEN_TOO_EARLY: 'STOP_PANIC',
+  STOP_HESITATION: 'HESITATION',
+  HESITATION_PRE_ENTRY: 'HESITATION',
+  RAPID_REENTRY_POST_STOP: 'LOSS_CHASING',
+  STOP_PARTIAL_SIZING: 'SUB_SIZING',
+  CHASE_REENTRY: 'CHASE_REENTRY',
+  REVENGE_CLUSTER: 'LOSS_CHASING',
+  UNDERSIZED_TRADE: 'SUB_SIZING',
+  GREED_CLUSTER: 'GREED_CLUSTER',
+  HOLD_ASYMMETRY: 'HOLD_ASYMMETRY',
+  OVERTRADING: 'OVERTRADING',
+  IMPULSE_CLUSTER: 'IMPULSE_CLUSTER',
+  DIRECTION_FLIP: 'DIRECTION_FLIP',
+  HESITATION: 'HESITATION',
+  STOP_PANIC: 'STOP_PANIC',
+  FOMO_ENTRY: 'FOMO_ENTRY',
+  EARLY_EXIT: 'EARLY_EXIT',
+  LATE_EXIT: 'LATE_EXIT',
+  AVERAGING_DOWN: 'AVERAGING_DOWN',
+  CLEAN_EXECUTION: 'CLEAN_EXECUTION',
+  TARGET_HIT: 'TARGET_HIT',
+  TILT_DETECTED: 'TILT',
+  REVENGE_DETECTED: 'LOSS_CHASING',
+});
+
+function resolveCanonical(code) {
+  if (!code) return null;
+  if (BEHAVIORAL_PATTERNS[code]) return code;
+  return LEGACY_CODE_ALIAS[code] || null;
+}
+
+function getPattern(code) {
+  const canonical = resolveCanonical(code);
+  return canonical ? BEHAVIORAL_PATTERNS[canonical] : null;
+}
+
+const SCORING_CODES = Object.freeze(
+  Object.values(BEHAVIORAL_PATTERNS).filter((p) => p.feedsScore).map((p) => p.code),
+);
+const GATE_CODES = Object.freeze(
+  Object.values(BEHAVIORAL_PATTERNS).filter((p) => p.feedsGates).map((p) => p.code),
+);
+
+module.exports = {
+  DIMENSIONS, SEVERITY, RESOLUTION,
+  BEHAVIORAL_PATTERNS, LEGACY_CODE_ALIAS,
+  resolveCanonical, getPattern, SCORING_CODES, GATE_CODES,
+};

--- a/src/__tests__/constants/behavioralTaxonomy.parity.test.js
+++ b/src/__tests__/constants/behavioralTaxonomy.parity.test.js
@@ -1,0 +1,85 @@
+/**
+ * Paridade ESM↔CJS + invariantes da taxonomia comportamental (CHUNK-11 Fase 0).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import * as esm from '../../constants/behavioralTaxonomy';
+
+const require = createRequire(import.meta.url);
+const cjs = require('../../../functions/maturity/behavioralTaxonomyMirror.js');
+
+describe('behavioralTaxonomy — paridade ESM≡CJS', () => {
+  it('BEHAVIORAL_PATTERNS idêntico', () => {
+    expect(cjs.BEHAVIORAL_PATTERNS).toEqual(esm.BEHAVIORAL_PATTERNS);
+  });
+  it('LEGACY_CODE_ALIAS idêntico', () => {
+    expect(cjs.LEGACY_CODE_ALIAS).toEqual(esm.LEGACY_CODE_ALIAS);
+  });
+  it('SCORING_CODES e GATE_CODES idênticos', () => {
+    expect(cjs.SCORING_CODES).toEqual(esm.SCORING_CODES);
+    expect(cjs.GATE_CODES).toEqual(esm.GATE_CODES);
+  });
+  it('DIMENSIONS/SEVERITY/RESOLUTION idênticos', () => {
+    expect(cjs.DIMENSIONS).toEqual(esm.DIMENSIONS);
+    expect(cjs.SEVERITY).toEqual(esm.SEVERITY);
+    expect(cjs.RESOLUTION).toEqual(esm.RESOLUTION);
+  });
+  it('resolveCanonical/getPattern consistentes', () => {
+    for (const code of ['STOP_TAMPERING', 'REVENGE_CLUSTER', 'TILT', 'UNKNOWN_X']) {
+      expect(cjs.resolveCanonical(code)).toBe(esm.resolveCanonical(code));
+    }
+  });
+});
+
+describe('behavioralTaxonomy — invariantes', () => {
+  const { BEHAVIORAL_PATTERNS, LEGACY_CODE_ALIAS, resolveCanonical, getPattern } = esm;
+
+  it('todo alias aponta para um código canônico existente', () => {
+    for (const [legacy, canonical] of Object.entries(LEGACY_CODE_ALIAS)) {
+      expect(BEHAVIORAL_PATTERNS[canonical], `${legacy}→${canonical}`).toBeTruthy();
+    }
+  });
+
+  it('as 4 sobreposições colapsam corretamente', () => {
+    expect(resolveCanonical('STOP_TAMPERING')).toBe('STOP_PANIC');
+    expect(resolveCanonical('STOP_BREAKEVEN_TOO_EARLY')).toBe('STOP_PANIC');
+    expect(resolveCanonical('RAPID_REENTRY_POST_STOP')).toBe('LOSS_CHASING');
+    expect(resolveCanonical('REVENGE_CLUSTER')).toBe('LOSS_CHASING');
+    expect(resolveCanonical('STOP_PARTIAL_SIZING')).toBe('SUB_SIZING');
+    expect(resolveCanonical('UNDERSIZED_TRADE')).toBe('SUB_SIZING');
+    expect(resolveCanonical('HESITATION_PRE_ENTRY')).toBe('HESITATION');
+    expect(resolveCanonical('STOP_HESITATION')).toBe('HESITATION');
+  });
+
+  it('cada padrão tem code===chave, dimensão válida e severidade coerente com a valência', () => {
+    for (const [key, p] of Object.entries(BEHAVIORAL_PATTERNS)) {
+      expect(p.code).toBe(key);
+      expect(p.dimensao.length).toBeGreaterThan(0);
+      expect(p.dimensao.every((d) => ['E', 'F', 'O'].includes(d))).toBe(true);
+      if (p.valence === 'positive') expect(p.severityDefault).toBeNull();
+      else expect(['HIGH', 'MEDIUM', 'LOW']).toContain(p.severityDefault);
+    }
+  });
+
+  it('todo código legado dos 3 motores resolve para canônico', () => {
+    const legacy = [
+      'STOP_TAMPERING', 'STOP_PARTIAL_SIZING', 'RAPID_REENTRY_POST_STOP',
+      'HESITATION_PRE_ENTRY', 'CHASE_REENTRY', 'STOP_BREAKEVEN_TOO_EARLY', 'STOP_HESITATION',
+      'HOLD_ASYMMETRY', 'REVENGE_CLUSTER', 'GREED_CLUSTER', 'OVERTRADING', 'IMPULSE_CLUSTER',
+      'CLEAN_EXECUTION', 'TARGET_HIT', 'DIRECTION_FLIP', 'UNDERSIZED_TRADE',
+      'FOMO_ENTRY', 'EARLY_EXIT', 'LATE_EXIT', 'AVERAGING_DOWN',
+      'TILT_DETECTED', 'REVENGE_DETECTED',
+    ];
+    for (const code of legacy) {
+      expect(getPattern(code), code).toBeTruthy();
+    }
+  });
+
+  it('positivos são bônus (feedsScore) e não-gate', () => {
+    for (const code of ['CLEAN_EXECUTION', 'TARGET_HIT']) {
+      expect(BEHAVIORAL_PATTERNS[code].valence).toBe('positive');
+      expect(BEHAVIORAL_PATTERNS[code].feedsScore).toBe(true);
+      expect(BEHAVIORAL_PATTERNS[code].feedsGates).toBe(false);
+    }
+  });
+});

--- a/src/__tests__/utils/__snapshots__/behavioralBaseline.snapshot.test.js.snap
+++ b/src/__tests__/utils/__snapshots__/behavioralBaseline.snapshot.test.js.snap
@@ -1,0 +1,28 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Baseline comportamental (Fase 0) — contrato de não-regressão > emotionalAnalysisV2: periodScore [congelado] 1`] = `40`;
+
+exports[`Baseline comportamental (Fase 0) — contrato de não-regressão > emotionalAnalysisV2: revenge [congelado] 1`] = `
+{
+  "count": 2,
+  "detected": true,
+}
+`;
+
+exports[`Baseline comportamental (Fase 0) — contrato de não-regressão > emotionalAnalysisV2: tilt [congelado] 1`] = `
+{
+  "detected": true,
+  "sequences": 1,
+  "totalTiltTrades": 3,
+}
+`;
+
+exports[`Baseline comportamental (Fase 0) — contrato de não-regressão > executionBehaviorEngine: eventos por trade [congelado] 1`] = `
+[
+  {
+    "severity": "HIGH",
+    "tradeId": "T1",
+    "type": "STOP_TAMPERING",
+  },
+]
+`;

--- a/src/__tests__/utils/behavioralBaseline.snapshot.test.js
+++ b/src/__tests__/utils/behavioralBaseline.snapshot.test.js
@@ -1,0 +1,80 @@
+/**
+ * Baseline snapshot (CHUNK-11 Fase 0) — rede de segurança de NÃO-REGRESSÃO.
+ *
+ * Congela os outputs ATUAIS dos motores comportamentais (execução + emocional)
+ * para um conjunto determinístico de fixtures. As Fases 1/3/5 do motor unificado
+ * devem reproduzir estes snapshots bit a bit (modo compat); a Fase 2 (re-baseline
+ * deliberado) regrava com aprovação.
+ *
+ * Fixtures sintéticas e determinísticas (CI-safe — não dependem da massa Elza
+ * em /mnt/c). Cobrem: stop tampering (orders), reentrada rápida pós-loss,
+ * sequência de tilt e revenge por aumento de qty.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectExecutionEvents } from '../../utils/executionBehaviorEngine';
+import {
+  calculatePeriodScore,
+  detectTiltV2,
+  detectRevengeV2,
+  DEFAULT_DETECTION_CONFIG,
+} from '../../utils/emotionalAnalysisV2';
+
+const EMOTIONS = [
+  { name: 'Calmo', score: 2, analysisCategory: 'POSITIVE', behavioralPattern: 'OTHER' },
+  { name: 'Ansioso', score: -2, analysisCategory: 'NEGATIVE', behavioralPattern: 'ANXIETY' },
+  { name: 'Revanche', score: -3, analysisCategory: 'CRITICAL', behavioralPattern: 'REVENGE' },
+];
+const getEmotionConfig = (name) =>
+  EMOTIONS.find((e) => e.name === name) ||
+  { name: name || 'Desconhecida', score: 0, analysisCategory: 'NEUTRAL', behavioralPattern: 'OTHER' };
+
+// ---- Fixtures determinísticas ----
+const TRADES = [
+  { id: 'T1', side: 'LONG', qty: 1, entry: 5100, result: -50, emotionEntry: 'Ansioso',
+    entryTime: '2026-04-22T10:00:00', exitTime: '2026-04-22T10:05:00' },
+  { id: 'T2', side: 'LONG', qty: 2, entry: 5095, result: -40, emotionEntry: 'Revanche',
+    entryTime: '2026-04-22T10:08:00', exitTime: '2026-04-22T10:12:00' },
+  { id: 'T3', side: 'LONG', qty: 4, entry: 5090, result: -30, emotionEntry: 'Revanche',
+    entryTime: '2026-04-22T10:14:00', exitTime: '2026-04-22T10:18:00' },
+  { id: 'T4', side: 'SHORT', qty: 1, entry: 5080, result: 60, emotionEntry: 'Calmo',
+    entryTime: '2026-04-22T11:30:00', exitTime: '2026-04-22T11:45:00' },
+];
+
+// Orders: T1 com stop tampering (stop reemitido mais largo); T1 reentrada rápida coberta por T2.
+const ORDERS = [
+  { externalOrderId: 'O1', instrument: 'ESH6', side: 'BUY', quantity: 1, status: 'FILLED',
+    correlatedTradeId: 'T1', isStopOrder: false, filledAt: '2026-04-22T10:00:00',
+    _ts: Date.parse('2026-04-22T10:00:00Z'), _price: 5100 },
+  { externalOrderId: 'O2', instrument: 'ESH6', side: 'SELL', quantity: 1, status: 'FILLED',
+    correlatedTradeId: 'T1', isStopOrder: true, stopPrice: 5090, filledAt: '2026-04-22T10:01:00',
+    _ts: Date.parse('2026-04-22T10:01:00Z'), _price: 5090 },
+  { externalOrderId: 'O3', instrument: 'ESH6', side: 'SELL', quantity: 1, status: 'FILLED',
+    correlatedTradeId: 'T1', isStopOrder: true, stopPrice: 5080, filledAt: '2026-04-22T10:03:00',
+    _ts: Date.parse('2026-04-22T10:03:00Z'), _price: 5080 },
+];
+
+const simplifyEvents = (events) =>
+  events.map((e) => ({ type: e.type, severity: e.severity, tradeId: e.tradeId ?? null }))
+        .sort((a, b) => (a.type + a.tradeId).localeCompare(b.type + b.tradeId));
+
+describe('Baseline comportamental (Fase 0) — contrato de não-regressão', () => {
+  it('executionBehaviorEngine: eventos por trade [congelado]', () => {
+    expect(simplifyEvents(detectExecutionEvents({ trades: TRADES, orders: ORDERS }))).toMatchSnapshot();
+  });
+
+  it('emotionalAnalysisV2: periodScore [congelado]', () => {
+    const { score } = calculatePeriodScore(TRADES, getEmotionConfig);
+    expect(Math.round(score * 100) / 100).toMatchSnapshot();
+  });
+
+  it('emotionalAnalysisV2: tilt [congelado]', () => {
+    const tilt = detectTiltV2(TRADES, getEmotionConfig, DEFAULT_DETECTION_CONFIG.tilt);
+    expect({ detected: tilt.detected, sequences: tilt.sequences?.length ?? 0,
+             totalTiltTrades: tilt.totalTiltTrades ?? 0 }).toMatchSnapshot();
+  });
+
+  it('emotionalAnalysisV2: revenge [congelado]', () => {
+    const rev = detectRevengeV2(TRADES, getEmotionConfig, DEFAULT_DETECTION_CONFIG.revenge);
+    expect({ detected: rev.detected, count: rev.count ?? rev.instances?.length ?? 0 }).toMatchSnapshot();
+  });
+});

--- a/src/constants/behavioralTaxonomy.js
+++ b/src/constants/behavioralTaxonomy.js
@@ -1,0 +1,203 @@
+/**
+ * behavioralTaxonomy.js — SSoT da taxonomia comportamental unificada (CHUNK-11)
+ * @version 1.0.0 (Epic #298 Fase 0 — issue #299)
+ *
+ * Fonte de verdade ÚNICA dos padrões comportamentais (opinião). Reconcilia os
+ * 7 eventos de execução (#208) + 15 padrões shadow (#129) + tilt/revenge (#189)
+ * numa lista canônica, colapsando as 4 sobreposições. Compliance (fato, INV-21)
+ * NÃO entra aqui.
+ *
+ * Pesos/dimensões DERIVAM de `docs/dev/behavioral-weight-map.md` (aprovado), que
+ * por sua vez deriva de `docs/dev/trader_evolution_framework.md`.
+ *
+ * Paridade obrigatória com o mirror CJS `functions/maturity/behavioralTaxonomyMirror.js`
+ * (teste `src/__tests__/constants/behavioralTaxonomy.parity.test.js`).
+ *
+ * Campos de cada padrão:
+ *   code            — código canônico (chave)
+ *   family          — família p/ dedupe/agregação (códigos sinônimos compartilham)
+ *   valence         — 'negative' | 'positive'
+ *   dimensao        — dimensões 4D que informa: subconjunto de ['E','F','O']
+ *   viesFramework   — viés nomeado + seção do framework
+ *   severityDefault — 'HIGH' | 'MEDIUM' | 'LOW' | null (positivos)
+ *   emotionMapping  — emoção associada (mantém vocabulário de #129)
+ *   resolutionLayer — 'LOW' | 'MEDIUM' | 'HIGH' (DEC-074: ordens>parciais>sequência)
+ *   requires        — dados necessários: 'trades' | 'orders' | 'plan'
+ *   feedsScore      — entra no score emocional/4D
+ *   feedsGates      — entra em gate de transição de estágio
+ */
+
+export const DIMENSIONS = Object.freeze({ E: 'emotional', F: 'financial', O: 'operational' });
+export const SEVERITY = Object.freeze({ HIGH: 'HIGH', MEDIUM: 'MEDIUM', LOW: 'LOW' });
+export const RESOLUTION = Object.freeze({ HIGH: 'HIGH', MEDIUM: 'MEDIUM', LOW: 'LOW' });
+
+const P = (o) => Object.freeze(o);
+
+export const BEHAVIORAL_PATTERNS = Object.freeze({
+  // ---- Emocional (já pesavam) ----
+  TILT: P({
+    code: 'TILT', family: 'TILT', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Reatividade / regulação baixa (§2.3-2; §7.1 emo)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'ANXIETY',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: true,
+  }),
+  LOSS_CHASING: P({
+    code: 'LOSS_CHASING', family: 'LOSS_CHASING', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Revenge trading (§2.2 Q5)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'REVENGE',
+    resolutionLayer: RESOLUTION.MEDIUM, requires: ['trades'], feedsScore: true, feedsGates: true,
+  }),
+  STOP_PANIC: P({
+    code: 'STOP_PANIC', family: 'STOP_PANIC', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Loss aversion / disposition (§2.2; §7.1)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'PANIC',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: true,
+  }),
+  HESITATION: P({
+    code: 'HESITATION', family: 'HESITATION', valence: 'negative', dimensao: ['E'],
+    viesFramework: 'Indecisão / regulação (§2.3)',
+    severityDefault: SEVERITY.LOW, emotionMapping: 'FEAR',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  // ---- Financeiro (novos: greed/disposition/martingale) ----
+  GREED_CLUSTER: P({
+    code: 'GREED_CLUSTER', family: 'GREED_CLUSTER', valence: 'negative', dimensao: ['F'],
+    viesFramework: 'Profit-taking / greed (§3; §7.1 fin)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'GREED',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  AVERAGING_DOWN: P({
+    code: 'AVERAGING_DOWN', family: 'AVERAGING_DOWN', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Martingale escalation / denial (§3 Bloco C; blow-up §6.2)',
+    severityDefault: SEVERITY.HIGH, emotionMapping: 'DENIAL',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  HOLD_ASYMMETRY: P({
+    code: 'HOLD_ASYMMETRY', family: 'HOLD_ASYMMETRY', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Disposition effect (§2.2 Q4)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FEAR',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  EARLY_EXIT: P({
+    code: 'EARLY_EXIT', family: 'EARLY_EXIT', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Disposition / fear (§2.2 Q4)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FEAR',
+    resolutionLayer: RESOLUTION.MEDIUM, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  LATE_EXIT: P({
+    code: 'LATE_EXIT', family: 'LATE_EXIT', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Hope / loss aversion (§7.1)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'HOPE',
+    resolutionLayer: RESOLUTION.MEDIUM, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  SUB_SIZING: P({
+    code: 'SUB_SIZING', family: 'SUB_SIZING', valence: 'negative', dimensao: ['E', 'F'],
+    viesFramework: 'Avoidance / subdimensionar (§2.2; UNDERSIZED #129)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'AVOIDANCE',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders', 'plan'], feedsScore: true, feedsGates: true,
+  }),
+  // ---- Operacional (novos: triggers/sistema) ----
+  CHASE_REENTRY: P({
+    code: 'CHASE_REENTRY', family: 'CHASE_REENTRY', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'Overconfidence / FOMO (§2.2 Q6)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FOMO',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: true,
+  }),
+  FOMO_ENTRY: P({
+    code: 'FOMO_ENTRY', family: 'FOMO_ENTRY', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'FOMO trigger (§3 Bloco C)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'FOMO',
+    resolutionLayer: RESOLUTION.HIGH, requires: ['orders'], feedsScore: true, feedsGates: false,
+  }),
+  OVERTRADING: P({
+    code: 'OVERTRADING', family: 'OVERTRADING', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'Anxiety / rule violations (§5.3)',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'ANXIETY',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: true,
+  }),
+  IMPULSE_CLUSTER: P({
+    code: 'IMPULSE_CLUSTER', family: 'OVERTRADING', valence: 'negative', dimensao: ['E', 'O'],
+    viesFramework: 'Impulsividade (§5.3) — sub-sinal de OVERTRADING',
+    severityDefault: SEVERITY.MEDIUM, emotionMapping: 'IMPULSIVITY',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  DIRECTION_FLIP: P({
+    code: 'DIRECTION_FLIP', family: 'DIRECTION_FLIP', valence: 'negative', dimensao: ['O'],
+    viesFramework: 'Confusion / falta de sistema (§4)',
+    severityDefault: SEVERITY.LOW, emotionMapping: 'CONFUSION',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  // ---- Positivos (reforço) ----
+  CLEAN_EXECUTION: P({
+    code: 'CLEAN_EXECUTION', family: 'CLEAN_EXECUTION', valence: 'positive', dimensao: ['E'],
+    viesFramework: 'Disciplina — perfil SAGE (§2.4)',
+    severityDefault: null, emotionMapping: 'DISCIPLINE',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades'], feedsScore: true, feedsGates: false,
+  }),
+  TARGET_HIT: P({
+    code: 'TARGET_HIT', family: 'TARGET_HIT', valence: 'positive', dimensao: ['E', 'O'],
+    viesFramework: 'Paciência / adesão ao plano (§5)',
+    severityDefault: null, emotionMapping: 'PATIENCE',
+    resolutionLayer: RESOLUTION.LOW, requires: ['trades', 'plan'], feedsScore: true, feedsGates: false,
+  }),
+});
+
+/**
+ * Códigos legados (motores antigos) → código canônico. Permite dual-emit durante
+ * a transição (Fases 1–6): EVENT_PENALTIES, switches de UI e gates por string
+ * literal continuam resolvendo. Códigos já canônicos mapeiam para si mesmos.
+ */
+export const LEGACY_CODE_ALIAS = Object.freeze({
+  // execução (#208)
+  STOP_TAMPERING: 'STOP_PANIC',
+  STOP_BREAKEVEN_TOO_EARLY: 'STOP_PANIC',
+  STOP_HESITATION: 'HESITATION',
+  HESITATION_PRE_ENTRY: 'HESITATION',
+  RAPID_REENTRY_POST_STOP: 'LOSS_CHASING',
+  STOP_PARTIAL_SIZING: 'SUB_SIZING',
+  CHASE_REENTRY: 'CHASE_REENTRY',
+  // shadow (#129)
+  REVENGE_CLUSTER: 'LOSS_CHASING',
+  UNDERSIZED_TRADE: 'SUB_SIZING',
+  GREED_CLUSTER: 'GREED_CLUSTER',
+  HOLD_ASYMMETRY: 'HOLD_ASYMMETRY',
+  OVERTRADING: 'OVERTRADING',
+  IMPULSE_CLUSTER: 'IMPULSE_CLUSTER',
+  DIRECTION_FLIP: 'DIRECTION_FLIP',
+  HESITATION: 'HESITATION',
+  STOP_PANIC: 'STOP_PANIC',
+  FOMO_ENTRY: 'FOMO_ENTRY',
+  EARLY_EXIT: 'EARLY_EXIT',
+  LATE_EXIT: 'LATE_EXIT',
+  AVERAGING_DOWN: 'AVERAGING_DOWN',
+  CLEAN_EXECUTION: 'CLEAN_EXECUTION',
+  TARGET_HIT: 'TARGET_HIT',
+  // emocional (#189)
+  TILT_DETECTED: 'TILT',
+  REVENGE_DETECTED: 'LOSS_CHASING',
+});
+
+/** Resolve um código (legado ou canônico) para o canônico. null se desconhecido. */
+export function resolveCanonical(code) {
+  if (!code) return null;
+  if (BEHAVIORAL_PATTERNS[code]) return code;
+  return LEGACY_CODE_ALIAS[code] || null;
+}
+
+/** Retorna a definição canônica de um código (legado ou canônico). null se desconhecido. */
+export function getPattern(code) {
+  const canonical = resolveCanonical(code);
+  return canonical ? BEHAVIORAL_PATTERNS[canonical] : null;
+}
+
+/** Lista de códigos canônicos que pesam no score. */
+export const SCORING_CODES = Object.freeze(
+  Object.values(BEHAVIORAL_PATTERNS).filter((p) => p.feedsScore).map((p) => p.code),
+);
+
+/** Lista de códigos canônicos que pesam em gates. */
+export const GATE_CODES = Object.freeze(
+  Object.values(BEHAVIORAL_PATTERNS).filter((p) => p.feedsGates).map((p) => p.code),
+);
+
+export default BEHAVIORAL_PATTERNS;

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.72.0: #299 feat CHUNK-11 Fase 0 — baseline + taxonomia comportamental + mapa de pesos do framework (groundwork, zero mudança de produção).
  * - 1.71.1: #296 fix correlator op↔trade compara wall-clock (offset-neutro) (PR #297, 31/05/2026)
  * - 1.71.0: #294 feat rebrand Espelho do Trader nas telas de entrada (Login + Sidebar) (PR #295, 31/05/2026)
  * - 1.70.0: #292 feat timezone explícito no import de trades (CSV + Order) — fuso por lote.
@@ -364,10 +365,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.71.1',
-  build: '20260531',
-  display: 'v1.71.1',
-  full: '1.71.1+20260531',
+  version: '1.72.0',
+  build: '20260601',
+  display: 'v1.72.0',
+  full: '1.72.0+20260601',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## CHUNK-11 Fase 0 — Baseline + taxonomia + mapa de pesos (Epic #298)

Fundação do motor unificado de detecção comportamental. **Zero código de produção alterado** — puro groundwork + rede de segurança.

### Entregue
- **`docs/dev/behavioral-weight-map.md`** — mapa de pesos derivado do `trader_evolution_framework.md` (aprovado por Marcio 01/06; findings passam a mapear viés→dimensão E/F/O; positivos como bônus; `ruleViolationRate` §5.3 como gate). Números finais calibram na Fase 2.
- **`src/constants/behavioralTaxonomy.js`** (+ mirror CJS `functions/maturity/behavioralTaxonomyMirror.js`) — SSoT: 17 padrões canônicos, `LEGACY_CODE_ALIAS` colapsando as 4 sobreposições (hesitação×3, loss-chasing×2, stop-panic×2, sub-sizing×2), helpers `resolveCanonical`/`getPattern`, `SCORING_CODES`/`GATE_CODES`.
- **`behavioralBaseline.snapshot.test.js`** — congela outputs atuais (STOP_TAMPERING/HIGH, tilt 3, revenge×2, periodScore 40) como contrato de não-regressão das Fases 1/3/5.
- **`behavioralTaxonomy.parity.test.js`** — paridade ESM≡CJS + invariantes.

### Verificação
- Suíte completa **3354/3354** + build verdes. Zero regressão.
- Paridade ESM≡CJS verde. Nenhuma alteração de Firestore/CF.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
