### PR TITLE
fix(#302): hard seal #259 isenta feedback do mentor em ciclo fechado

### DIFF
--- a/docs/dev/issues/issue-302-mentor-feedback-seal.md
+++ b/docs/dev/issues/issue-302-mentor-feedback-seal.md
@@ -1,0 +1,67 @@
+# Issue #302 — fix: hard seal #259 isenta feedback do mentor em ciclo fechado
+
+> Template enxuto (R4). Fix de regra Firestore — sem UI nova.
+
+## Autorização
+
+**Status atual do documento:**
+- [x] Mockup — N/A (fix de regra, sem UI)
+- [x] Memória de cálculo — N/A (sem fórmula; lógica de allowlist abaixo)
+- [x] Marcio autorizou — 01/06/2026: decisão de produto "Sim — feedback sempre liberado" (mentor revisa/classifica trade em qualquer estado de ciclo)
+- [x] Gate Pré-Código liberado
+
+## Context
+
+Feedback em massa do mentor (`MentorDashboard`) falha com `permission-denied`. Regressão da v1.64.0 (#259): o hard seal `isTradeDateNotSealed(planId, date)` foi aplicado a TODO update de `/trades`, travando a revisão do mentor quando o trade está em ciclo fechado (caso A) ou quando o plano foi deletado e `get().data` quebra (caso B). Falha visível no bulk porque `writeBatch` é atômico — um trade selado/órfão derruba o lote inteiro.
+
+## Spec
+
+Ver issue body no GitHub: #302.
+
+## Lógica do fix (allowlist)
+
+Regra de update de `/trades` em `firestore.rules`. Hoje (linha 146):
+
+```
+&& isTradeDateNotSealed(resource.data.planId, resource.data.date)
+```
+
+Passa a:
+
+```
+&& (
+  isTradeDateNotSealed(resource.data.planId, resource.data.date) ||
+  ( isMentor() &&
+    request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+      'mentorFeedback','feedbackDate','feedbackHistory','status','updatedAt',
+      'mentorClassification','mentorClassificationFlags','mentorClassificationReason',
+      'mentorClassifiedAt','mentorClassifiedBy','mentorClearedViolations'
+    ])
+  )
+)
+```
+
+**Por que `hasOnly`:** quando o ÚNICO delta é metadado de revisão do mentor, o seal é dispensado — não chama `get()` (resolve caso B, plano órfão) e libera revisão em ciclo fechado (caso A). Se o diff tocar qualquer campo financeiro/comportamental, cai no ramo `isTradeDateNotSealed` e o seal volta a valer.
+
+**Allowlist derivada de:** campos escritos por `addBulkFeedback`/`addFeedback` (feedback) + #219 classificação (`mentorClassification*`) + #221 `mentorClearedViolations`. Confere com a allowlist do bloco aluno-readonly (rules:138-142) — mesmos campos mentor-only.
+
+## Phases
+- A1 — Editar `firestore.rules` (isenção mentor no seal de update /trades)
+- A2 — Testes de rules (mentor feedback em ciclo selado passa; aluno bloqueado; edição financeira em ciclo selado bloqueada)
+- A3 — Deploy rules + smoke bulk feedback
+
+## Sessions
+- _(a preencher)_
+
+## Shared Deltas
+- `src/version.js` — bump v1.72.1 (aplicar no fechamento; main está em 1.73.0 por #301 — não rebaixar antes do merge)
+- `docs/registry/versions.md` — marcar v1.72.1 consumida
+- `docs/registry/chunks.md` — liberar CHUNK-04
+- `CHANGELOG.md` — nova entrada `[1.72.1] - 01/06/2026`
+
+## Decisions
+- DEC-AUTO-302-01 — feedback/classificação do mentor isento do hard seal #259 (decisão de produto Marcio 01/06/2026)
+
+## Chunks
+- CHUNK-04 (escrita) — regra Firestore de `/trades`
+- CHUNK-08 (leitura) — contexto do fluxo de feedback do mentor

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-11 | #301 | `feat/issue-301-chunk11-fase1` | 01/06/2026 | Epic #298 Fase 1 — motor unificado dark/compat |

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -6,3 +6,4 @@
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
 | CHUNK-11 | #301 | `feat/issue-301-chunk11-fase1` | 01/06/2026 | Epic #298 Fase 1 — motor unificado dark/compat |
+| CHUNK-04 | #302 | `fix/issue-302-mentor-feedback-seal` | 01/06/2026 | hard seal #259 isenta feedback do mentor |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -46,3 +46,4 @@
 | 1.71.0 | #294 | `feat/issue-294-rebrand-espelho` | 31/05/2026 | consumida (PR #295 squash `29a669de`) |
 | 1.71.1 | #296 | `fix/issue-296-correlator-wallclock` | 31/05/2026 | consumida (PR #297 squash `42fd3da2`) |
 | 1.72.0 | #299 | `feat/issue-299-chunk11-fase0` | 01/06/2026 | consumida (PR #300 squash `c10be425`) |
+| 1.73.0 | #301 | `feat/issue-301-chunk11-fase1` | 01/06/2026 | reservada |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -47,3 +47,4 @@
 | 1.71.1 | #296 | `fix/issue-296-correlator-wallclock` | 31/05/2026 | consumida (PR #297 squash `42fd3da2`) |
 | 1.72.0 | #299 | `feat/issue-299-chunk11-fase0` | 01/06/2026 | consumida (PR #300 squash `c10be425`) |
 | 1.73.0 | #301 | `feat/issue-301-chunk11-fase1` | 01/06/2026 | reservada |
+| 1.72.1 | #302 | `fix/issue-302-mentor-feedback-seal` | 01/06/2026 | reservada (patch sobre 1.72.0; bump do version.js no fechamento p/ não rebaixar main 1.73.0) |

--- a/firestore.rules
+++ b/firestore.rules
@@ -141,9 +141,25 @@ service cloud.firestore {
           // Issue #221 — limpeza de violação (compliance + emocional). Aluno read-only.
           'mentorClearedViolations'
         ])
-      ) &&
-      // Hard seal #259 — bloqueia update se date está em ciclo fechado.
-      isTradeDateNotSealed(resource.data.planId, resource.data.date);
+      ) && (
+        // Hard seal #259 — bloqueia update se date está em ciclo fechado.
+        isTradeDateNotSealed(resource.data.planId, resource.data.date) ||
+        // Exceção #302 — metadados de revisão do mentor são isentos do seal:
+        // mentor revisa/classifica trade em qualquer estado de ciclo (decisão de
+        // produto 01/06/2026). Quando o ÚNICO delta é metadado mentor-only, dispensa
+        // o seal e NÃO chama get() — resolve também plano órfão (get().data quebra).
+        // Bug original: bulk feedback (writeBatch atômico) caía se 1 trade do lote
+        // estava em ciclo selado. Allowlist espelha o bloco aluno-readonly acima.
+        (
+          isMentor() &&
+          request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+            'mentorFeedback', 'feedbackDate', 'feedbackHistory', 'status', 'updatedAt',
+            'mentorClassification', 'mentorClassificationFlags',
+            'mentorClassificationReason', 'mentorClassifiedAt', 'mentorClassifiedBy',
+            'mentorClearedViolations'
+          ])
+        )
+      );
       allow delete: if isAuthenticated() && (
         isMentor() ||
         isOwner(resource.data.studentId) ||

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.73.0: #301 feat CHUNK-11 Fase 1 — motor unificado detectBehavior (dark/compat, reusa detectores + dual-emit).
  * - 1.72.0: #299 feat baseline + taxonomia + mapa de pesos do framework (PR #300, 01/06/2026)
  * - 1.71.1: #296 fix correlator op↔trade compara wall-clock (offset-neutro) (PR #297, 31/05/2026)
  * - 1.71.0: #294 feat rebrand Espelho do Trader nas telas de entrada (Login + Sidebar) (PR #295, 31/05/2026)
@@ -365,10 +366,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.72.0',
+  version: '1.73.0',
   build: '20260601',
-  display: 'v1.72.0',
-  full: '1.72.0+20260601',
+  display: 'v1.73.0',
+  full: '1.73.0+20260601',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Problema

Feedback em massa do mentor falhava com `FirebaseError: Missing or insufficient permissions`. Regressão da v1.64.0 (#259).

## Causa raiz

O hard seal `isTradeDateNotSealed(planId, date)` do #259 foi aplicado a **todo** `update` de `/trades`, travando a revisão do mentor por dois caminhos:

- **A) Trade em ciclo fechado.** Status `OPEN` (workflow de revisão) e ciclo selado (fechamento) são ortogonais — aluno fecha ciclo com trades ainda `OPEN` esperando o mentor.
- **B) Plano órfão.** `get(/plans/planId).data` quebra se o plano foi deletado → `permission-denied`.

Visível no bulk porque `writeBatch` é atômico: um trade selado/órfão derruba o lote inteiro.

## Fix

Quando o **único delta** do update é metadado de revisão mentor-only (`mentorFeedback`, `feedbackDate`, `feedbackHistory`, `status`, `updatedAt`, `mentorClassification*`, `mentorClearedViolations`), o seal é dispensado e o `get()` do plano não é chamado. Edição de campo financeiro/comportamental em ciclo fechado **segue bloqueada**. Allowlist espelha o bloco aluno-readonly da mesma regra.

Decisão de produto (Marcio, 01/06/2026): mentor revisa/classifica trade em qualquer estado de ciclo.

## Verificação

- Sem harness de rules-unit-testing no repo (consistente com #271/#254 — deploy + smoke). Validação de sintaxe via deploy.
- Smoke pós-deploy: feedback em massa em trade de ciclo fechado.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)