### PR TITLE
fix(#323): reflexão do aluno no feedback — full-page + aviso ao mentor quando ausente

### DIFF
--- a/docs/dev/issues/issue-323-reflection-feedback-fullpage-warn.md
+++ b/docs/dev/issues/issue-323-reflection-feedback-fullpage-warn.md
@@ -1,0 +1,24 @@
+# Issue #323 — fix: reflexão do aluno no feedback (full-page + aviso ao mentor)
+
+> Fast-track. Regressão/gap do #315. Sem mockup (comportamento conhecido + aviso simples).
+
+## Autorização
+- [x] Bugfix + aviso — Marcio: "se o aluno não tiver feito a reflexão quero ser avisado... é grave, forçar o hábito" (01/07/2026)
+- [x] Gate Pré-Código liberado
+
+## Context
+O #315 pôs a reflexão do aluno no feedback só no branch `embedded` (bug de layout, igual #320) e, quando ausente, só um texto cinza passivo. Marcio quer: nos dois layouts + **aviso âmbar** pro mentor cobrar a reflexão quando o aluno não fez (hábito é parte do processo).
+
+## Spec
+Ver issue body no GitHub: #323.
+
+## Phases
+- A1 — `components/reviews/StudentReflectionPanel` (DRY): selfReview → `TradeReviewSection` read-only; ausente + mentor → alerta âmbar; ausente + não-mentor → null.
+- A2 — usar nos dois layouts da FeedbackPage (embedded + full-page); remover inline do #315; limpar imports órfãos (TradeReviewSection, ClipboardCheck).
+- A3 — teste do componente (3 ramos).
+
+## Shared Deltas
+- MAIN (commit `0b65e32e`, pushed): lock CHUNK-08 (#323) + reserva v1.80.1.
+
+## Chunks
+CHUNK-08 (Mentor Feedback). Regressão de #315.

--- a/src/__tests__/components/reviews/StudentReflectionPanel.test.jsx
+++ b/src/__tests__/components/reviews/StudentReflectionPanel.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StudentReflectionPanel from '../../../components/reviews/StudentReflectionPanel';
+
+describe('StudentReflectionPanel (#323)', () => {
+  it('reflexão feita → mostra a auto-análise (read-only)', () => {
+    const trade = { result: 100, selfReview: { wouldRepeat: true, answers: {} } };
+    render(<StudentReflectionPanel trade={trade} isMentor />);
+    expect(screen.getByText('Reflexão')).toBeInTheDocument();
+    // não mostra o aviso de ausência
+    expect(screen.queryByText(/não fez a auto-análise/i)).not.toBeInTheDocument();
+  });
+
+  it('sem reflexão + mentor → aviso âmbar pra cobrar', () => {
+    render(<StudentReflectionPanel trade={{ result: -50 }} isMentor />);
+    expect(screen.getByText(/não fez a auto-análise/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cobre a reflexão no feedback/i)).toBeInTheDocument();
+  });
+
+  it('sem reflexão + NÃO mentor → não renderiza nada', () => {
+    const { container } = render(<StudentReflectionPanel trade={{ result: 10 }} isMentor={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('sem reflexão + mentor default (prop ausente) → não renderiza aviso', () => {
+    const { container } = render(<StudentReflectionPanel trade={{ result: 10 }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/reviews/StudentReflectionPanel.jsx
+++ b/src/components/reviews/StudentReflectionPanel.jsx
@@ -1,0 +1,30 @@
+/**
+ * StudentReflectionPanel — reflexão (auto-análise) do aluno na composição de feedback (#323).
+ *
+ * Completa o #315 C: aparece nos DOIS layouts da FeedbackPage.
+ *  - Reflexão feita  → TradeReviewSection read-only (mentor cruza "faria de novo?" × comportamento).
+ *  - Reflexão ausente + mentor → alerta âmbar pra COBRAR o hábito no feedback (Marcio: reflexão
+ *    é parte do processo; mentor tem que ser avisado quando falta).
+ *  - Reflexão ausente + não-mentor → nada (o prompt de reflexão do aluno vive no registro do trade).
+ */
+import { AlertTriangle } from 'lucide-react';
+import TradeReviewSection from '../Trades/TradeReviewSection';
+import DebugBadge from '../DebugBadge';
+
+const StudentReflectionPanel = ({ trade, isMentor = false }) => {
+  if (trade?.selfReview) return <TradeReviewSection trade={trade} />;
+  if (!isMentor) return null;
+
+  return (
+    <div className="relative mt-4 border border-amber-500/30 rounded-xl p-4 bg-amber-500/10 flex items-start gap-2">
+      <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
+      <div className="text-sm text-amber-200">
+        <span className="font-medium">O aluno não fez a auto-análise deste trade.</span>{' '}
+        Cobre a reflexão no feedback — rever cada operação é parte do processo.
+      </div>
+      <DebugBadge component="StudentReflectionPanel" />
+    </div>
+  );
+};
+
+export default StudentReflectionPanel;

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -31,7 +31,7 @@ import {
   ChevronLeft, Send, HelpCircle, Lock, User, GraduationCap,
   Calendar, TrendingUp, TrendingDown, Clock, AlertCircle, AlertTriangle,
   BarChart3, Brain, Maximize2, X, CheckCircle, MessageSquare, Loader2,
-  Layers, ArrowDownRight, ArrowUpRight, ImageIcon, Activity, ClipboardCheck
+  Layers, ArrowDownRight, ArrowUpRight, ImageIcon, Activity
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import DebugBadge from '../components/DebugBadge';
@@ -39,7 +39,7 @@ import TradeStatusBadges from '../components/TradeStatusBadges';
 import ExcursionDisplay from '../components/ExcursionDisplay';
 import TradeLockBadge from '../components/TradeLockBadge';
 import BehaviorPanel from '../components/Trades/BehaviorPanel';
-import TradeReviewSection from '../components/Trades/TradeReviewSection';
+import StudentReflectionPanel from '../components/reviews/StudentReflectionPanel';
 import TradeOrdersPanel from '../components/OrderImport/TradeOrdersPanel';
 import PlanSummaryCard from '../components/PlanSummaryCard';
 import AddReviewNoteButton from '../components/reviews/AddReviewNoteButton';
@@ -674,16 +674,9 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
                 <MentorClassificationPanel trade={trade} readOnly />
               )}
             />
-            {/* #315 C — reflexão do aluno (selfReview) read-only ao compor feedback.
-                O mentor cruza o julgamento do aluno ("faria de novo?") com o comportamento detectado. */}
-            {trade.selfReview ? (
-              <TradeReviewSection trade={trade} />
-            ) : (
-              <div className="mt-4 border border-white/10 rounded-xl p-4 bg-white/5 flex items-center gap-2">
-                <ClipboardCheck className="w-4 h-4 text-slate-500" />
-                <span className="text-sm text-slate-400">O aluno ainda não fez a auto-análise deste trade.</span>
-              </div>
-            )}
+            {/* #315 C / #323 — reflexão do aluno (selfReview) ao compor feedback: read-only se feita,
+                aviso pro mentor cobrar se ausente. DRY nos dois layouts via StudentReflectionPanel. */}
+            <StudentReflectionPanel trade={trade} isMentor={userIsMentor} />
           </div>
 
           {/* Coluna Direita - Chat */}
@@ -880,6 +873,8 @@ const FeedbackPage = ({ trade, onBack, onAddComment, onUpdateStatus, loading = f
               <MentorClassificationPanel trade={trade} readOnly />
             )}
           />
+          {/* #323 — reflexão do aluno (ou aviso ao mentor) também no full-page. */}
+          <StudentReflectionPanel trade={trade} isMentor={userIsMentor} />
         </div>
 
         {/* Coluna Direita - Chat */}

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.80.1: #323 fix reflexão do aluno no feedback também no full-page + aviso âmbar ao mentor quando ausente (regressão #315) (01/07/2026)
  * - 1.80.0: #315 feat evidência mentor-only + imagens HTF/LTF opcionais + reflexão do aluno no feedb (PR #322, 01/07/2026)
  * - 1.78.0: #315 feat (RESERVA) evidência técnica mentor-only + imagens HTF/LTF opcionais no registro + reflexão do aluno na composição de feedback
  * - 1.79.1: #320 fix botão 'Anotar ponto pra revisão' faltava no layout full-page da FeedbackPage (PR #321, 01/07/2026)
@@ -377,10 +378,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.80.0',
+  version: '1.80.1',
   build: '20260701',
-  display: 'v1.80.0',
-  full: '1.80.0+20260701',
+  display: 'v1.80.1',
+  full: '1.80.1+20260701',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
## Problema
1. A reflexão do aluno (selfReview) só aparecia no layout **embedded** da FeedbackPage (bug de layout, igual #320) — mentor no full-page não via.
2. Quando o aluno **não** fez a reflexão, só havia um texto cinza passivo. Marcio precisa ser **avisado** pra cobrar o hábito (reflexão é parte do processo).

## Fix
Componente `StudentReflectionPanel` (DRY), usado nos **dois** layouts:
- Reflexão feita → `TradeReviewSection` read-only.
- Ausente + mentor → **alerta âmbar** ('aluno não fez a auto-análise — cobre no feedback').
- Ausente + não-mentor → nada.

Remove o inline do #315 + imports órfãos (`TradeReviewSection`, `ClipboardCheck`).

## Testes
Componente (3 ramos: feita / ausente+mentor / ausente+não-mentor). Suite: **3507 passed / 225 files**. Build verde.

Regressão de #315.

Closes #323