### PR TITLE
feat(#315): evidência mentor-only + imagens HTF/LTF opcionais + reflexão do aluno no feedback

### DIFF
--- a/src/__tests__/components/Trades/BehaviorPanel.test.jsx
+++ b/src/__tests__/components/Trades/BehaviorPanel.test.jsx
@@ -165,6 +165,49 @@ describe('BehaviorPanel', () => {
     expect(screen.getByText(/tradeDurationMinutes:/)).toBeInTheDocument();
   });
 
+  it('#315: aluno (isMentor=false) expande mas NÃO vê "Evidência técnica" — só a narrativa', () => {
+    const t = {
+      id: 'T3b', currency: 'USD',
+      behaviorProfile: {
+        version: '1.0.0', gateInputs: [], scoreContribution: { tilt: false, revenge: false },
+        families: [{
+          family: 'HOLD_ASYMMETRY', canonicalCode: 'HOLD_ASYMMETRY', severity: 'HIGH', source: 'shadow',
+          resolutionLayer: 'LOW', emotionMapping: 'FEAR', valence: 'negative', isGate: false, confidence: 0.95,
+          evidence: { tradeDurationMinutes: 60, avgWinDurationMinutes: 5, ratio: 12 },
+        }],
+      },
+    };
+    render(<BehaviorPanel trade={t} isMentor={false} embedded />);
+    fireEvent.click(screen.getByText(/Você segurou este trade por 60 min/));
+    expect(screen.queryByText('Evidência técnica')).not.toBeInTheDocument();
+    expect(screen.queryByText(/tradeDurationMinutes:/)).not.toBeInTheDocument();
+    // narrativa permanece
+    expect(screen.getByText(/Você segurou este trade por 60 min/)).toBeInTheDocument();
+  });
+
+  it('#315: aluno (isMentor=false) no SUB_SIZING não vê o accordion cru, mas vê o texto educacional', () => {
+    const t = {
+      id: 'T3c', currency: 'BRL',
+      behaviorProfile: {
+        version: '1.0.0', gateInputs: [], scoreContribution: { tilt: false, revenge: false },
+        families: [{
+          family: 'SUB_SIZING', canonicalCode: 'SUB_SIZING', severity: 'HIGH', source: 'shadow',
+          resolutionLayer: 'LOW', emotionMapping: 'AVOIDANCE', valence: 'negative', isGate: true, confidence: 0.9,
+          evidence: {
+            scenario: 'WIN_RR_MISS', planRrTarget: 2, utilizationPct: 26, planRoAmount: 200,
+            actualRiskAmount: 52, expectedGainAtPlanRR: 400, actualGain: 6, planRsDelivered: 0.03,
+          },
+        }],
+      },
+    };
+    render(<BehaviorPanel trade={t} isMentor={false} embedded />);
+    fireEvent.click(screen.getByText('⚠ Operação subdimensionada')); // título do card (desambigua da frase-chave)
+    expect(screen.queryByText('Evidência técnica')).not.toBeInTheDocument();
+    expect(screen.queryByText(/utilizationPct:/)).not.toBeInTheDocument();
+    // texto educacional (prosa) permanece
+    expect(screen.getByText(/abaixo do alvo do próprio trade/)).toBeInTheDocument();
+  });
+
   it('cai na descrição (prosa) quando faltam campos da narrativa — nunca dump cru', () => {
     const t = {
       id: 'T4', currency: 'USD',

--- a/src/__tests__/components/reviews/ReviewTradesSection.test.jsx
+++ b/src/__tests__/components/reviews/ReviewTradesSection.test.jsx
@@ -24,6 +24,22 @@ describe('<ReviewTradesSection />', () => {
     expect(screen.getByText(/Sem trades no período/i)).toBeInTheDocument();
   });
 
+  it('#315 C — showSelfReview + selfReview: mostra o botão da reflexão e expande', () => {
+    const trades = [makeTrade({ selfReview: { wouldRepeat: true, answers: {} } })];
+    render(<ReviewTradesSection trades={trades} showSelfReview />);
+    const btn = screen.getByTitle('Ver a reflexão do aluno');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(screen.getByText('Reflexão')).toBeInTheDocument();
+    expect(screen.getByText(/Faria de novo: Sim/)).toBeInTheDocument();
+  });
+
+  it('#315 C — sem showSelfReview, não mostra o botão da reflexão mesmo com selfReview', () => {
+    const trades = [makeTrade({ selfReview: { wouldRepeat: true, answers: {} } })];
+    render(<ReviewTradesSection trades={trades} />);
+    expect(screen.queryByTitle('Ver a reflexão do aluno')).not.toBeInTheDocument();
+  });
+
   it('renderiza trades flat quando ≤2 por dia', () => {
     const trades = [
       makeTrade({ tradeId: 't1', pnl: 10 }),

--- a/src/components/AddTradeModal.jsx
+++ b/src/components/AddTradeModal.jsx
@@ -736,11 +736,8 @@ const AddTradeModal = ({
         ? 'Corrija os valores de horário das parciais' 
         : 'Preencha data e horário de todas as parciais';
     }
-    
-    if (!editTrade) {
-      if (!htfFile && !htfPreview) newErrors.htf = 'Imagem HTF é obrigatória';
-      if (!ltfFile && !ltfPreview) newErrors.ltf = 'Imagem LTF é obrigatória';
-    }
+
+    // #315 B — imagens HTF/LTF são opcionais no registro (antes obrigatórias na criação).
     setErrors(newErrors);
     if (Object.keys(newErrors).length > 0) console.warn('[MODAL] Erros de validação:', newErrors);
     return Object.keys(newErrors).length === 0;
@@ -1187,7 +1184,7 @@ const AddTradeModal = ({
             <div className="grid grid-cols-2 gap-4">
                {['htf', 'ltf'].map(type => (
                  <div key={type} onPaste={(e) => handlePasteImage(e, type)} tabIndex={0} className="outline-none focus:ring-1 focus:ring-blue-500/30 rounded-lg">
-                   <label className="input-label mb-2 uppercase flex items-center gap-1">{type} Image <span className="text-red-400">*</span></label>
+                   <label className="input-label mb-2 uppercase flex items-center gap-1">{type} Image <span className="text-slate-600 normal-case text-[10px]">(opcional)</span></label>
                    {(type === 'htf' ? htfPreview : ltfPreview) ? (
                      <div className="relative group h-24 rounded-lg overflow-hidden border border-slate-700"><img src={type === 'htf' ? htfPreview : ltfPreview} className="w-full h-full object-cover" /><button type="button" onClick={() => removeImage(type)} className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 flex items-center justify-center text-white"><X/></button></div>
                    ) : (

--- a/src/components/Trades/BehaviorPanel.jsx
+++ b/src/components/Trades/BehaviorPanel.jsx
@@ -4,8 +4,9 @@
  * Substitui ShadowBehaviorPanel + ExecutionPatternsPanel + redFlags inline.
  *
  * Hierarquia: ① Adesão ao plano (fato) → ② Padrões comportamentais (opinião/motor) →
- * ③ Trava de gate → camada do mentor (slot). Aluno vê os dados; só os controles de
- * limpar violação / editar são gated por isMentor (decisão Marcio: aluno vê tudo).
+ * ③ Trava de gate → camada do mentor (slot). Aluno vê a narrativa humanizada; os
+ * controles de limpar violação / editar E o accordion "Evidência técnica" cru são
+ * mentor-only (isMentor) — #315: o dump de campos do schema não tem leitura pro aluno.
  */
 import React, { useState } from 'react';
 import { AlertTriangle, Lock } from 'lucide-react';
@@ -64,12 +65,13 @@ const FamilyCard = ({ family, currency, trade, isMentor = false, onToggleViolati
       </div>
 
       {isUndersized ? (
-        <UndersizedBody evidence={family.evidence || {}} currency={currency} expanded={expanded} />
+        <UndersizedBody evidence={family.evidence || {}} currency={currency} expanded={expanded} isMentor={isMentor} />
       ) : (
         <>
           {/* Narrativa semântica (não despeja campos técnicos) — o aluno lê o que aconteceu. */}
           <p className="text-xs text-zinc-300 mt-1 leading-relaxed">{narrativeFor({ ...family, currency })}</p>
-          {expanded && family.evidence && Object.keys(family.evidence).length > 0 && (
+          {/* Evidência técnica crua é mentor-only (#315): campos do schema do motor não têm leitura pro aluno. */}
+          {isMentor && expanded && family.evidence && Object.keys(family.evidence).length > 0 && (
             <div className="mt-3 pt-2 border-t border-white/10">
               <p className="text-[10px] uppercase tracking-wider text-zinc-500 mb-1">Evidência técnica</p>
               <div className="grid grid-cols-2 gap-1">

--- a/src/components/Trades/behaviorDisplay.jsx
+++ b/src/components/Trades/behaviorDisplay.jsx
@@ -220,8 +220,9 @@ export const UndersizedEducational = ({ scenario, evidence, currency }) => {
   );
 };
 
-/** Corpo do card de SUB_SIZING (evidência rica). Recebe `evidence` direto da família. */
-export const UndersizedBody = ({ evidence = {}, currency, expanded }) => {
+/** Corpo do card de SUB_SIZING (evidência rica). Recebe `evidence` direto da família.
+ *  O accordion "Evidência técnica" cru é mentor-only (#315) — aluno fica com o texto educacional. */
+export const UndersizedBody = ({ evidence = {}, currency, expanded, isMentor = false }) => {
   const { scenario, planRrTarget, utilizationPct } = evidence;
   const hasAmounts = evidence.planRoAmount != null;
   const keySentence = UNDERSIZED_KEY_SENTENCE(scenario, planRrTarget);
@@ -233,7 +234,7 @@ export const UndersizedBody = ({ evidence = {}, currency, expanded }) => {
         <p className="text-sm font-medium text-zinc-100 mt-2">Você utilizou {utilizationPct}% do RO contratado. {keySentence}</p>
       )}
       {hasAmounts && <UndersizedEducational scenario={scenario} evidence={evidence} currency={currency} />}
-      {expanded && (
+      {isMentor && expanded && (
         <div className="mt-3 pt-2 border-t border-white/10">
           <p className="text-[10px] uppercase tracking-wider text-zinc-500 mb-1">Evidência técnica</p>
           <div className="grid grid-cols-2 gap-1">

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -31,7 +31,7 @@ import {
   ChevronLeft, Send, HelpCircle, Lock, User, GraduationCap,
   Calendar, TrendingUp, TrendingDown, Clock, AlertCircle, AlertTriangle,
   BarChart3, Brain, Maximize2, X, CheckCircle, MessageSquare, Loader2,
-  Layers, ArrowDownRight, ArrowUpRight, ImageIcon, Activity
+  Layers, ArrowDownRight, ArrowUpRight, ImageIcon, Activity, ClipboardCheck
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import DebugBadge from '../components/DebugBadge';
@@ -39,6 +39,7 @@ import TradeStatusBadges from '../components/TradeStatusBadges';
 import ExcursionDisplay from '../components/ExcursionDisplay';
 import TradeLockBadge from '../components/TradeLockBadge';
 import BehaviorPanel from '../components/Trades/BehaviorPanel';
+import TradeReviewSection from '../components/Trades/TradeReviewSection';
 import TradeOrdersPanel from '../components/OrderImport/TradeOrdersPanel';
 import PlanSummaryCard from '../components/PlanSummaryCard';
 import AddReviewNoteButton from '../components/reviews/AddReviewNoteButton';
@@ -673,6 +674,16 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                 <MentorClassificationPanel trade={trade} readOnly />
               )}
             />
+            {/* #315 C — reflexão do aluno (selfReview) read-only ao compor feedback.
+                O mentor cruza o julgamento do aluno ("faria de novo?") com o comportamento detectado. */}
+            {trade.selfReview ? (
+              <TradeReviewSection trade={trade} />
+            ) : (
+              <div className="mt-4 border border-white/10 rounded-xl p-4 bg-white/5 flex items-center gap-2">
+                <ClipboardCheck className="w-4 h-4 text-slate-500" />
+                <span className="text-sm text-slate-400">O aluno ainda não fez a auto-análise deste trade.</span>
+              </div>
+            )}
           </div>
 
           {/* Coluna Direita - Chat */}

--- a/src/pages/StudentReviewsPage.jsx
+++ b/src/pages/StudentReviewsPage.jsx
@@ -152,6 +152,7 @@ const ReviewDetail = ({
           currency={currency}
           weekStart={review.weekStart}
           weekEnd={review.weekEnd}
+          showSelfReview
           onNavigateToFeedback={onNavigateToFeedback}
         />
       </section>


### PR DESCRIPTION
Closes #315

Três ajustes no fluxo de trade/feedback (consolidados numa issue só).

## A — Evidência técnica do BehaviorPanel: mentor-only (CHUNK-11)
O accordion "Evidência técnica" despejava campos crus do schema do motor. Passa a ser visível só pro mentor (`isMentor`); o aluno fica com a narrativa humanizada + texto educacional do undersized.
- `BehaviorPanel.jsx` + `UndersizedBody` (`behaviorDisplay.jsx`): gate `isMentor`.

## B — Imagens HTF/LTF opcionais no registro de trade (CHUNK-04)
`AddTradeModal` exigia HTF **e** LTF na criação. Ambas passam a ser opcionais.
- Removida a validação `newErrors.htf/ltf` + asterisco dos labels. Edição inalterada.

## C — Reflexão do aluno visível na composição de feedback (CHUNK-08)
A reflexão (`trade.selfReview`) não aparecia na `FeedbackPage` nem na `StudentReviewsPage`. O mentor compunha feedback sem ver o julgamento do aluno.
- `FeedbackPage`: renderiza `<TradeReviewSection trade={trade} />` read-only perto do `BehaviorPanel`.
- `StudentReviewsPage`: passa `showSelfReview` ao `ReviewTradesSection` (paridade com `WeeklyReviewPage`).
- Estado explícito "o aluno ainda não fez a auto-análise deste trade" quando não há `selfReview`.

## Testes (INV-05)
- `BehaviorPanel.test.jsx` (21) + `ReviewTradesSection.test.jsx` (11) — 32 passando. Build verde.

## Notas
- Versão (bump v1.80.0) + CHANGELOG + liberação de locks ficam pro encerramento (`cc-close-issue.sh`). A reserva original de v1.78.0 ficou obsoleta — main avançou pra 1.79.1 (#318/#320) enquanto a issue estava aberta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)