### PR TITLE
fix(CHUNK-02): deleteStudent limpa movements/cycleClosures/Storage órfãos (#309)

### DIFF
--- a/docs/dev/issues/issue-309-deletestudent-orphans.md
+++ b/docs/dev/issues/issue-309-deletestudent-orphans.md
@@ -1,0 +1,73 @@
+# Issue #309 — fix(CHUNK-02): deleteStudent deixa órfãos (movements, cycleClosures, Storage)
+
+> Template enxuto (R4). Backend-only (Cloud Function) — sem UI, sem mockup visual.
+
+## Autorização (OBRIGATÓRIA)
+
+**Status atual do documento:**
+- [x] Mockup — N/A (backend/CF; contrato em "Spec comportamental" abaixo)
+- [x] Memória de cálculo — N/A (sem fórmula; é cascata de delete, lógica em "Spec comportamental")
+- [x] Marcio autorizou — 10/06/2026 "go"
+- [x] Gate Pré-Código liberado
+
+## Context
+
+A callable `deleteStudent` (`functions/index.js:728`) faz hard delete cascateado do aluno mas deixa
+3 coisas órfãs: (1) `movements` de depósito/saque/INITIAL_BALANCE/ADJUSTMENT (que só têm `accountId`,
+não `studentId`), (2) `cycleClosures` (top-level com `studentId`, fora do array), (3) screenshots
+HTF/LTF dos trades no Storage (`trades/{tradeId}/...`). Objetivo: cleanup total LGPD-like real.
+
+## Spec
+
+Ver issue body no GitHub: #309.
+
+## Spec comportamental (contrato do CF)
+
+Por `studentId` (sid), na CF `deleteStudent`, ANTES de apagar as contas/trades coletar ids:
+
+1. **accountIds** ← `accounts where studentId == sid` (id do doc = accountId usado em `movements.accountId`).
+2. **tradeIds** ← `trades where studentId == sid` (pra limpar Storage).
+3. Subcollections recursivas de `students/{sid}/*` (inalterado).
+4. Top-level por `studentId`: **adicionar `cycleClosures`** ao array (já tem `studentId` — `closeCycle.js:181`).
+5. **movements por accountId**: deletar `movements where accountId in [accountIds]` (chunks de 10, batches de 400).
+   — Cobre TRADE_RESULT (tem studentId, mas accountId basta) + DEPOSIT/WITHDRAWAL/INITIAL_BALANCE/ADJUSTMENT (só accountId).
+6. Doc `students/{sid}` + Auth user (inalterado).
+7. **Storage best-effort**: por tradeId, `bucket.deleteFiles({ prefix: 'trades/{tradeId}/' })` em try/catch — falha não aborta a CF.
+
+### Evidências (anti-AP-07)
+- `cycleClosures.studentId` + `accountId`: `functions/cycleClosure/closeCycle.js:181`.
+- movements só-accountId: `useMovements.js:99-111` (DEP/WTD), `useAccounts.js:155-166` (INITIAL), `:219-230` (ADJUST).
+- TRADE_RESULT tem studentId: `useTrades.js:396-404`.
+- account.studentId, id=accountId: `useAccounts.js:111-148`.
+- Storage path `trades/{tradeId}/...`: `useTrades.js:191-195`.
+- `admin.storage().bucket()` disponível (admin init em `functions/index.js:55-59`).
+
+## Arquitetura (decisão técnica)
+
+Extrair a cascata de `deleteStudent` para módulo testável `functions/students/deleteStudentData.js`
+(espelha `deleteAccountCascade` ser módulo próprio). Assinatura: `deleteStudentData({ db, bucket, sid })`
+→ retorna `counts`. `index.js` delega; mantém auth-delete + fallback-by-email inline. Permite teste
+unitário com fake-db in-memory (sem emulador), satisfazendo INV-05 + critério de aceite.
+
+## Phases
+- A1 — extrair módulo `deleteStudentData.js` (move `deleteCollectionRecursive`/`deleteByStudentIdQuery`) + 3 fixes
+- A2 — `index.js` delega ao módulo
+- A3 — teste vitest com fake-db (movements DEP só-accountId + TRADE_RESULT; cycleClosures; storage best-effort)
+
+## Sessions
+- _(log)_
+
+## Shared Deltas
+- `src/version.js` — bump v1.74.1
+- `docs/registry/versions.md` — marcar v1.74.1 consumida
+- `docs/registry/chunks.md` — liberar CHUNK-02
+- `CHANGELOG.md` — nova entrada `[1.74.1] - 10/06/2026`
+- `docs/cloud-functions.md` — atualizar descrição de `deleteStudent` (movements/cycleClosures/Storage)
+
+## Decisions
+- DEC-AUTO-309-01 — Storage cleanup best-effort (try/catch, não aborta CF; "lixo barato" por issue)
+- DEC-AUTO-309-02 — extração de `deleteStudentData` em módulo próprio p/ testabilidade
+
+## Chunks
+- CHUNK-02 (escrita) — `deleteStudent` em `functions/`
+- CHUNK-04 (leitura) — modelo de `movements`/`accounts`/`cycleClosures`

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-04 | #308 | `feat/issue-308-trade-self-review` | 07/06/2026 | Auto-revisão de trade — campo `trade.selfReview` + gateway `submitTradeReview` + rules |

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -6,3 +6,4 @@
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
 | CHUNK-04 | #308 | `feat/issue-308-trade-self-review` | 07/06/2026 | Auto-revisão de trade — campo `trade.selfReview` + gateway `submitTradeReview` + rules |
+| CHUNK-02 | #309 | `fix/issue-309-deletestudent-orphans` | 10/06/2026 | deleteStudent deixa órfãos — movements (por accountId), cycleClosures, Storage dos trades |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -50,3 +50,4 @@
 | 1.72.1 | #302 | `fix/issue-302-mentor-feedback-seal` | 01/06/2026 | consumida (PR #303 squash `4d72dea5`) |
 | 1.74.0 | #305 | `feat/issue-305-chunk11-fase2` | 04/06/2026 | consumida (PR #306 squash `730ff902`) |
 | 1.75.0 | #308 | `feat/issue-308-trade-self-review` | 07/06/2026 | RESERVADA |
+| 1.74.1 | #309 | `fix/issue-309-deletestudent-orphans` | 10/06/2026 | RESERVADA |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -49,3 +49,4 @@
 | 1.73.0 | #301 | `feat/issue-301-chunk11-fase1` | 01/06/2026 | consumida (PR #304 squash `67122d42`) |
 | 1.72.1 | #302 | `fix/issue-302-mentor-feedback-seal` | 01/06/2026 | consumida (PR #303 squash `4d72dea5`) |
 | 1.74.0 | #305 | `feat/issue-305-chunk11-fase2` | 04/06/2026 | consumida (PR #306 squash `730ff902`) |
+| 1.75.0 | #308 | `feat/issue-308-trade-self-review` | 07/06/2026 | RESERVADA |

--- a/functions/__tests__/students/deleteStudentData.test.js
+++ b/functions/__tests__/students/deleteStudentData.test.js
@@ -1,0 +1,192 @@
+/**
+ * deleteStudentData.test.js — issue #309
+ *
+ * Cobre as 3 lacunas fechadas pela cascata de hard-delete do aluno:
+ *   (1) movements por accountId — TRADE_RESULT (tem studentId) E
+ *       DEPOSIT/INITIAL_BALANCE/ADJUSTMENT (só accountId) ambos apagados;
+ *   (2) cycleClosures (studentId) apagado;
+ *   (3) Storage trades/{tradeId}/ best-effort (não aborta se falhar).
+ * Dados de OUTRO aluno (accounts/movements/cycleClosures/trades) sobrevivem.
+ *
+ * Fake-Firestore in-memory (sem emulador), no estilo CJS dos testes de functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { deleteStudentData } = require('../../students/deleteStudentData');
+
+// ── Fake Firestore ──────────────────────────────────────────────────────────
+
+function makeFakeDb(seed) {
+  const store = {};
+  for (const [coll, docs] of Object.entries(seed)) {
+    store[coll] = new Map(docs.map((d) => [d.id, { ...d }]));
+  }
+
+  const docRef = (coll, id) => ({
+    id,
+    __coll: coll,
+    __id: id,
+    listCollections: async () => [], // sem subcollections nas fixtures
+    delete: async () => { (store[coll] || new Map()).delete(id); },
+  });
+
+  class Query {
+    constructor(coll, filters = [], limitN = null) {
+      this.coll = coll;
+      this.filters = filters;
+      this.limitN = limitN;
+    }
+    where(field, op, value) {
+      return new Query(this.coll, [...this.filters, { field, op, value }], this.limitN);
+    }
+    limit(n) {
+      return new Query(this.coll, this.filters, n);
+    }
+    doc(id) {
+      return docRef(this.coll, id);
+    }
+    async get() {
+      const map = store[this.coll] || new Map();
+      let docs = [...map.entries()].map(([id, data]) => ({ id, data }));
+      for (const f of this.filters) {
+        docs = docs.filter((d) => {
+          const val = d.data[f.field];
+          if (f.op === '==') return val === f.value;
+          if (f.op === 'in') return f.value.includes(val);
+          return true;
+        });
+      }
+      if (this.limitN != null) docs = docs.slice(0, this.limitN);
+      const wrapped = docs.map((d) => ({ id: d.id, data: () => d.data, ref: docRef(this.coll, d.id) }));
+      return { empty: wrapped.length === 0, size: wrapped.length, docs: wrapped };
+    }
+  }
+
+  const batch = () => {
+    const ops = [];
+    return {
+      delete(ref) { ops.push(ref); return this; },
+      async commit() { for (const r of ops) (store[r.__coll] || new Map()).delete(r.__id); ops.length = 0; },
+    };
+  };
+
+  return {
+    store,
+    collection: (name) => new Query(name),
+    batch,
+  };
+}
+
+const ids = (store, coll) => [...(store[coll] || new Map()).keys()].sort();
+
+// ── Fixtures: aluno S1 (alvo) + S2 (sobrevive) ──────────────────────────────
+
+function seedTwoStudents() {
+  return {
+    students: [{ id: 'S1' }, { id: 'S2' }],
+    accounts: [
+      { id: 'A1', studentId: 'S1' },
+      { id: 'A2', studentId: 'S1' },
+      { id: 'A3', studentId: 'S2' },
+    ],
+    movements: [
+      { id: 'm1', accountId: 'A1', studentId: 'S1', type: 'TRADE_RESULT' }, // tem studentId
+      { id: 'm2', accountId: 'A1', type: 'DEPOSIT' },                       // só accountId
+      { id: 'm3', accountId: 'A2', type: 'INITIAL_BALANCE' },               // só accountId
+      { id: 'm4', accountId: 'A1', type: 'ADJUSTMENT' },                    // só accountId
+      { id: 'm9', accountId: 'A3', type: 'DEPOSIT' },                       // de S2 — sobrevive
+    ],
+    cycleClosures: [
+      { id: 'c1', studentId: 'S1', accountId: 'A1' },
+      { id: 'c2', studentId: 'S2', accountId: 'A3' }, // sobrevive
+    ],
+    trades: [
+      { id: 't1', studentId: 'S1' },
+      { id: 't2', studentId: 'S1' },
+      { id: 't3', studentId: 'S2' }, // sobrevive
+    ],
+    notifications: [{ id: 'n1', studentId: 'S1' }],
+  };
+}
+
+function fakeBucket() {
+  const prefixes = [];
+  return {
+    prefixes,
+    deleteFiles: async ({ prefix }) => { prefixes.push(prefix); },
+  };
+}
+
+// ── Testes ──────────────────────────────────────────────────────────────────
+
+describe('deleteStudentData (issue #309)', () => {
+  it('apaga movements por accountId (TRADE_RESULT com studentId E DEPOSIT/INITIAL/ADJUST só accountId)', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    const bucket = fakeBucket();
+
+    await deleteStudentData({ db, bucket, sid: 'S1' });
+
+    // m1 (TRADE_RESULT), m2 (DEPOSIT), m3 (INITIAL_BALANCE), m4 (ADJUSTMENT) de S1 apagados;
+    // m9 (de S2) sobrevive.
+    expect(ids(db.store, 'movements')).toEqual(['m9']);
+  });
+
+  it('apaga cycleClosures do aluno e preserva os de outro aluno', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    await deleteStudentData({ db, bucket: fakeBucket(), sid: 'S1' });
+    expect(ids(db.store, 'cycleClosures')).toEqual(['c2']);
+  });
+
+  it('apaga trades/accounts/notifications/students do aluno e isola o outro aluno', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    await deleteStudentData({ db, bucket: fakeBucket(), sid: 'S1' });
+    expect(ids(db.store, 'trades')).toEqual(['t3']);
+    expect(ids(db.store, 'accounts')).toEqual(['A3']);
+    expect(ids(db.store, 'notifications')).toEqual([]);
+    expect(ids(db.store, 'students')).toEqual(['S2']);
+  });
+
+  it('limpa Storage trades/{tradeId}/ para cada trade do aluno', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    const bucket = fakeBucket();
+    await deleteStudentData({ db, bucket, sid: 'S1' });
+    expect(bucket.prefixes.sort()).toEqual(['trades/t1/', 'trades/t2/']);
+  });
+
+  it('Storage é best-effort: falha no bucket não aborta a cascata (DEC-AUTO-309-01)', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    const explodingBucket = { deleteFiles: async () => { throw new Error('storage down'); } };
+
+    await expect(deleteStudentData({ db, bucket: explodingBucket, sid: 'S1' })).resolves.toBeTruthy();
+    // Dados Firestore ainda apagados apesar da falha de Storage.
+    expect(ids(db.store, 'students')).toEqual(['S2']);
+    expect(ids(db.store, 'movements')).toEqual(['m9']);
+  });
+
+  it('bucket null não quebra (Storage opcional)', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    await expect(deleteStudentData({ db, bucket: null, sid: 'S1' })).resolves.toBeTruthy();
+    expect(ids(db.store, 'students')).toEqual(['S2']);
+  });
+
+  it('aluno sem contas nem movements: cascata não quebra e remove o doc', async () => {
+    const db = makeFakeDb({ students: [{ id: 'S1' }], trades: [], accounts: [], movements: [] });
+    const counts = await deleteStudentData({ db, bucket: fakeBucket(), sid: 'S1' });
+    expect(ids(db.store, 'students')).toEqual([]);
+    expect(counts.students).toBe(1);
+  });
+
+  it('retorna counts por coleção', async () => {
+    const db = makeFakeDb(seedTwoStudents());
+    const counts = await deleteStudentData({ db, bucket: fakeBucket(), sid: 'S1' });
+    expect(counts.movements).toBe(4);          // m1..m4
+    expect(counts['top:cycleClosures']).toBe(1);
+    expect(counts['top:trades']).toBe(2);
+    expect(counts['top:accounts']).toBe(2);
+    expect(counts['storage:trades']).toBe(2);
+    expect(counts.students).toBe(1);
+  });
+});

--- a/functions/__tests__/students/deleteStudentData.test.js
+++ b/functions/__tests__/students/deleteStudentData.test.js
@@ -134,6 +134,16 @@ describe('deleteStudentData (issue #309)', () => {
     expect(ids(db.store, 'movements')).toEqual(['m9']);
   });
 
+  it('apaga TRADE_RESULT órfão (studentId mas account já deletado avulso)', async () => {
+    const seed = seedTwoStudents();
+    // m5: TRADE_RESULT de S1 cujo account 'GONE' não está em accounts (orfão).
+    seed.movements.push({ id: 'm5', accountId: 'GONE', studentId: 'S1', type: 'TRADE_RESULT' });
+    const db = makeFakeDb(seed);
+    await deleteStudentData({ db, bucket: fakeBucket(), sid: 'S1' });
+    // m5 não cai por accountId (GONE fora de [A1,A2]) mas cai pelo passe por studentId.
+    expect(ids(db.store, 'movements')).toEqual(['m9']);
+  });
+
   it('apaga cycleClosures do aluno e preserva os de outro aluno', async () => {
     const db = makeFakeDb(seedTwoStudents());
     await deleteStudentData({ db, bucket: fakeBucket(), sid: 'S1' });

--- a/functions/index.js
+++ b/functions/index.js
@@ -687,7 +687,10 @@ exports.createStudent = functions.https.onCall(async (data, context) => {
   }
 });
 
-exports.deleteStudent = functions.https.onCall(async (data, context) => {
+// timeoutSeconds: 300 (#309) — hard delete LGPD-like itera subcollections +
+// 9 coleções top-level + paginação de movements + 1 deleteFiles por trade.
+// Aluno com muitos trades pode estourar o default de 60s e deixar delete parcial.
+exports.deleteStudent = functions.runWith({ timeoutSeconds: 300 }).https.onCall(async (data, context) => {
   if (!context.auth) {
     throw new functions.https.HttpsError('unauthenticated', 'Usuário não autenticado');
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -58,6 +58,9 @@ const admin = require('firebase-admin');
 admin.initializeApp();
 const db = admin.firestore();
 
+// Cascata de hard-delete de aluno — módulo testável (issue #309).
+const { deleteStudentData } = require('./students/deleteStudentData');
+
 // === PROP FIRM ENGINE (Fase 2 #52) ===
 // Engine puro testado em src/__tests__/utils/propFirmDrawdownEngine.test.js (58 testes)
 // Espelhado em functions/propFirmEngine.js — DT-034: unificar via build step
@@ -531,47 +534,6 @@ const deleteCollection = async (collRef, batchSize = 100) => {
   }
 };
 
-// Helper — apaga recursivamente uma collection e TODAS suas subcollections
-// (em profundidade arbitrária). Usado pelo deleteStudent no modo deep
-// cleanup pra garantir que nenhuma sub-sub-coleção do aluno sobreviva.
-const deleteCollectionRecursive = async (collRef, batchSize = 100) => {
-  let snapshot = await collRef.limit(batchSize).get();
-  let count = 0;
-  while (!snapshot.empty) {
-    for (const d of snapshot.docs) {
-      const subColls = await d.ref.listCollections();
-      for (const sc of subColls) {
-        count += await deleteCollectionRecursive(sc, batchSize);
-      }
-    }
-    const batch = db.batch();
-    snapshot.docs.forEach((d) => batch.delete(d.ref));
-    await batch.commit();
-    count += snapshot.size;
-    snapshot = await collRef.limit(batchSize).get();
-  }
-  return count;
-};
-
-// Helper — apaga em batch todos os docs de uma coleção top-level que tenham
-// `studentId == sid`. Retorna count pra log. DEC-AUTO-263-08 (refinado
-// 2026-05-10): deleteStudent cascateia também trades/orders/notifications/
-// plans/csvStaging/csvStagingTrades/accounts/crossCheck (opção A — limpeza
-// total, LGPD-like).
-const deleteByStudentIdQuery = async (collName, sid, batchSize = 100) => {
-  let count = 0;
-  while (true) {
-    const snap = await db.collection(collName).where('studentId', '==', sid).limit(batchSize).get();
-    if (snap.empty) break;
-    const batch = db.batch();
-    snap.docs.forEach((d) => batch.delete(d.ref));
-    await batch.commit();
-    count += snap.size;
-    if (snap.size < batchSize) break;
-  }
-  return count;
-};
-
 // Helper — copia recursivamente uma collection (e suas subcollections) entre
 // caminhos. Usado pelo "modo promote" do createStudent pra mover
 // /students/{old}/subscriptions/* + payments aninhados pra /students/{new}/...
@@ -747,43 +709,19 @@ exports.deleteStudent = functions.https.onCall(async (data, context) => {
     }
 
     // Hard delete cascateado deep (DEC-AUTO-263-08 refinado 2026-05-10
-    // — opção A, limpeza total LGPD-like):
-    //   1. Todas subcollections de /students/{sid}/ (subscriptions+payments,
-    //      assessment, maturity+_historyBucket, reviews, etc.) via listCollections
-    //      recursivo — qualquer subcoll futura entra automaticamente.
-    //   2. Coleções top-level com studentId: trades, orders, notifications,
-    //      plans, csvStaging, csvStagingTrades, accounts, crossCheck.
-    //   3. Doc /students/{sid}.
-    //   4. Auth user.
-    const TOP_LEVEL_COLLECTIONS = [
-      'trades',
-      'orders',
-      'notifications',
-      'plans',
-      'csvStaging',
-      'csvStagingTrades',
-      'accounts',
-      'crossCheck',
-    ];
+    // — opção A, limpeza total LGPD-like; issue #309 fechou 3 lacunas:
+    // movements por accountId, cycleClosures, Storage). A cascata Firestore +
+    // Storage mora em ./students/deleteStudentData (testável); aqui só fica o
+    // Auth user, que é admin.auth() e não entra na cascata de dados.
+    let bucket = null;
+    try { bucket = admin.storage().bucket(); } catch (e) {
+      console.warn('[deleteStudent] Storage bucket indisponível (cleanup pulado):', e.message);
+    }
     for (const sid of studentIds) {
-      const studentRef = db.collection('students').doc(sid);
-      const counts = {};
-      // 1. Subcollections recursivas
-      const subColls = await studentRef.listCollections();
-      for (const sc of subColls) {
-        counts[`sub:${sc.id}`] = await deleteCollectionRecursive(sc);
-      }
-      // 2. Top-level por studentId
-      for (const coll of TOP_LEVEL_COLLECTIONS) {
-        const n = await deleteByStudentIdQuery(coll, sid);
-        if (n > 0) counts[`top:${coll}`] = n;
-      }
-      // 3. Doc principal
-      await studentRef.delete();
-      counts['students'] = 1;
+      const counts = await deleteStudentData({ db, bucket, sid });
       console.log(`[deleteStudent] Deep cleanup /students/${sid}:`, counts);
 
-      // 4. Auth user (uid pode ser pseudo-id de createInlineStudent — nesse caso
+      // Auth user (uid pode ser pseudo-id de createInlineStudent — nesse caso
       // não existe Auth e o catch absorve.)
       try { await admin.auth().deleteUser(sid); } catch (e) {
         if (e.code !== 'auth/user-not-found') console.warn('[deleteStudent] Auth delete:', e.message);

--- a/functions/students/deleteStudentData.js
+++ b/functions/students/deleteStudentData.js
@@ -7,7 +7,8 @@
  *   2. Top-level por studentId: trades, orders, notifications, plans, csvStaging,
  *      csvStagingTrades, accounts, crossCheck, cycleClosures.
  *   3. movements por accountId (DEP/WTD/INITIAL_BALANCE/ADJUSTMENT só têm accountId;
- *      TRADE_RESULT tem studentId mas accountId basta) — coletados ANTES de apagar accounts.
+ *      coletados ANTES de apagar accounts) + por studentId (belt-and-suspenders pra
+ *      TRADE_RESULT órfão cujo account já foi deletado avulso).
  *   4. Storage best-effort: trades/{tradeId}/ (screenshots HTF/LTF). DEC-AUTO-309-01.
  *   5. Doc /students/{sid}.
  * Auth user e fallback-by-email continuam em index.js (admin.auth, fora desta cascata).
@@ -131,8 +132,12 @@ const deleteStudentData = async ({ db, bucket, sid }) => {
     if (n > 0) counts[`top:${coll}`] = n;
   }
 
-  // 3. movements por accountId (cobre depósito/saque/initial/adjustment sem studentId).
-  const movementsDeleted = await deleteMovementsByAccountIds(db, accountIds);
+  // 3. movements: por accountId (cobre depósito/saque/initial/adjustment sem studentId)
+  //    + belt-and-suspenders por studentId (captura TRADE_RESULT órfão cujo account
+  //    já foi deletado avulso e portanto não está em accountIds).
+  const movementsByAccount = await deleteMovementsByAccountIds(db, accountIds);
+  const movementsByStudent = await deleteByStudentIdQuery(db, 'movements', sid);
+  const movementsDeleted = movementsByAccount + movementsByStudent;
   if (movementsDeleted > 0) counts['movements'] = movementsDeleted;
 
   // 4. Storage best-effort.

--- a/functions/students/deleteStudentData.js
+++ b/functions/students/deleteStudentData.js
@@ -1,0 +1,156 @@
+/**
+ * deleteStudentData.js — cascata de hard-delete de um aluno (issue #309)
+ *
+ * Extraído de `deleteStudent` (functions/index.js, DEC-AUTO-263-08) pra ficar
+ * testável sem emulador (fake-db). Apaga, por `sid`:
+ *   1. Subcollections recursivas de /students/{sid}/* (qualquer subcoll futura entra).
+ *   2. Top-level por studentId: trades, orders, notifications, plans, csvStaging,
+ *      csvStagingTrades, accounts, crossCheck, cycleClosures.
+ *   3. movements por accountId (DEP/WTD/INITIAL_BALANCE/ADJUSTMENT só têm accountId;
+ *      TRADE_RESULT tem studentId mas accountId basta) — coletados ANTES de apagar accounts.
+ *   4. Storage best-effort: trades/{tradeId}/ (screenshots HTF/LTF). DEC-AUTO-309-01.
+ *   5. Doc /students/{sid}.
+ * Auth user e fallback-by-email continuam em index.js (admin.auth, fora desta cascata).
+ *
+ * Não toca shared files / rules. CHUNK-02 (escrita).
+ */
+
+const TOP_LEVEL_COLLECTIONS = [
+  'trades',
+  'orders',
+  'notifications',
+  'plans',
+  'csvStaging',
+  'csvStagingTrades',
+  'accounts',
+  'crossCheck',
+  'cycleClosures',
+];
+
+const FIRESTORE_IN_LIMIT = 10; // chunk de valores por query `in` (consistente com deleteAccountCascade)
+
+// Apaga recursivamente uma collection (e subcollections) em batches.
+const deleteCollectionRecursive = async (db, collRef, batchSize = 100) => {
+  let snapshot = await collRef.limit(batchSize).get();
+  let count = 0;
+  while (!snapshot.empty) {
+    for (const d of snapshot.docs) {
+      const subColls = await d.ref.listCollections();
+      for (const sc of subColls) {
+        count += await deleteCollectionRecursive(db, sc, batchSize);
+      }
+    }
+    const batch = db.batch();
+    snapshot.docs.forEach((d) => batch.delete(d.ref));
+    await batch.commit();
+    count += snapshot.size;
+    snapshot = await collRef.limit(batchSize).get();
+  }
+  return count;
+};
+
+// Apaga em batch todos os docs de uma coleção top-level com `studentId == sid`.
+const deleteByStudentIdQuery = async (db, collName, sid, batchSize = 100) => {
+  let count = 0;
+  while (true) {
+    const snap = await db.collection(collName).where('studentId', '==', sid).limit(batchSize).get();
+    if (snap.empty) break;
+    const batch = db.batch();
+    snap.docs.forEach((d) => batch.delete(d.ref));
+    await batch.commit();
+    count += snap.size;
+    if (snap.size < batchSize) break;
+  }
+  return count;
+};
+
+// Apaga `movements where accountId in [accountIds]` — chunks de 10, batches de 100.
+const deleteMovementsByAccountIds = async (db, accountIds, batchSize = 100) => {
+  let count = 0;
+  for (let i = 0; i < accountIds.length; i += FIRESTORE_IN_LIMIT) {
+    const chunk = accountIds.slice(i, i + FIRESTORE_IN_LIMIT);
+    while (true) {
+      const snap = await db
+        .collection('movements')
+        .where('accountId', 'in', chunk)
+        .limit(batchSize)
+        .get();
+      if (snap.empty) break;
+      const batch = db.batch();
+      snap.docs.forEach((d) => batch.delete(d.ref));
+      await batch.commit();
+      count += snap.size;
+      if (snap.size < batchSize) break;
+    }
+  }
+  return count;
+};
+
+// Best-effort: apaga objetos trades/{tradeId}/ do bucket. Falha nunca aborta. DEC-AUTO-309-01.
+const deleteTradeStorage = async (bucket, tradeIds) => {
+  if (!bucket || !tradeIds.length) return 0;
+  let cleaned = 0;
+  for (const tradeId of tradeIds) {
+    try {
+      await bucket.deleteFiles({ prefix: `trades/${tradeId}/` });
+      cleaned += 1;
+    } catch (e) {
+      console.warn(`[deleteStudentData] Storage cleanup trades/${tradeId}/:`, e.message);
+    }
+  }
+  return cleaned;
+};
+
+/**
+ * Executa a cascata para um único aluno.
+ * @param {object} args
+ * @param {FirebaseFirestore.Firestore} args.db
+ * @param {object|null} args.bucket  bucket do Admin Storage (best-effort; pode ser null)
+ * @param {string} args.sid          studentId
+ * @returns {Promise<object>} counts por coleção (pra log)
+ */
+const deleteStudentData = async ({ db, bucket, sid }) => {
+  const studentRef = db.collection('students').doc(sid);
+  const counts = {};
+
+  // 0. Coletar ids ANTES de apagar accounts/trades.
+  const accountsSnap = await db.collection('accounts').where('studentId', '==', sid).get();
+  const accountIds = accountsSnap.docs.map((d) => d.id);
+  const tradesSnap = await db.collection('trades').where('studentId', '==', sid).get();
+  const tradeIds = tradesSnap.docs.map((d) => d.id);
+
+  // 1. Subcollections recursivas.
+  const subColls = await studentRef.listCollections();
+  for (const sc of subColls) {
+    counts[`sub:${sc.id}`] = await deleteCollectionRecursive(db, sc);
+  }
+
+  // 2. Top-level por studentId (inclui cycleClosures).
+  for (const coll of TOP_LEVEL_COLLECTIONS) {
+    const n = await deleteByStudentIdQuery(db, coll, sid);
+    if (n > 0) counts[`top:${coll}`] = n;
+  }
+
+  // 3. movements por accountId (cobre depósito/saque/initial/adjustment sem studentId).
+  const movementsDeleted = await deleteMovementsByAccountIds(db, accountIds);
+  if (movementsDeleted > 0) counts['movements'] = movementsDeleted;
+
+  // 4. Storage best-effort.
+  const storageCleaned = await deleteTradeStorage(bucket, tradeIds);
+  if (storageCleaned > 0) counts['storage:trades'] = storageCleaned;
+
+  // 5. Doc principal.
+  await studentRef.delete();
+  counts['students'] = 1;
+
+  return counts;
+};
+
+module.exports = {
+  deleteStudentData,
+  deleteCollectionRecursive,
+  deleteByStudentIdQuery,
+  deleteMovementsByAccountIds,
+  deleteTradeStorage,
+  TOP_LEVEL_COLLECTIONS,
+};


### PR DESCRIPTION
Closes #309

## Problema
`deleteStudent` apagava as coleções top-level por `studentId`, mas:
- `movements` de **DEPOSIT/WITHDRAWAL/INITIAL_BALANCE/ADJUSTMENT** só têm `accountId` (sem `studentId`) → ficavam órfãos. Só `TRADE_RESULT` tem `studentId`.
- `cycleClosures` (top-level com `studentId`) estava **fora** de `TOP_LEVEL_COLLECTIONS`.
- Screenshots HTF/LTF em `trades/{tradeId}/...` no Storage nunca eram limpas.

## Fix
Cascata extraída para módulo testável `functions/students/deleteStudentData.js` (espelha `deleteAccountCascade`). `index.js` delega; mantém só o Auth-delete + fallback-by-email.

1. **movements por accountId** — coleta os `accountId` das contas do aluno **antes** de apagá-las e deleta `movements where accountId in [contas]` (chunks de 10, batches de 100). Cobre as 4 variantes só-accountId + TRADE_RESULT.
2. **cycleClosures** adicionado a `TOP_LEVEL_COLLECTIONS` (tem `studentId` — `closeCycle.js:181`).
3. **Storage best-effort** — `bucket.deleteFiles({ prefix: 'trades/{tradeId}/' })` por trade, em try/catch; falha não aborta a cascata (DEC-AUTO-309-01). Bucket obtido defensivamente.

## Testes
`functions/__tests__/students/deleteStudentData.test.js` — fake-db in-memory, 8 casos:
- movement de **depósito (só accountId)** E de **trade (studentId)** ambos apagados;
- `cycleClosures` apagado; isolamento dos dados de outro aluno;
- Storage best-effort (falha não aborta) + bucket null;
- aluno sem contas; counts por coleção.

**149 testes de functions verdes.**

## Pós-merge
- `firebase deploy --only functions` (toca `functions/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)