### PR TITLE
feat(#313): Reflexão na entrada do trade + copy de auto-análise

### DIFF
--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -840,6 +840,7 @@ const AddTradeModal = ({
             <TradeReviewSection
               trade={reviewTrade}
               canReview={true}
+              startOpen={true}
               onSubmit={async (reviewPayload) => { await onSubmitReview(reviewTrade.id, reviewPayload); closeAll(); }}
             />
           </div>

--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -99,6 +99,8 @@ const AddTradeModal = ({
   const [ltfPreview, setLtfPreview] = useState(null);
   const [errors, setErrors] = useState({});
   const [previewResult, setPreviewResult] = useState(null);
+  // #313 — Espelho no registro: trade recém-criado aguardando reflexão (passo pós-save).
+  const [reviewTrade, setReviewTrade] = useState(null);
   const [durationPreview, setDurationPreview] = useState(null);
   const [showPlanDropdown, setShowPlanDropdown] = useState(false);
   const [activeAssetRule, setActiveAssetRule] = useState(null);
@@ -800,8 +802,14 @@ const AddTradeModal = ({
     console.log('[MODAL] Enviando payload:', payload);
 
     try {
-      await onSubmit(payload, htfFile, ltfFile);
-      onClose();
+      const created = await onSubmit(payload, htfFile, ltfFile);
+      // #313 — trade NOVO já nasce com result (entry+exit+qty → result no gateway). Em vez de
+      // fechar, abre o Espelho na hora; o aluno reflete (ou pula). Edição segue fechando direto.
+      if (!editTrade && created?.id && created?.result != null && typeof onSubmitReview === 'function') {
+        setReviewTrade(created);
+      } else {
+        onClose();
+      }
     } catch (err) {
       console.error(err);
       setErrors({ submit: err.message });
@@ -814,6 +822,36 @@ const AddTradeModal = ({
 
   if (!isOpen) return null;
   if (masterLoading || accountsLoading) return <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center"><Loader2 className="animate-spin text-blue-500" /></div>;
+
+  // #313 — Passo do Espelho: trade registrado, aluno reflete agora (ou pula).
+  const closeAll = () => { setReviewTrade(null); onClose(); };
+  if (reviewTrade) {
+    return (
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4 overflow-auto">
+        <div className="bg-slate-900 border border-slate-800 rounded-2xl w-full max-w-2xl my-8 shadow-2xl flex flex-col max-h-[90vh]">
+          <div className="flex-none flex items-center justify-between p-4 border-b border-slate-800">
+            <div>
+              <h2 className="text-xl font-bold text-white">Trade registrado · Espelho</h2>
+              <p className="text-sm text-slate-500 mt-0.5">Reflita sobre a decisão, sem se prender ao resultado.</p>
+            </div>
+            <button onClick={closeAll} className="text-slate-400 hover:text-white"><X className="w-6 h-6" /></button>
+          </div>
+          <div className="flex-1 overflow-y-auto p-6">
+            <TradeReviewSection
+              trade={reviewTrade}
+              canReview={true}
+              onSubmit={async (reviewPayload) => { await onSubmitReview(reviewTrade.id, reviewPayload); closeAll(); }}
+            />
+          </div>
+          <div className="flex-none p-4 border-t border-slate-800 flex justify-end">
+            <button onClick={closeAll} className="px-4 py-2 text-sm text-slate-300 hover:text-white bg-slate-800 hover:bg-slate-700 rounded-lg">
+              Pular por agora
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4 overflow-auto">

--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -831,8 +831,8 @@ const AddTradeModal = ({
         <div className="bg-slate-900 border border-slate-800 rounded-2xl w-full max-w-2xl my-8 shadow-2xl flex flex-col max-h-[90vh]">
           <div className="flex-none flex items-center justify-between p-4 border-b border-slate-800">
             <div>
-              <h2 className="text-xl font-bold text-white">Trade registrado · Espelho</h2>
-              <p className="text-sm text-slate-500 mt-0.5">Reflita sobre a decisão, sem se prender ao resultado.</p>
+              <h2 className="text-xl font-bold text-white">Reflexão sobre o trade</h2>
+              <p className="text-sm text-slate-500 mt-0.5">Analise a decisão que tomou — o que a motivou e se você a repetiria, independente do resultado.</p>
             </div>
             <button onClick={closeAll} className="text-slate-400 hover:text-white"><X className="w-6 h-6" /></button>
           </div>

--- a/src/components/Trades/TradeReviewSection.jsx
+++ b/src/components/Trades/TradeReviewSection.jsx
@@ -69,7 +69,7 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
       <div className="relative border border-white/10 rounded-xl p-4 bg-white/5 mt-4">
         <div className="flex items-center gap-2 mb-3">
           <ClipboardCheck className="w-4 h-4 text-zinc-300" />
-          <span className="text-sm font-medium text-zinc-200">Espelho</span>
+          <span className="text-sm font-medium text-zinc-200">Reflexão</span>
           {meta && <span className="text-xs text-zinc-400">· {meta.label}</span>}
           <span className={`text-xs px-1.5 py-0.5 rounded border ${existing.wouldRepeat ? 'border-emerald-500/30 text-emerald-300' : 'border-amber-500/30 text-amber-300'}`}>
             Faria de novo: {existing.wouldRepeat ? 'Sim' : 'Não'}
@@ -89,7 +89,7 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
         )}
         {banner && (
           <div className={`text-xs rounded-lg border px-3 py-2 ${CONFRONT_TONE_STYLES[banner.tone]}`}>
-            <span className="font-medium">Reflexo · </span>{banner.text}
+            <span className="font-medium">Análise · </span>{banner.text}
           </div>
         )}
         <DebugBadge component="TradeReviewSection" />
@@ -125,14 +125,14 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
         <div className="flex items-center justify-between gap-3 flex-wrap">
           <div className="flex items-center gap-2">
             <ClipboardCheck className="w-4 h-4 text-zinc-300" />
-            <span className="text-sm text-zinc-300">Este trade ainda não passou pelo espelho.</span>
+            <span className="text-sm text-zinc-300">Este trade ainda não tem sua auto-análise.</span>
           </div>
           <button
             type="button"
             onClick={() => setEditing(true)}
             className="text-sm px-3 py-1.5 rounded-lg border border-emerald-500/40 text-emerald-300 hover:bg-emerald-500/10 transition-colors"
           >
-            Olhar no espelho
+            Analisar o trade
           </button>
         </div>
         <DebugBadge component="TradeReviewSection" />
@@ -146,7 +146,7 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
     <div className="relative border border-white/10 rounded-xl p-4 bg-white/5 mt-4">
       <div className="flex items-center gap-2 mb-3">
         <ClipboardCheck className="w-4 h-4 text-zinc-300" />
-        <span className="text-sm font-medium text-zinc-200">Espelho</span>
+        <span className="text-sm font-medium text-zinc-200">Reflexão</span>
         <span className={`text-xs px-1.5 py-0.5 rounded border ${isWin ? 'border-emerald-500/30 text-emerald-300' : 'border-red-500/30 text-red-300'}`}>
           {isWin ? 'Ganho' : 'Perda'}
         </span>

--- a/src/components/Trades/TradeReviewSection.jsx
+++ b/src/components/Trades/TradeReviewSection.jsx
@@ -48,9 +48,10 @@ const DimBadge = ({ dimension }) => {
   );
 };
 
-const TradeReviewSection = ({ trade, canReview = false, onSubmit }) => {
+const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = false }) => {
   const existing = trade?.selfReview || null;
-  const [editing, setEditing] = useState(false);
+  // #313 — no fluxo de registro o Espelho já abre nas perguntas (pula o nudge "Olhar no espelho").
+  const [editing, setEditing] = useState(startOpen);
   const [wouldRepeat, setWouldRepeat] = useState(null);
   const [answers, setAnswers] = useState({});
   const [saving, setSaving] = useState(false);

--- a/src/components/reviews/ReviewTradesSection.jsx
+++ b/src/components/reviews/ReviewTradesSection.jsx
@@ -158,7 +158,7 @@ const ReviewTradesSection = ({
                     <button
                       onClick={() => toggleMirror(t.tradeId)}
                       className={`p-0.5 rounded transition-colors ${mirrorOpen ? 'text-emerald-400' : 'text-slate-500 hover:text-emerald-400'}`}
-                      title={mirrorOpen ? 'Recolher o Espelho (auto-revisão do aluno)' : 'Ver o Espelho (auto-revisão do aluno)'}
+                      title={mirrorOpen ? 'Recolher a reflexão do aluno' : 'Ver a reflexão do aluno'}
                     >
                       <ClipboardCheck className="w-3.5 h-3.5" />
                     </button>

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -435,11 +435,11 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
     try {
       if (editingTrade) {
         await updateTrade(editingTrade.id, tradeData, htfFile, ltfFile);
-      } else {
-        await addTrade(tradeData, htfFile, ltfFile);
+        return null;
       }
-      setShowAddModal(false);
-      setEditingTrade(null);
+      // #313: retorna o trade criado p/ o AddTradeModal abrir o Espelho no registro.
+      // Fechamento passa a ser do modal (onClose).
+      return await addTrade(tradeData, htfFile, ltfFile);
     } catch (error) {
       console.error('Erro ao salvar trade:', error);
       // Re-throw pro AddTradeModal pegar e renderizar inline (glass-card vermelho).

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -147,10 +147,10 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
   const handleAddTrade = async (tradeData, htfFile, ltfFile) => {
     setIsSubmitting(true);
     try {
-      if (editingTrade) await updateTrade(editingTrade.id, tradeData, htfFile, ltfFile);
-      else await addTrade(tradeData, htfFile, ltfFile);
-      setShowAddModal(false);
-      setEditingTrade(null);
+      if (editingTrade) { await updateTrade(editingTrade.id, tradeData, htfFile, ltfFile); return null; }
+      // #313: retorna o trade criado p/ o AddTradeModal abrir o Espelho no registro.
+      // O fechamento passa a ser do modal (onClose), não daqui.
+      return await addTrade(tradeData, htfFile, ltfFile);
     } finally { setIsSubmitting(false); }
   };
 


### PR DESCRIPTION
Closes #313

## Resumo
Move a reflexão do trade (`TradeReviewSection`) do lápis de trade fechado para o **ato de registrar**: ao salvar um trade novo, abre o modal de reflexão na hora (o trade já nasce com `result`, então o questionário por quadrante serve como está). Reescreve a copy para tom de **auto-análise** (remove o framing lúdico "espelho", que denegria o nome do produto).

## Mudanças
- `AddTradeModal`: pós-create (trade novo, com result, `onSubmitReview` presente) abre o passo de Reflexão do trade recém-criado em vez de fechar; botão "Pular por agora". Edição segue fechando direto.
- `TradeReviewSection`: prop `startOpen` abre direto nas perguntas (pula o nudge) no fluxo de registro. Copy reescrita (Reflexão / auto-análise / "Análise ·"); **não** toca o nome do produto/plano "Espelho".
- `TradesJournal`/`StudentDashboard`: `handleAddTrade` retorna o trade criado; fechamento passa a ser do `onClose`. View-as do mentor não dispara reflexão.

Mesmo componente cobre registro E lápis de edição. Build cliente verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)