### PR TITLE
feat(#318): anotar ponto pra Revisão (Notas da Sessão) direto do trade

### DIFF
--- a/docs/dev/issues/issue-318-review-note-from-trade.md
+++ b/docs/dev/issues/issue-318-review-note-from-trade.md
@@ -1,0 +1,31 @@
+# Issue #318 — feat: anotar ponto pra Revisão (Notas da Sessão) direto do trade
+
+> Fast-track. Restore de comportamento conhecido (PinToReviewButton, removido no #269 v2). Mockup dispensado — referência é o componente antigo; autorização "faça um fast-track disso" (Marcio, 01/07/2026).
+
+## Autorização
+- [x] Exceção mockup/memória — restore de comportamento existente; sem cálculo novo
+- [x] Marcio autorizou — "faça um fast-track disso" (01/07/2026)
+- [x] Gate Pré-Código liberado
+
+## Context
+O #269 v2 Fase 6 (commit `49617c32`, v1.76.0) removeu o `PinToReviewButton`. Junto foi embora a capacidade de, a partir do trade em feedback, anexar um ponto a conversar nas Notas da Sessão (`sessionNotes`) da revisão. Marcio usa isso ao revisar trades. Este issue restaura só essa parte (append em sessionNotes) — NÃO o pin/picker/inclusão de trade (que o #269 automatizou de propósito).
+
+## Spec
+Ver issue body no GitHub: #318.
+
+## Phases
+- A1 — `useWeeklyReviews.appendSessionNote(reviewId, text)`: read-modify-write (getDoc → append `\n` → updateDoc). Não sobrescreve.
+- A2 — helper puro `utils/reviewNotePrefix.fmtTradePrefix(trade)` (restore do antigo).
+- A3 — `components/reviews/AddReviewNoteButton.jsx` (mentor-only): acha DRAFT aberto do `trade.planId`; se existe → popover append; senão → desabilitado ("após o 1º feedback"). NÃO cria revisão no cliente.
+- A4 — wire na FeedbackPage (linha de ações do mentor).
+- A5 — testes: `reviewNotePrefix` + `appendSessionNote` (append preserva prévio, no-op vazio, trim, error).
+
+## Shared Deltas
+- MAIN (commit `91d12502`, pushed): lock CHUNK-08 (#318) + reserva v1.79.0.
+- `version.js` → 1.79.0 neste branch (main fica na sua reserva vigente).
+
+## Decisions
+- DEC autônoma: client-only, sem novo CF; gated em DRAFT existente pra evitar rascunho duplicado (bug do hotfix `14cca576`). Append em sessionNotes (fiel ao `appendSessionNotes` antigo), não takeaway.
+
+## Chunks
+CHUNK-08 (Mentor Feedback) — co-lock com #315. CHUNK-04 (leitura).

--- a/src/__tests__/hooks/useWeeklyReviews.test.js
+++ b/src/__tests__/hooks/useWeeklyReviews.test.js
@@ -8,6 +8,8 @@ const mockServerTimestamp = vi.fn(() => ({ __type: 'serverTimestamp' }));
 // getDocs default: snapshot vazio (nenhuma revisão anterior para carry-over).
 // Cada teste que precisar pode sobrescrever via mockGetDocs.mockResolvedValueOnce(...).
 const mockGetDocs = vi.fn(() => Promise.resolve({ docs: [], empty: true }));
+// getDoc default: doc sem sessionNotes prévio (append parte de vazio).
+const mockGetDoc = vi.fn(() => Promise.resolve({ exists: () => true, data: () => ({}) }));
 const mockDeleteDoc = vi.fn(() => Promise.resolve());
 const mockArrayUnion = vi.fn((...items) => ({ __type: 'arrayUnion', items }));
 const mockArrayRemove = vi.fn((...items) => ({ __type: 'arrayRemove', items }));
@@ -30,6 +32,7 @@ vi.mock('firebase/firestore', () => ({
   updateDoc: (...args) => mockUpdateDoc(...args),
   deleteDoc: (...args) => mockDeleteDoc(...args),
   getDocs: (...args) => mockGetDocs(...args),
+  getDoc: (...args) => mockGetDoc(...args),
   serverTimestamp: () => mockServerTimestamp(),
   arrayUnion: (...items) => mockArrayUnion(...items),
   arrayRemove: (...items) => mockArrayRemove(...items),
@@ -53,6 +56,8 @@ describe('useWeeklyReviews', () => {
     mockOnSnapshot.mockClear();
     mockGetDocs.mockClear();
     mockGetDocs.mockImplementation(() => Promise.resolve({ docs: [], empty: true }));
+    mockGetDoc.mockClear();
+    mockGetDoc.mockImplementation(() => Promise.resolve({ exists: () => true, data: () => ({}) }));
     mockDeleteDoc.mockClear();
     mockArrayUnion.mockClear();
     mockArrayRemove.mockClear();
@@ -352,6 +357,59 @@ describe('useWeeklyReviews', () => {
           meetingLink: 'https://zoom.us/j/123',
           videoLink: '',
         })).rejects.toThrow('rules denied');
+      });
+      expect(result.current.error).toBe('rules denied');
+    });
+  });
+
+  describe('appendSessionNote (#318)', () => {
+    it('acrescenta ao conteúdo existente sem sobrescrever', async () => {
+      mockGetDoc.mockImplementationOnce(() =>
+        Promise.resolve({ exists: () => true, data: () => ({ sessionNotes: 'nota anterior' }) }));
+      const { result } = renderHook(() => useWeeklyReviews('student-1'));
+      await act(async () => {
+        await result.current.appendSessionNote('r1', '[15/06 WIN +10.00] rever stop');
+      });
+      expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
+      const [, payload] = mockUpdateDoc.mock.calls[0];
+      expect(payload.sessionNotes).toBe('nota anterior\n[15/06 WIN +10.00] rever stop');
+    });
+
+    it('parte de vazio quando não há sessionNotes prévio', async () => {
+      mockGetDoc.mockImplementationOnce(() =>
+        Promise.resolve({ exists: () => true, data: () => ({}) }));
+      const { result } = renderHook(() => useWeeklyReviews('student-1'));
+      await act(async () => {
+        await result.current.appendSessionNote('r1', 'primeiro ponto');
+      });
+      const [, payload] = mockUpdateDoc.mock.calls[0];
+      expect(payload.sessionNotes).toBe('primeiro ponto');
+    });
+
+    it('texto vazio/whitespace é no-op (não escreve)', async () => {
+      const { result } = renderHook(() => useWeeklyReviews('student-1'));
+      await act(async () => {
+        await result.current.appendSessionNote('r1', '   ');
+      });
+      expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+
+    it('faz trim do acréscimo antes de anexar', async () => {
+      mockGetDoc.mockImplementationOnce(() =>
+        Promise.resolve({ exists: () => true, data: () => ({ sessionNotes: 'A' }) }));
+      const { result } = renderHook(() => useWeeklyReviews('student-1'));
+      await act(async () => {
+        await result.current.appendSessionNote('r1', '  B  ');
+      });
+      const [, payload] = mockUpdateDoc.mock.calls[0];
+      expect(payload.sessionNotes).toBe('A\nB');
+    });
+
+    it('expõe error quando updateDoc rejeita', async () => {
+      mockUpdateDoc.mockRejectedValueOnce(new Error('rules denied'));
+      const { result } = renderHook(() => useWeeklyReviews('student-1'));
+      await act(async () => {
+        await expect(result.current.appendSessionNote('r1', 'x')).rejects.toThrow('rules denied');
       });
       expect(result.current.error).toBe('rules denied');
     });

--- a/src/__tests__/utils/reviewNotePrefix.test.js
+++ b/src/__tests__/utils/reviewNotePrefix.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { fmtTradePrefix } from '../../utils/reviewNotePrefix';
+
+describe('fmtTradePrefix (#318)', () => {
+  it('monta prefixo com data curta, símbolo e resultado positivo', () => {
+    const p = fmtTradePrefix({ date: '2026-06-15', symbol: 'WINFUT', result: 320.5 });
+    expect(p).toBe('[15/06 WINFUT +320.50] ');
+  });
+
+  it('resultado negativo mantém o sinal', () => {
+    const p = fmtTradePrefix({ date: '2026-06-15', ticker: 'PETR4', result: -80 });
+    expect(p).toBe('[15/06 PETR4 -80.00] ');
+  });
+
+  it('inclui hora quando entryTime tem timestamp', () => {
+    const p = fmtTradePrefix({ entryTime: '2026-06-15T09:31:00', symbol: 'ES', result: 12 });
+    expect(p).toBe('[15/06 09:31 ES +12.00] ');
+  });
+
+  it('deriva data de entryTime quando date ausente', () => {
+    const p = fmtTradePrefix({ entryTime: '2026-06-15T09:31:00', ticker: 'NQ', result: 4 });
+    expect(p).toBe('[15/06 09:31 NQ +4.00] ');
+  });
+
+  it('sem símbolo não deixa espaço duplo', () => {
+    const p = fmtTradePrefix({ date: '2026-06-15', result: 5 });
+    expect(p).toBe('[15/06 +5.00] ');
+  });
+
+  it('trade nulo → string vazia', () => {
+    expect(fmtTradePrefix(null)).toBe('');
+  });
+
+  it('result não-numérico vira 0 (sem sinal +, pois não é > 0)', () => {
+    const p = fmtTradePrefix({ date: '2026-06-15', symbol: 'X', result: undefined });
+    expect(p).toBe('[15/06 X 0.00] ');
+  });
+});

--- a/src/components/reviews/AddReviewNoteButton.jsx
+++ b/src/components/reviews/AddReviewNoteButton.jsx
@@ -1,0 +1,168 @@
+/**
+ * AddReviewNoteButton — anotar um ponto pra conversar na Revisão Semanal, a partir
+ * do trade que o mentor está revisando (#318).
+ *
+ * Restore enxuto do PinToReviewButton (removido no #269 v2). Diferença: NÃO recria
+ * pin/picker/inclusão de trade (isso o #269 automatizou — dar feedback ancora o
+ * trade na revisão via getOrCreateOpenReview). Aqui só ACRESCENTA (append) o texto
+ * nas Notas da Sessão (sessionNotes) da revisão DRAFT aberta daquele plano.
+ *
+ * Gate: mentor-only. Se ainda não existe DRAFT aberto (nenhum feedback dado ainda),
+ * fica desabilitado — a revisão nasce no 1º feedback. Não cria revisão pelo cliente
+ * (evita rascunho duplicado, bug do hotfix 14cca576).
+ */
+import { useEffect, useMemo, useState, useCallback } from 'react';
+import { PinIcon, X, Loader2, CheckCircle2 } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useWeeklyReviews } from '../../hooks/useWeeklyReviews';
+import { fmtTradePrefix } from '../../utils/reviewNotePrefix';
+import DebugBadge from '../DebugBadge';
+
+const AddReviewNoteButton = ({ trade }) => {
+  const { isMentor } = useAuth();
+  const mentor = typeof isMentor === 'function' ? isMentor() : Boolean(isMentor);
+
+  const studentId = trade?.studentId || null;
+  const planId = trade?.planId || null;
+  const { reviews, appendSessionNote } = useWeeklyReviews(studentId);
+
+  const [open, setOpen] = useState(false);
+  const [note, setNote] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [flash, setFlash] = useState(null);
+  const [error, setError] = useState(null);
+
+  const prefix = useMemo(() => fmtTradePrefix(trade), [trade]);
+
+  // Revisão DRAFT aberta deste plano (nasce automática no 1º feedback — #269).
+  // planId direto no doc (backlog) ou via frozenSnapshot em reviews legadas.
+  const openDraft = useMemo(() => {
+    if (!planId) return null;
+    return (reviews || []).find((r) =>
+      r.status === 'DRAFT' &&
+      (r.planId === planId || r.frozenSnapshot?.planContext?.planId === planId)
+    ) || null;
+  }, [reviews, planId]);
+
+  useEffect(() => {
+    if (open && !note) setNote(prefix);
+  }, [open, note, prefix]);
+
+  const handleSave = useCallback(async () => {
+    if (!openDraft) return;
+    const trimmed = note.trim();
+    if (!trimmed || trimmed === prefix.trim()) {
+      setError('Escreva o ponto a conversar.');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await appendSessionNote(openDraft.id, note);
+      setFlash('Adicionado às Notas da Sessão');
+      setNote('');
+      setOpen(false);
+      setTimeout(() => setFlash(null), 2500);
+    } catch {
+      setError('Não foi possível anexar. Tente novamente.');
+    } finally {
+      setBusy(false);
+    }
+  }, [openDraft, note, prefix, appendSessionNote]);
+
+  if (!mentor) return null;
+
+  // Sem DRAFT aberto → desabilitado (a revisão nasce no 1º feedback).
+  if (!openDraft) {
+    return (
+      <div className="relative inline-block">
+        <button
+          type="button"
+          disabled
+          title="Disponível após o primeiro feedback — a revisão da semana nasce aí."
+          className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg border border-white/10 text-slate-500 cursor-not-allowed"
+        >
+          <PinIcon className="w-3.5 h-3.5" />
+          Anotar ponto pra revisão
+        </button>
+        <DebugBadge component="AddReviewNoteButton" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Anotar um ponto para conversar na Revisão Semanal"
+        className="inline-flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-lg border border-emerald-500/30 text-emerald-300 hover:bg-emerald-500/10 transition-colors"
+      >
+        <PinIcon className="w-3.5 h-3.5" />
+        Anotar ponto pra revisão
+      </button>
+
+      {flash && (
+        <span className="ml-2 inline-flex items-center gap-1 text-xs text-emerald-400">
+          <CheckCircle2 className="w-3.5 h-3.5" /> {flash}
+        </span>
+      )}
+
+      {open && (
+        <div className="absolute z-50 mt-2 w-80 rounded-xl border border-white/10 bg-slate-900/95 backdrop-blur p-3 shadow-xl">
+          <div className="flex items-center justify-between mb-2">
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-300">
+              <PinIcon className="w-3 h-3" /> Ponto pra revisão
+            </span>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); setNote(''); setError(null); }}
+              disabled={busy}
+              className="text-slate-500 hover:text-slate-300"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          <label className="text-[10px] text-slate-500 block mb-1">
+            Acrescentado nas Notas da Sessão da revisão aberta:
+          </label>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={3}
+            autoFocus
+            placeholder={`${prefix}O que precisa conversar...`}
+            className="w-full text-sm rounded-lg bg-slate-800/60 border border-white/10 px-2.5 py-2 text-slate-200 placeholder:text-slate-600 focus:outline-none focus:border-emerald-500/40 resize-none"
+          />
+
+          {error && <div className="text-[11px] text-red-400 mt-1">{error}</div>}
+
+          <div className="flex items-center justify-end gap-2 mt-2">
+            <button
+              type="button"
+              onClick={() => { setOpen(false); setNote(''); setError(null); }}
+              disabled={busy}
+              className="text-xs px-2.5 py-1.5 rounded-lg text-slate-400 hover:text-slate-200"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={busy}
+              className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white disabled:opacity-50"
+            >
+              {busy && <Loader2 className="w-3 h-3 animate-spin" />}
+              Anotar
+            </button>
+          </div>
+        </div>
+      )}
+
+      <DebugBadge component="AddReviewNoteButton" />
+    </div>
+  );
+};
+
+export default AddReviewNoteButton;

--- a/src/hooks/useWeeklyReviews.js
+++ b/src/hooks/useWeeklyReviews.js
@@ -11,7 +11,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
-  collection, query, where, orderBy, onSnapshot, getDocs,
+  collection, query, where, orderBy, onSnapshot, getDocs, getDoc,
   doc, updateDoc, serverTimestamp, arrayUnion, arrayRemove,
 } from 'firebase/firestore';
 import { getFunctions, httpsCallable } from 'firebase/functions';
@@ -272,6 +272,30 @@ export const useWeeklyReviews = (studentId) => {
     }
   }, [studentId]);
 
+  // Acrescenta (append) um ponto às Notas da Sessão sem sobrescrever o conteúdo
+  // existente — restore do fluxo do PinToReviewButton (#318). Read-modify-write
+  // via getDoc pra preservar notas anteriores (mentor único, baixa concorrência).
+  const appendSessionNote = useCallback(async (reviewId, text) => {
+    const addition = typeof text === 'string' ? text.trim() : '';
+    if (!addition) return;
+    setActionLoading(true);
+    setError(null);
+    try {
+      const ref = doc(db, 'students', studentId, 'reviews', reviewId);
+      const snap = await getDoc(ref);
+      const current = snap.exists() && typeof snap.data().sessionNotes === 'string'
+        ? snap.data().sessionNotes
+        : '';
+      const next = current ? `${current}\n${addition}` : addition;
+      await updateDoc(ref, { sessionNotes: next });
+    } catch (err) {
+      setError(err.message || 'Erro ao anexar nota da sessão');
+      throw err;
+    } finally {
+      setActionLoading(false);
+    }
+  }, [studentId]);
+
   // ===== Takeaways checklist (Stage 4) =====
   // Schema: review.takeawayItems: [{id, text, done, createdAt, sourceTradeId?}]
   // Adição via arrayUnion (race-safe). Toggle/remove via read-modify-write.
@@ -363,6 +387,7 @@ export const useWeeklyReviews = (studentId) => {
     closeReview,
     archiveReview,
     updateSessionNotes,
+    appendSessionNote,
     saveDraftFields,
     updateMeetingLinks,
     addTakeawayItem,

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -41,6 +41,7 @@ import TradeLockBadge from '../components/TradeLockBadge';
 import BehaviorPanel from '../components/Trades/BehaviorPanel';
 import TradeOrdersPanel from '../components/OrderImport/TradeOrdersPanel';
 import PlanSummaryCard from '../components/PlanSummaryCard';
+import AddReviewNoteButton from '../components/reviews/AddReviewNoteButton';
 import MentorEditPanel from '../components/feedback/MentorEditPanel';
 import MentorClassificationPanel from '../components/feedback/MentorClassificationPanel';
 import { useShadowAnalysis } from '../hooks/useShadowAnalysis';
@@ -645,6 +646,7 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                   {shadowLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Activity className="w-3 h-3" />}
                   {shadowLoading ? 'Recalculando...' : 'Recalcular Comportamento'}
                 </button>
+                <AddReviewNoteButton trade={trade} />
                 {shadowMessage && (
                   <div className={`w-full text-xs px-2 py-1 rounded ${shadowMessage.type === 'success' ? 'bg-emerald-500/10 text-emerald-300' : 'bg-red-500/10 text-red-300'}`}>
                     {shadowMessage.text}

--- a/src/utils/reviewNotePrefix.js
+++ b/src/utils/reviewNotePrefix.js
@@ -1,0 +1,19 @@
+/**
+ * reviewNotePrefix — prefixo identificador do trade para uma nota da Revisão (#318).
+ *
+ * Restore do `fmtTradePrefix` do antigo PinToReviewButton (removido no #269 v2).
+ * Formato: `[DD/MM HH:MM SÍMBOLO ±RESULT] ` — âncora legível do trade dentro do
+ * texto livre de sessionNotes (Notas da Sessão).
+ */
+export const fmtTradePrefix = (trade) => {
+  if (!trade) return '';
+  const date = trade.date || (trade.entryTime ? String(trade.entryTime).slice(0, 10) : '');
+  const [y, m, d] = String(date || '').split('-');
+  const shortDate = y && m && d ? `${d}/${m}` : (date || '?');
+  const time = trade.entryTime ? String(trade.entryTime).slice(11, 16) : '';
+  const symbol = trade.symbol || trade.ticker || '';
+  const result = Number(trade.result) || 0;
+  const resultStr = result > 0 ? `+${result.toFixed(2)}` : result.toFixed(2);
+  const parts = [shortDate + (time ? ` ${time}` : ''), symbol, resultStr].filter(Boolean);
+  return `[${parts.join(' ')}] `;
+};

--- a/src/version.js
+++ b/src/version.js
@@ -4,6 +4,7 @@
  *
  * CHANGELOG:
  * - 1.78.0: #315 feat (RESERVA) evidência técnica mentor-only + imagens HTF/LTF opcionais no registro + reflexão do aluno na composição de feedback
+ * - 1.79.0: #318 feat anotar ponto pra Revisão (append em sessionNotes) direto do trade em feedback — restore do PinToReviewButton removido no #269 (01/07/2026)
  * - 1.77.1: #316 fix mentor não consegue dar feedback — classifyStudent com args trocados (PR #317, 01/07/2026)
  * - 1.77.0: #313 feat Reflexão na entrada do trade + copy de auto-análise (PR #314, 25/06/2026)
  * - 1.76.0: #269 feat Revisão por backlog (FK reviewId) + SWOT customizável + filtro matriz Alpha/Tr (PR #312, 24/06/2026)
@@ -374,10 +375,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.77.1',
+  version: '1.79.0',
   build: '20260701',
-  display: 'v1.77.1',
-  full: '1.77.1+20260701',
+  display: 'v1.79.0',
+  full: '1.79.0+20260701',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Problema
O #269 v2 Fase 6 (commit `49617c32`, v1.76.0) removeu o `PinToReviewButton`. Junto foi embora a capacidade de, ao revisar um trade, anexar um ponto a conversar nas **Notas da Sessão** (`sessionNotes`) da revisão. É fluxo que o mentor usa: ir jogando os assuntos a tratar enquanto dá feedback.

## Solução (restore enxuto)
Botão mentor-only na FeedbackPage: escreve um 'ponto pra revisão' que é **acrescentado (append)** nas Notas da Sessão da revisão DRAFT aberta daquele plano, com prefixo identificando o trade.

**NÃO** reintroduz pin/picker/inclusão de trade — isso o #269 automatizou de propósito (dar feedback já ancora o trade na revisão via `getOrCreateOpenReview`).

## Mudanças
- `useWeeklyReviews.appendSessionNote(reviewId, text)` — read-modify-write (`getDoc` → append `\n` → `updateDoc`); **não** sobrescreve o blob (≠ `updateSessionNotes`).
- `utils/reviewNotePrefix.fmtTradePrefix` — âncora `[DD/MM HH:MM SÍMBOLO ±RESULT]` (restore do helper antigo).
- `components/reviews/AddReviewNoteButton` (mentor-only) — acha o DRAFT aberto de `trade.planId`; se não existe ainda, **desabilitado** ("disponível após o 1º feedback — a revisão nasce aí"). **Não cria revisão no cliente** → evita rascunho duplicado (bug do hotfix `14cca576`).
- Wire na FeedbackPage (linha de ações do mentor).

## Segurança / escopo
- Sem collection/campo novo (`sessionNotes` já existe) → INV-15 não dispara.
- Sem mudança de rules (mentor já edita DRAFT via cliente).
- Sem novo CF / sem deploy.

## Testes
- `reviewNotePrefix` (7) + `appendSessionNote` (5: append preserva prévio, no-op vazio, trim, error).
- Suite completa: **3499 passed / 224 files**. Build verde.

## Coordenação
CHUNK-08 co-locado com **#315** (sessão paralela). Coordenar ordem de merge.

Closes #318