### PR TITLE
fix(#320): botão 'Anotar ponto pra revisão' faltava no layout full-page da FeedbackPage

### DIFF
--- a/docs/dev/issues/issue-320-review-note-fullpage-layout.md
+++ b/docs/dev/issues/issue-320-review-note-fullpage-layout.md
@@ -1,0 +1,25 @@
+# Issue #320 — fix: botão 'Anotar ponto pra revisão' faltando no layout full-page
+
+> Fast-track. Regressão de layout do #318. Sem mockup/memória (placement fix).
+
+## Autorização
+- [x] Bugfix de placement — Marcio reportou "não vejo nada no feedback dela" (01/07/2026)
+- [x] Gate Pré-Código liberado
+
+## Context
+O #318 adicionou `AddReviewNoteButton` só no branch `embedded` da FeedbackPage. O layout full-page (standalone, `return` ~805) tem seu próprio bloco `{userIsMentor && (...)}` no header, que ficou sem o botão. O `PinToReviewButton` original aparecia nos dois layouts. Mentor no full-page não via nada.
+
+## Spec
+Ver issue body no GitHub: #320.
+
+## Phases
+- A1 — `<AddReviewNoteButton trade={trade} />` no bloco de mentor do layout full-page (após 'Recalcular Comportamento'). Import já existe (do #318).
+
+## Shared Deltas
+- MAIN (commit `4f9dcc86`, pushed): lock CHUNK-08 (#320) + reserva v1.79.1.
+
+## Decisions
+- Sem teste dedicado de FeedbackPage (componente pesado; a lógica do AddReviewNoteButton já é testada no #318). Placement validado por build.
+
+## Chunks
+CHUNK-08 — co-lock com #315.

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -828,6 +828,7 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                   {shadowLoading ? <Loader2 className="w-3 h-3 animate-spin" /> : <Activity className="w-3 h-3" />}
                   {shadowLoading ? 'Recalculando...' : 'Recalcular Comportamento'}
                 </button>
+                <AddReviewNoteButton trade={trade} />
               </>
             )}
             <StatusBadge status={status} />

--- a/src/version.js
+++ b/src/version.js
@@ -4,6 +4,7 @@
  *
  * CHANGELOG:
  * - 1.78.0: #315 feat (RESERVA) evidência técnica mentor-only + imagens HTF/LTF opcionais no registro + reflexão do aluno na composição de feedback
+ * - 1.79.1: #320 fix botão 'Anotar ponto pra revisão' faltava no layout full-page da FeedbackPage (regressão #318) (01/07/2026)
  * - 1.79.0: #318 feat anotar ponto pra Revisão (Notas da Sessão) direto do trade (PR #319, 01/07/2026)
  * - 1.77.1: #316 fix mentor não consegue dar feedback — classifyStudent com args trocados (PR #317, 01/07/2026)
  * - 1.77.0: #313 feat Reflexão na entrada do trade + copy de auto-análise (PR #314, 25/06/2026)
@@ -375,10 +376,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.79.0',
+  version: '1.79.1',
   build: '20260701',
-  display: 'v1.79.0',
-  full: '1.79.0+20260701',
+  display: 'v1.79.1',
+  full: '1.79.1+20260701',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Problema
Após #318 (v1.79.0), o botão 'Anotar ponto pra revisão' não aparecia na tela de feedback full-page (standalone) — mentor 'não via nada', mesmo com revisão DRAFT aberta.

## Causa
A FeedbackPage tem dois layouts: `embedded` (master-detail) e full-page (standalone). O #318 adicionou `AddReviewNoteButton` **só no branch embedded**. O full-page tem bloco de mentor próprio no header (ao lado de 'Recalcular Comportamento') que ficou sem o botão. O `PinToReviewButton` original aparecia nos **dois**.

## Fix
`<AddReviewNoteButton trade={trade} />` no bloco de mentor do layout full-page. Import já existia (do #318). Agora 2 usos (paridade).

## Testes
Placement puro (lógica do componente já testada no #318). Suite completa: **3499 passed / 224 files**. Build verde.

## Coordenação
CHUNK-08 co-locado com **#315**. Regressão de #318.

Closes #320