### PR TITLE
fix(#316): mentor não consegue dar feedback — classifyStudent com args trocados

### DIFF
--- a/docs/dev/issues/issue-315-humanize-evidence.md
+++ b/docs/dev/issues/issue-315-humanize-evidence.md
@@ -1,46 +1,35 @@
-# Issue #315 — feat: humanizar "Evidência técnica" do BehaviorPanel
+# Issue #315 — feat: Evidência técnica do BehaviorPanel visível só pro mentor
 
 > Template enxuto (R4). Fast-track autorizado por Marcio (25/06/2026).
 
 ## Autorização
 
 **Status atual do documento:**
-- [x] Mockup apresentado (tabela antes→depois no chat + body do issue)
-- [x] Memória de cálculo — N/A (sem fórmula; só mapeamento rótulo + formatação)
-- [x] Marcio autorizou — 25/06/2026 "abre a issue fast-track"
+- [x] Mockup — N/A (esconde elemento existente; sem UI nova)
+- [x] Memória de cálculo — N/A (sem fórmula)
+- [x] Marcio autorizou — 25/06/2026 "rebaixa pra opção 1, ajusta o escopo da issue, só mentor vê"
 - [x] Gate Pré-Código liberado
 
 ## Context
 
 O accordion "Evidência técnica" do `BehaviorPanel` despeja campos crus do schema do
-motor comportamental (`intervalMinutes`, `previousSide`, `actualRR: 0.11538…`). Sem o
-dicionário de dados, o aluno não entende o que aquilo diz sobre o que ele fez.
-Objetivo: substituir o dump por rótulos PT-BR + valores formatados, mantendo a
-transparência do diagnóstico.
+motor (`intervalMinutes`, `actualRR: 0.11538…`, `hiddenRrInflation`). Painel colapsado,
+atrás da narrativa que já é humanizada. Avaliação de ROI (25/06): humanizar o universo
+de campos é over-engineering com cauda de manutenção num epic ativo (CHUNK-11).
+**Decisão:** evidência crua vira mentor-only; aluno fica só com a narrativa.
 
 ## Spec
 Ver issue body no GitHub: #315.
 
 ## Mockup
-Accordion mantém o mesmo layout (grid 2 colunas), trocando `key: rawValue` por
-`Rótulo PT-BR: valor formatado`. Título "Evidência técnica" → menos intimidador
-("Os números por trás" / "Como cheguei nisso" — decidir na implementação).
-Exemplos (DIRECTION_FLIP):
-- Tempo desde o trade anterior: 7,9 min
-- Operação anterior: Compra · Resultado anterior: −R$ 49,00
-- Esta operação: Venda · Ativo: WINM26
+N/A — esconde bloco existente do aluno. Sem layout novo.
 
 ## Memória de Cálculo
-N/A — sem cálculo. Apenas:
-- Dicionário `EVIDENCE_FIELD_LABELS` (key → { label, format }).
-- Formatadores: moeda (`formatCurrencyDynamic`), %, min, lado (LONG→Compra/SHORT→Venda),
-  RR (2 casas). Campo não-mapeado → fallback (oculta campos só-de-motor:
-  `scenario`, `hiddenRrInflation`, `planRsDelivered`, `rrLocalAchieved`).
+N/A.
 
 ## Phases
-- A1 — Dicionário de rótulos + formatadores em `behaviorDisplay.jsx` + testes (INV-05)
-- A2 — Componente `EvidenceTechnical` compartilhado; trocar dump em `BehaviorPanel.jsx` e `UndersizedBody`
-- A3 — Revisar título do bloco + build verde
+- A1 — Testes (INV-05): aluno NÃO vê "Evidência técnica" ao expandir; mentor vê
+- A2 — `BehaviorPanel.jsx`: gate do bloco atrás de `isMentor`; `UndersizedBody` recebe e gateia `isMentor`; atualizar comentário de cabeçalho
 
 ## Sessions
 - _(a preencher)_

--- a/docs/dev/issues/issue-315-humanize-evidence.md
+++ b/docs/dev/issues/issue-315-humanize-evidence.md
@@ -1,35 +1,48 @@
-# Issue #315 — feat: Evidência técnica do BehaviorPanel visível só pro mentor
+# Issue #315 — feat: evidência mentor-only + imagens opcionais + reflexão na composição de feedback
 
 > Template enxuto (R4). Fast-track autorizado por Marcio (25/06/2026).
+> Consolidado em 1 issue (Marcio: "inclui aqui mesmo, sai com uma issue só").
 
 ## Autorização
 
 **Status atual do documento:**
-- [x] Mockup — N/A (esconde elemento existente; sem UI nova)
+- [x] Mockup — N/A (esconde/move elementos existentes; sem UI nova)
 - [x] Memória de cálculo — N/A (sem fórmula)
-- [x] Marcio autorizou — 25/06/2026 "rebaixa pra opção 1, ajusta o escopo da issue, só mentor vê"
+- [x] Marcio autorizou — 25/06/2026 (escopo A "rebaixa pra opção 1"; B "imagens não obrigatórias"; C "inclui aqui mesmo, sai com uma issue só")
 - [x] Gate Pré-Código liberado
 
 ## Context
 
-O accordion "Evidência técnica" do `BehaviorPanel` despeja campos crus do schema do
-motor (`intervalMinutes`, `actualRR: 0.11538…`, `hiddenRrInflation`). Painel colapsado,
-atrás da narrativa que já é humanizada. Avaliação de ROI (25/06): humanizar o universo
-de campos é over-engineering com cauda de manutenção num epic ativo (CHUNK-11).
-**Decisão:** evidência crua vira mentor-only; aluno fica só com a narrativa.
+Três ajustes no fluxo de trade/feedback, consolidados:
+- **A (CHUNK-11)** — accordion "Evidência técnica" do `BehaviorPanel` despeja campos crus
+  do schema. ROI de humanizar é baixo (painel colapsado, epic ativo). → evidência crua
+  vira **mentor-only**; aluno fica com a narrativa.
+- **B (CHUNK-04)** — `AddTradeModal` exige imagem HTF e LTF na criação do trade. → tornar
+  ambas **opcionais**.
+- **C (CHUNK-08)** — a reflexão do aluno (`trade.selfReview`: "Faria de novo" + respostas)
+  não aparece na `FeedbackPage` (onde o mentor compõe feedback) nem na `StudentReviewsPage`.
+  → exibir a reflexão read-only nessas telas, com estado explícito quando o aluno ainda
+  não refletiu.
 
 ## Spec
 Ver issue body no GitHub: #315.
 
 ## Mockup
-N/A — esconde bloco existente do aluno. Sem layout novo.
+N/A — esconde/move blocos existentes (`TradeReviewSection` já é read-only auto-suficiente).
 
 ## Memória de Cálculo
 N/A.
 
 ## Phases
-- A1 — Testes (INV-05): aluno NÃO vê "Evidência técnica" ao expandir; mentor vê
-- A2 — `BehaviorPanel.jsx`: gate do bloco atrás de `isMentor`; `UndersizedBody` recebe e gateia `isMentor`; atualizar comentário de cabeçalho
+- A — Evidência mentor-only: `BehaviorPanel.jsx` + `UndersizedBody` gate `isMentor` + testes ✅ (commit fd66e522)
+- B — Imagens opcionais: `AddTradeModal.jsx` remove validação HTF/LTF + asterisco; teste
+- C — Reflexão na composição: `FeedbackPage` renderiza `TradeReviewSection`; `StudentReviewsPage`
+      passa `showSelfReview`; estado "aluno ainda não refletiu" pro mentor; testes
+
+## Chunks
+- CHUNK-11 (escrita) — display do `behaviorProfile`
+- CHUNK-04 (escrita) — registro de trade (`AddTradeModal`)
+- CHUNK-08 (escrita) — composição de feedback (`FeedbackPage`, `StudentReviewsPage`)
 
 ## Sessions
 - _(a preencher)_
@@ -37,11 +50,8 @@ N/A.
 ## Shared Deltas
 - `src/version.js` — bump v1.78.0 (reservado no main)
 - `docs/registry/versions.md` — marcar v1.78.0 consumida (no encerramento)
-- `docs/registry/chunks.md` — liberar CHUNK-11 (no encerramento)
+- `docs/registry/chunks.md` — liberar CHUNK-11 / CHUNK-04 / CHUNK-08 (no encerramento)
 - `CHANGELOG.md` — nova entrada `[1.78.0] - 25/06/2026`
 
 ## Decisions
 - _(a preencher se houver DEC-AUTO)_
-
-## Chunks
-- CHUNK-11 (escrita) — display do `trade.behaviorProfile`

--- a/docs/dev/issues/issue-315-humanize-evidence.md
+++ b/docs/dev/issues/issue-315-humanize-evidence.md
@@ -1,0 +1,58 @@
+# Issue #315 — feat: humanizar "Evidência técnica" do BehaviorPanel
+
+> Template enxuto (R4). Fast-track autorizado por Marcio (25/06/2026).
+
+## Autorização
+
+**Status atual do documento:**
+- [x] Mockup apresentado (tabela antes→depois no chat + body do issue)
+- [x] Memória de cálculo — N/A (sem fórmula; só mapeamento rótulo + formatação)
+- [x] Marcio autorizou — 25/06/2026 "abre a issue fast-track"
+- [x] Gate Pré-Código liberado
+
+## Context
+
+O accordion "Evidência técnica" do `BehaviorPanel` despeja campos crus do schema do
+motor comportamental (`intervalMinutes`, `previousSide`, `actualRR: 0.11538…`). Sem o
+dicionário de dados, o aluno não entende o que aquilo diz sobre o que ele fez.
+Objetivo: substituir o dump por rótulos PT-BR + valores formatados, mantendo a
+transparência do diagnóstico.
+
+## Spec
+Ver issue body no GitHub: #315.
+
+## Mockup
+Accordion mantém o mesmo layout (grid 2 colunas), trocando `key: rawValue` por
+`Rótulo PT-BR: valor formatado`. Título "Evidência técnica" → menos intimidador
+("Os números por trás" / "Como cheguei nisso" — decidir na implementação).
+Exemplos (DIRECTION_FLIP):
+- Tempo desde o trade anterior: 7,9 min
+- Operação anterior: Compra · Resultado anterior: −R$ 49,00
+- Esta operação: Venda · Ativo: WINM26
+
+## Memória de Cálculo
+N/A — sem cálculo. Apenas:
+- Dicionário `EVIDENCE_FIELD_LABELS` (key → { label, format }).
+- Formatadores: moeda (`formatCurrencyDynamic`), %, min, lado (LONG→Compra/SHORT→Venda),
+  RR (2 casas). Campo não-mapeado → fallback (oculta campos só-de-motor:
+  `scenario`, `hiddenRrInflation`, `planRsDelivered`, `rrLocalAchieved`).
+
+## Phases
+- A1 — Dicionário de rótulos + formatadores em `behaviorDisplay.jsx` + testes (INV-05)
+- A2 — Componente `EvidenceTechnical` compartilhado; trocar dump em `BehaviorPanel.jsx` e `UndersizedBody`
+- A3 — Revisar título do bloco + build verde
+
+## Sessions
+- _(a preencher)_
+
+## Shared Deltas
+- `src/version.js` — bump v1.78.0 (reservado no main)
+- `docs/registry/versions.md` — marcar v1.78.0 consumida (no encerramento)
+- `docs/registry/chunks.md` — liberar CHUNK-11 (no encerramento)
+- `CHANGELOG.md` — nova entrada `[1.78.0] - 25/06/2026`
+
+## Decisions
+- _(a preencher se houver DEC-AUTO)_
+
+## Chunks
+- CHUNK-11 (escrita) — display do `trade.behaviorProfile`

--- a/docs/dev/issues/issue-316-feedback-classify-args.md
+++ b/docs/dev/issues/issue-316-feedback-classify-args.md
@@ -1,0 +1,30 @@
+# Issue #316 — fix: mentor não consegue dar feedback (classifyStudent com args trocados)
+
+> HOTFIX de regressão em prod. Mockup/memória de cálculo dispensados (bugfix, autorização "go" do Marcio em 01/07/2026).
+
+## Autorização
+- [x] Exceção mockup/memória — bugfix, não há UI/cálculo novo
+- [x] Marcio autorizou — "go, segue com o hotfix por cima do #315" (01/07/2026)
+- [x] Gate Pré-Código liberado
+
+## Context
+Regressão da #269 (v1.76.0): todo mentor recebe `Feedback disponível apenas para alunos Alpha ou Trial-Alpha` ao tentar dar feedback, **para qualquer aluno**. Causa: o gate `assertStudentInReviewScope` (`useTrades.js:46`) chama a versão FRONT de `classifyStudent`, cuja assinatura é `(_student, subs)`, com **1 argumento só** (padrão copiado do backend, que é `(subs)`). As subs caem em `_student`; `subs` fica `undefined` → sempre retorna `null` → gate bloqueia todos. Afeta `addFeedbackComment` (:481) e `addBulkFeedback` (:556).
+
+## Spec
+Ver issue body no GitHub: #316.
+
+## Phases
+- A1 — Fix da chamada em `useTrades.js:46` (passar subs como 2º arg).
+- A2 — Trazer `useTrades.test.js` (untracked, coverage da #269) pro commit.
+- A3 — Teste de regressão `useTrades.reviewScope.test.js` com `classifyStudent` REAL (validado: fica vermelho sem o fix).
+- A4 — Bump `version.js` → 1.77.1.
+
+## Shared Deltas
+- MAIN (commit `907e8a0d`): lock CHUNK-04+08 (#316) em `registry/chunks.md` + reserva v1.77.1 em `registry/versions.md`.
+- `version.js` do main permanece 1.78.0 (ponteiro reserva #315); bump 1.77.1 vive só neste branch.
+
+## Decisions
+- Nenhuma DEC nova. Bug puramente mecânico (args).
+
+## Chunks
+CHUNK-08 (Mentor Feedback), CHUNK-04 (Trade Ledger). Co-lock com #315 — coordenar ordem de merge.

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,4 +5,6 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
-| CHUNK-11 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | humanizar Evidência técnica do BehaviorPanel |
+| CHUNK-11 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | evidência técnica mentor-only no BehaviorPanel |
+| CHUNK-04 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | imagens HTF/LTF opcionais no registro de trade |
+| CHUNK-08 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | reflexão do aluno visível na composição de feedback |

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -8,3 +8,5 @@
 | CHUNK-11 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | evidência técnica mentor-only no BehaviorPanel |
 | CHUNK-04 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | imagens HTF/LTF opcionais no registro de trade |
 | CHUNK-08 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | reflexão do aluno visível na composição de feedback |
+| CHUNK-08 | #316 | `fix/issue-316-feedback-classify-args` | 01/07/2026 | HOTFIX co-lock com #315 — gate de feedback quebrado (args de classifyStudent). Coordenar ordem de merge |
+| CHUNK-04 | #316 | `fix/issue-316-feedback-classify-args` | 01/07/2026 | HOTFIX co-lock com #315 — toca só `useTrades.js:46` (gate). Coordenar ordem de merge |

--- a/docs/registry/chunks.md
+++ b/docs/registry/chunks.md
@@ -5,3 +5,4 @@
 
 | Chunk | Issue | Branch | Data | Sessão |
 |-------|-------|--------|------|--------|
+| CHUNK-11 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | humanizar Evidência técnica do BehaviorPanel |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -53,3 +53,4 @@
 | 1.75.0 | #308 | `feat/issue-308-trade-self-review` | 10/06/2026 | consumida (PR #311 squash `6602b815`) |
 | 1.76.0 | #269 | `feat/issue-269-262-revisao-swot` | 16/06/2026 | consumida (PR #312 squash `7bc7eb57`) |
 | 1.77.0 | #313 | `feat/issue-313-espelho-na-entrada` | 24/06/2026 | consumida (PR #314 squash `238882f9`) |
+| 1.78.0 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | reservada |

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -54,3 +54,4 @@
 | 1.76.0 | #269 | `feat/issue-269-262-revisao-swot` | 16/06/2026 | consumida (PR #312 squash `7bc7eb57`) |
 | 1.77.0 | #313 | `feat/issue-313-espelho-na-entrada` | 24/06/2026 | consumida (PR #314 squash `238882f9`) |
 | 1.78.0 | #315 | `feat/issue-315-humanize-evidence` | 25/06/2026 | reservada |
+| 1.77.1 | #316 | `fix/issue-316-feedback-classify-args` | 01/07/2026 | reservada — HOTFIX patch sobre última consumida (1.77.0); passa por baixo da reserva 1.78.0 do #315. `version.js` do main fica em 1.78.0 (ponteiro do #315); bump p/ 1.77.1 só no branch do hotfix |

--- a/src/__tests__/hooks/useTrades.reviewScope.test.js
+++ b/src/__tests__/hooks/useTrades.reviewScope.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ============================================================
+// Regressão #316 — o gate de feedback (assertStudentInReviewScope) precisa
+// chamar classifyStudent do FRONT com a assinatura correta (_student, subs).
+// A #269 passou as subs na posição errada (1 arg), fazendo classifyStudent
+// retornar sempre null → mentor bloqueado pra TODO aluno, mesmo Alpha.
+//
+// Diferença chave vs useTrades.test.js: aqui NÃO mockamos studentClassify —
+// usamos a implementação REAL, e configuramos getDocs pra devolver subs
+// reais. Só assim o mismatch de argumentos aparece.
+// ============================================================
+
+const mockUpdateDoc = vi.fn(() => Promise.resolve());
+const mockBatchUpdate = vi.fn();
+const mockBatchCommit = vi.fn(() => Promise.resolve());
+
+// Subscriptions devolvidas por getDocs(students/{id}/subscriptions). Configurável.
+let mockSubsDocs = [];
+// getDoc(tradeRef) — trade "atual" configurável.
+let mockGetDocImpl = () => ({ exists: () => false });
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args) => ({ __type: 'collection', path: args.slice(1).join('/') }),
+  doc: (...args) => ({ __type: 'doc', path: args.slice(1).join('/') }),
+  query: (...args) => ({ __type: 'query', args }),
+  where: (...args) => ({ __type: 'where', args }),
+  orderBy: (...args) => ({ __type: 'orderBy', args }),
+  onSnapshot: (q, onNext) => {
+    onNext({ docs: [] });
+    return () => {};
+  },
+  addDoc: vi.fn(() => Promise.resolve({ id: 'new-id' })),
+  updateDoc: (...args) => mockUpdateDoc(...args),
+  deleteDoc: vi.fn(() => Promise.resolve()),
+  getDoc: (...args) => Promise.resolve(mockGetDocImpl(...args)),
+  // Único getDocs relevante no fluxo de feedback é o das subscriptions.
+  getDocs: vi.fn(() => Promise.resolve({ docs: mockSubsDocs.map((s) => ({ data: () => s })) })),
+  serverTimestamp: () => ({ __type: 'serverTimestamp' }),
+  arrayUnion: (...items) => ({ __type: 'arrayUnion', items }),
+  writeBatch: () => ({ update: mockBatchUpdate, commit: mockBatchCommit }),
+}));
+
+vi.mock('firebase/storage', () => ({
+  ref: vi.fn(() => ({})),
+  uploadBytes: vi.fn(() => Promise.resolve({ ref: {} })),
+  getDownloadURL: vi.fn(() => Promise.resolve('https://example.com/img.png')),
+}));
+
+vi.mock('../../firebase', () => ({
+  db: { __type: 'db' },
+  storage: { __type: 'storage' },
+}));
+
+// NOTA: studentClassify NÃO é mockado — usamos a implementação real de propósito.
+
+let mockAuthState = { user: null, isMentor: () => false };
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuthState,
+}));
+
+import { useTrades } from '../../hooks/useTrades';
+
+const MENTOR = { uid: 'mentor-1', email: 'mentor@espelho.com', displayName: 'Mentor' };
+
+const sub = (over = {}) => ({
+  type: 'paid', plan: 'alpha', status: 'active', renewalDate: '2026-12-01', ...over,
+});
+
+beforeEach(() => {
+  mockUpdateDoc.mockClear();
+  mockBatchUpdate.mockClear();
+  mockBatchCommit.mockClear();
+  mockSubsDocs = [];
+  mockGetDocImpl = () => ({ exists: () => false });
+  mockAuthState = { user: MENTOR, isMentor: () => true };
+});
+
+describe('useTrades — gate de feedback com classifyStudent REAL (#316)', () => {
+  it('aluno Alpha (paid): mentor consegue dar feedback — não bloqueia', async () => {
+    mockSubsDocs = [sub({ plan: 'alpha', type: 'paid' })];
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    // Sob o bug (args trocados) isto lançaria 'Alpha'. Com o fix, passa.
+    await act(async () => {
+      await result.current.addFeedbackComment('t1', 'observação');
+    });
+
+    const payload = mockUpdateDoc.mock.calls[0][1];
+    expect(payload.status).toBe('REVIEWED');
+  });
+
+  it('aluno Trial-Alpha: mentor consegue dar feedback — não bloqueia', async () => {
+    mockSubsDocs = [sub({ plan: 'alpha', type: 'trial', trialEndsAt: '2026-12-01' })];
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.addFeedbackComment('t1', 'observação');
+    });
+
+    expect(mockUpdateDoc).toHaveBeenCalled();
+  });
+
+  it('aluno Espelho (self_service): mentor é bloqueado', async () => {
+    mockSubsDocs = [sub({ plan: 'self_service', type: 'paid' })];
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await expect(result.current.addFeedbackComment('t1', 'x')).rejects.toThrow('Alpha');
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('aluno sem sub ativa: mentor é bloqueado', async () => {
+    mockSubsDocs = [];
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await expect(result.current.addFeedbackComment('t1', 'x')).rejects.toThrow('Alpha');
+  });
+
+  it('addBulkFeedback: aluno Alpha passa o gate e commita o batch', async () => {
+    mockSubsDocs = [sub({ plan: 'alpha', type: 'paid' })];
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    let ret;
+    await act(async () => {
+      ret = await result.current.addBulkFeedback(['t1', 't2'], 'feedback em massa');
+    });
+
+    expect(ret).toEqual({ success: true, count: 2 });
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/hooks/useTrades.test.js
+++ b/src/__tests__/hooks/useTrades.test.js
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ============================================================
+// Mocks firebase/firestore — captura de writes + snapshot configurável
+// ============================================================
+const mockUpdateDoc = vi.fn(() => Promise.resolve());
+const mockBatchUpdate = vi.fn();
+const mockBatchCommit = vi.fn(() => Promise.resolve());
+
+// Snapshot entregue ao listener (mentor mode → allTrades). Configurável por teste.
+let mockSnapshotDocs = [];
+// getDoc(tradeRef) configurável: retorna o snap do trade "atual".
+let mockGetDocImpl = () => ({ exists: () => false });
+
+function makeDoc(trade) {
+  const { id, ...fields } = trade;
+  return { id, data: () => fields };
+}
+
+vi.mock('firebase/firestore', () => ({
+  collection: (...args) => ({ __type: 'collection', path: args.slice(1).join('/') }),
+  doc: (...args) => ({ __type: 'doc', path: args.slice(1).join('/') }),
+  query: (...args) => ({ __type: 'query', args }),
+  where: (...args) => ({ __type: 'where', args }),
+  orderBy: (...args) => ({ __type: 'orderBy', args }),
+  onSnapshot: (q, onNext) => {
+    onNext({ docs: mockSnapshotDocs.map(makeDoc) });
+    return () => {};
+  },
+  addDoc: vi.fn(() => Promise.resolve({ id: 'new-id' })),
+  updateDoc: (...args) => mockUpdateDoc(...args),
+  deleteDoc: vi.fn(() => Promise.resolve()),
+  getDoc: (...args) => Promise.resolve(mockGetDocImpl(...args)),
+  getDocs: vi.fn(() => Promise.resolve({ docs: [], empty: true })),
+  serverTimestamp: () => ({ __type: 'serverTimestamp' }),
+  arrayUnion: (...items) => ({ __type: 'arrayUnion', items }),
+  writeBatch: () => ({ update: mockBatchUpdate, commit: mockBatchCommit }),
+}));
+
+vi.mock('firebase/storage', () => ({
+  ref: vi.fn(() => ({})),
+  uploadBytes: vi.fn(() => Promise.resolve({ ref: {} })),
+  getDownloadURL: vi.fn(() => Promise.resolve('https://example.com/img.png')),
+}));
+
+vi.mock('../../firebase', () => ({
+  db: { __type: 'db' },
+  storage: { __type: 'storage' },
+}));
+
+// Filtro matriz #269 — inReviewScope configurável por teste
+let mockInReviewScope = true;
+vi.mock('../../utils/studentClassify', () => ({
+  classifyStudent: () => 'alpha',
+  inReviewScope: () => mockInReviewScope,
+}));
+
+// useAuth configurável por teste
+let mockAuthState = { user: null, isMentor: () => false };
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuthState,
+}));
+
+import { useTrades } from '../../hooks/useTrades';
+
+const MENTOR = { uid: 'mentor-1', email: 'mentor@espelho.com', displayName: 'Mentor' };
+const ALUNO = { uid: 'aluno-1', email: 'aluno@espelho.com', displayName: 'Aluno' };
+
+// Helper: localiza a chamada de updateDoc cujo payload satisfaz o predicado
+function updatePayloadMatching(pred) {
+  const call = mockUpdateDoc.mock.calls.find((c) => pred(c[1]));
+  if (!call) throw new Error('Nenhuma chamada de updateDoc casou o predicado');
+  return call[1];
+}
+
+beforeEach(() => {
+  mockUpdateDoc.mockClear();
+  mockBatchUpdate.mockClear();
+  mockBatchCommit.mockClear();
+  mockSnapshotDocs = [];
+  mockGetDocImpl = () => ({ exists: () => false });
+  mockInReviewScope = true;
+  mockAuthState = { user: null, isMentor: () => false };
+});
+
+// ============================================================
+// Selectors / helpers (mentor mode popula allTrades via snapshot)
+// ============================================================
+describe('useTrades — selectors sobre allTrades', () => {
+  const FIXTURE = [
+    { id: 't1', studentEmail: 'a@x.com', studentName: 'Ana', studentId: 'sa', status: 'OPEN' },
+    { id: 't2', studentEmail: 'a@x.com', studentName: 'Ana', studentId: 'sa', status: 'REVIEWED' },
+    { id: 't3', studentEmail: 'a@x.com', studentName: 'Ana', studentId: 'sa', status: 'QUESTION' },
+    { id: 't4', studentEmail: 'b@x.com', studentName: 'Bob', studentId: 'sb', status: 'OPEN' },
+    { id: 't5', studentEmail: 'b@x.com', studentName: 'Bob', studentId: 'sb', status: 'CLOSED' },
+  ];
+
+  function renderMentorWith(docs) {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockSnapshotDocs = docs;
+    return renderHook(() => useTrades(null));
+  }
+
+  it('mentor mode: snapshot popula allTrades e trades', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    expect(result.current.allTrades).toHaveLength(5);
+    expect(result.current.allTrades[0]).toMatchObject({ id: 't1', studentEmail: 'a@x.com' });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('getTradesByStudent filtra por email', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    expect(result.current.getTradesByStudent('a@x.com').map((t) => t.id)).toEqual(['t1', 't2', 't3']);
+    expect(result.current.getTradesByStudent('b@x.com')).toHaveLength(2);
+    expect(result.current.getTradesByStudent('ninguem@x.com')).toEqual([]);
+  });
+
+  it('getTradesAwaitingFeedback retorna apenas OPEN e QUESTION', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    const ids = result.current.getTradesAwaitingFeedback().map((t) => t.id).sort();
+    expect(ids).toEqual(['t1', 't3', 't4']);
+  });
+
+  it('getTradesGroupedByStudent agrupa por email', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    const grouped = result.current.getTradesGroupedByStudent();
+    expect(Object.keys(grouped).sort()).toEqual(['a@x.com', 'b@x.com']);
+    expect(grouped['a@x.com']).toHaveLength(3);
+    expect(grouped['b@x.com']).toHaveLength(2);
+  });
+
+  it('getTradesGroupedByStudent usa "unknown" quando falta email', () => {
+    const { result } = renderMentorWith([{ id: 'tx', status: 'OPEN' }]);
+    expect(result.current.getTradesGroupedByStudent()).toHaveProperty('unknown');
+  });
+
+  it('getUniqueStudents deduplica por email', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    const students = result.current.getUniqueStudents();
+    expect(students).toHaveLength(2);
+    expect(students.find((s) => s.email === 'a@x.com')).toMatchObject({ name: 'Ana', studentId: 'sa' });
+  });
+
+  it('getUniqueStudents deriva nome do email quando studentName ausente', () => {
+    const { result } = renderMentorWith([{ id: 'tx', studentEmail: 'carol@x.com', studentId: 'sc', status: 'OPEN' }]);
+    expect(result.current.getUniqueStudents()[0].name).toBe('carol');
+  });
+
+  it('getStudentFeedbackCounts conta por status', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    expect(result.current.getStudentFeedbackCounts('a@x.com')).toEqual({
+      open: 1, question: 1, reviewed: 1, closed: 0, total: 3,
+    });
+    expect(result.current.getStudentFeedbackCounts('b@x.com')).toEqual({
+      open: 1, question: 0, reviewed: 0, closed: 1, total: 2,
+    });
+  });
+
+  it('getTradesByStudentAndStatus cruza email + status', () => {
+    const { result } = renderMentorWith(FIXTURE);
+    expect(result.current.getTradesByStudentAndStatus('a@x.com', 'REVIEWED').map((t) => t.id)).toEqual(['t2']);
+    expect(result.current.getTradesByStudentAndStatus('b@x.com', 'QUESTION')).toEqual([]);
+  });
+});
+
+// ============================================================
+// Guards de autenticação
+// ============================================================
+describe('useTrades — guards', () => {
+  it('addTrade sem usuário lança', async () => {
+    mockAuthState = { user: null, isMentor: () => false };
+    const { result } = renderHook(() => useTrades(null));
+    await expect(result.current.addTrade({})).rejects.toThrow('não autenticado');
+  });
+
+  it('sem usuário, trades fica vazio e loading resolve', () => {
+    mockAuthState = { user: null, isMentor: () => false };
+    const { result } = renderHook(() => useTrades(null));
+    expect(result.current.trades).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('addFeedback exige mentor', async () => {
+    mockAuthState = { user: ALUNO, isMentor: () => false };
+    const { result } = renderHook(() => useTrades(null));
+    await expect(result.current.addFeedback('t1', 'oi')).rejects.toThrow('Apenas mentores');
+  });
+
+  it('addBulkFeedback rejeita lista vazia', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    const { result } = renderHook(() => useTrades(null));
+    await expect(result.current.addBulkFeedback([], 'texto')).rejects.toThrow('obrigatórios');
+  });
+});
+
+// ============================================================
+// Sistema de feedback (máquina de estados)
+// ============================================================
+describe('useTrades — addFeedback', () => {
+  it('mentor: grava mentorFeedback, status REVIEWED e comentário no histórico', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.addFeedback('t1', '  bom trade  ');
+    });
+
+    const payload = updatePayloadMatching((p) => p.mentorFeedback !== undefined);
+    expect(payload.mentorFeedback).toBe('  bom trade  ');
+    expect(payload.status).toBe('REVIEWED');
+    const comment = payload.feedbackHistory.items[0];
+    expect(comment.authorRole).toBe('mentor');
+    expect(comment.content).toBe('bom trade'); // trim no comentário
+    expect(comment.isQuestion).toBe(false);
+  });
+});
+
+describe('useTrades — addFeedbackComment (máquina de estados)', () => {
+  it('mentor sobre trade OPEN: transita para REVIEWED e seta mentorFeedback legado', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.addFeedbackComment('t1', 'observação');
+    });
+
+    const payload = mockUpdateDoc.mock.calls[0][1];
+    expect(payload.status).toBe('REVIEWED');
+    expect(payload.mentorFeedback).toBe('observação'); // primeiro feedback do mentor
+    expect(payload.feedbackHistory.items[0].authorRole).toBe('mentor');
+  });
+
+  it('mentor sobre trade QUESTION: volta para REVIEWED sem reescrever mentorFeedback legado', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'QUESTION' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.addFeedbackComment('t1', 'resposta');
+    });
+
+    const payload = mockUpdateDoc.mock.calls[0][1];
+    expect(payload.status).toBe('REVIEWED');
+    expect(payload.mentorFeedback).toBeUndefined(); // só no primeiro (OPEN)
+  });
+
+  it('aluno com dúvida sobre trade REVIEWED: transita para QUESTION', async () => {
+    mockAuthState = { user: ALUNO, isMentor: () => false };
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'REVIEWED' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.addFeedbackComment('t1', 'não entendi', true);
+    });
+
+    const payload = mockUpdateDoc.mock.calls[0][1];
+    expect(payload.status).toBe('QUESTION');
+    expect(payload.feedbackHistory.items[0].authorRole).toBe('student');
+    expect(payload.feedbackHistory.items[0].isQuestion).toBe(true);
+  });
+
+  it('imageUrl é anexada ao comentário quando fornecida', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.addFeedbackComment('t1', 'veja', false, 'https://img/x.png');
+    });
+
+    const payload = mockUpdateDoc.mock.calls[0][1];
+    expect(payload.feedbackHistory.items[0].imageUrl).toBe('https://img/x.png');
+  });
+
+  it('mentor fora do escopo de revisão (#269) é bloqueado', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockInReviewScope = false;
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa', status: 'OPEN' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await expect(result.current.addFeedbackComment('t1', 'x')).rejects.toThrow('Alpha');
+    expect(mockUpdateDoc).not.toHaveBeenCalled();
+  });
+
+  it('trade inexistente lança', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockGetDocImpl = () => ({ exists: () => false });
+    const { result } = renderHook(() => useTrades(null));
+    await expect(result.current.addFeedbackComment('tX', 'x')).rejects.toThrow('não encontrado');
+  });
+});
+
+describe('useTrades — addBulkFeedback', () => {
+  it('aplica batch update em todos os trades e commita uma vez', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    let ret;
+    await act(async () => {
+      ret = await result.current.addBulkFeedback(['t1', 't2', 't3'], 'feedback em massa');
+    });
+
+    expect(ret).toEqual({ success: true, count: 3 });
+    expect(mockBatchUpdate).toHaveBeenCalledTimes(3);
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+
+    const firstPayload = mockBatchUpdate.mock.calls[0][1];
+    expect(firstPayload.status).toBe('REVIEWED');
+    expect(firstPayload.mentorFeedback).toBe('feedback em massa');
+    expect(firstPayload.feedbackHistory.items[0].isBulk).toBe(true);
+    expect(firstPayload.feedbackHistory.items[0].bulkCount).toBe(3);
+  });
+
+  it('bloqueado quando aluno fora do escopo (#269)', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    mockInReviewScope = false;
+    mockGetDocImpl = () => ({ exists: () => true, data: () => ({ studentId: 'sa' }) });
+    const { result } = renderHook(() => useTrades(null));
+
+    await expect(result.current.addBulkFeedback(['t1'], 'x')).rejects.toThrow('Alpha');
+    expect(mockBatchCommit).not.toHaveBeenCalled();
+  });
+});
+
+describe('useTrades — updateTradeStatus', () => {
+  it('grava status e updatedAt', async () => {
+    mockAuthState = { user: MENTOR, isMentor: () => true };
+    const { result } = renderHook(() => useTrades(null));
+
+    await act(async () => {
+      await result.current.updateTradeStatus('t1', 'CLOSED');
+    });
+
+    const payload = mockUpdateDoc.mock.calls[0][1];
+    expect(payload.status).toBe('CLOSED');
+    expect(payload.updatedAt).toEqual({ __type: 'serverTimestamp' });
+  });
+});

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -43,7 +43,10 @@ import { classifyStudent, inReviewScope } from '../utils/studentClassify';
 async function assertStudentInReviewScope(studentId) {
   if (!studentId) throw new Error('Trade sem studentId — feedback bloqueado');
   const subsSnap = await getDocs(collection(db, 'students', studentId, 'subscriptions'));
-  if (!inReviewScope(classifyStudent(subsSnap.docs.map((d) => d.data())))) {
+  // classifyStudent do FRONT tem assinatura (_student, subs) — subs é o 2º arg.
+  // (a versão do backend em functions/_shared é (subs); não confundir — #316)
+  const subs = subsSnap.docs.map((d) => d.data());
+  if (!inReviewScope(classifyStudent(null, subs))) {
     throw new Error('Feedback disponível apenas para alunos Alpha ou Trial-Alpha (em dupla com o mentor).');
   }
 }

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.78.0: #315 feat (RESERVA) humanizar "Evidência técnica" do BehaviorPanel — rótulos PT-BR + formatação
  * - 1.77.0: #313 feat Reflexão na entrada do trade + copy de auto-análise (PR #314, 25/06/2026)
  * - 1.76.0: #269 feat Revisão por backlog (FK reviewId) + SWOT customizável + filtro matriz Alpha/Tr (PR #312, 24/06/2026)
  * - 1.75.0: #308 feat Espelho (auto-revisão de trade) + fixes import (coverage gap, timezone) + email Espelho/app.marcioportes (PR #311, 10/06/2026)
@@ -372,10 +373,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.77.0',
+  version: '1.78.0',
   build: '20260625',
-  display: 'v1.77.0',
-  full: '1.77.0+20260625',
+  display: 'v1.78.0',
+  full: '1.78.0+20260625',
 };
 export default VERSION;
 export { VERSION };

--- a/src/version.js
+++ b/src/version.js
@@ -3,7 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
- * - 1.78.0: #315 feat (RESERVA) humanizar "Evidência técnica" do BehaviorPanel — rótulos PT-BR + formatação
+ * - 1.78.0: #315 feat (RESERVA) evidência técnica mentor-only + imagens HTF/LTF opcionais no registro + reflexão do aluno na composição de feedback
  * - 1.77.0: #313 feat Reflexão na entrada do trade + copy de auto-análise (PR #314, 25/06/2026)
  * - 1.76.0: #269 feat Revisão por backlog (FK reviewId) + SWOT customizável + filtro matriz Alpha/Tr (PR #312, 24/06/2026)
  * - 1.75.0: #308 feat Espelho (auto-revisão de trade) + fixes import (coverage gap, timezone) + email Espelho/app.marcioportes (PR #311, 10/06/2026)

--- a/src/version.js
+++ b/src/version.js
@@ -4,6 +4,7 @@
  *
  * CHANGELOG:
  * - 1.78.0: #315 feat (RESERVA) evidência técnica mentor-only + imagens HTF/LTF opcionais no registro + reflexão do aluno na composição de feedback
+ * - 1.77.1: #316 fix HOTFIX gate de feedback — classifyStudent (front) chamado com args trocados (regressão #269); mentor não dava feedback a ninguém (01/07/2026)
  * - 1.77.0: #313 feat Reflexão na entrada do trade + copy de auto-análise (PR #314, 25/06/2026)
  * - 1.76.0: #269 feat Revisão por backlog (FK reviewId) + SWOT customizável + filtro matriz Alpha/Tr (PR #312, 24/06/2026)
  * - 1.75.0: #308 feat Espelho (auto-revisão de trade) + fixes import (coverage gap, timezone) + email Espelho/app.marcioportes (PR #311, 10/06/2026)
@@ -373,10 +374,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.78.0',
-  build: '20260625',
-  display: 'v1.78.0',
-  full: '1.78.0+20260625',
+  version: '1.77.1',
+  build: '20260701',
+  display: 'v1.77.1',
+  full: '1.77.1+20260701',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Problema
Regressão da #269 (v1.76.0): **todo mentor** recebe `Feedback disponível apenas para alunos Alpha ou Trial-Alpha` ao tentar dar feedback, para **qualquer** aluno (Alpha inclusive).

## Causa raiz
As duas versões de `classifyStudent` têm assinaturas diferentes:
- Backend `functions/_shared/studentClassify.js`: `classifyStudent(subs)` — 1 arg
- Frontend `src/utils/studentClassify.js`: `classifyStudent(_student, subs)` — subs é o **2º** arg

O gate `assertStudentInReviewScope` (`useTrades.js`) chamava a versão do front com **1 arg só** (padrão copiado do backend). As subs caíam em `_student`; `subs` virava `undefined` → `classifyStudent` **sempre retornava null** → `inReviewScope(null)` sempre false → **throw pra todo aluno**. Afeta `addFeedbackComment` e `addBulkFeedback`.

## Por que passou nos testes
`useTrades.test.js` mockava `classifyStudent: () => 'alpha'` ignorando os argumentos — o mock escondia o mismatch de assinatura (AP-08).

## Fix
1 linha em `useTrades.js`: passar subs como 2º arg — `classifyStudent(null, subs)`.

## Testes
- **`useTrades.reviewScope.test.js` (novo):** exercita o gate com o `classifyStudent` **real** (sem mock) — alpha/trial-alpha passam, espelho/sem-sub bloqueiam. Validado que fica **vermelho sem o fix** (3 falhas).
- **`useTrades.test.js`:** trazido pro commit (coverage da #269 que ficou untracked no working tree).
- Suite completa: **3487 passed / 223 files**. Build verde.

## Versão
`version.js` → 1.77.1 (patch). Passa por baixo da reserva 1.78.0 do #315.

## Coordenação
CHUNK-04 e CHUNK-08 co-locados com **#315** (sessão paralela). Mudança cirúrgica (1 linha no gate); combinar ordem de merge — conflito trivial no pior caso.

Closes #316