### PR TITLE
feat(#327): fila 'trades a refletir' — cobra reflexão de fechados sem selfReview

### DIFF
--- a/docs/dev/issues/issue-327-pending-reflections-queue.md
+++ b/docs/dev/issues/issue-327-pending-reflections-queue.md
@@ -1,0 +1,31 @@
+# Issue #327 — feat: fila "trades a refletir"
+
+> Follow-up (2) do #325. Marcio escolheu **2b** (fila + contador).
+
+## Autorização
+- [x] Escolha de produto de Marcio: "2b" (01/07/2026)
+- [x] Gate Pré-Código liberado
+
+## Context
+Só o registro manual dispara reflexão (#313). Importados/pulados ficam sem `selfReview` e sem forma de refletir depois. Objetivo: forçar o hábito. Aluno carrega a responsabilidade ([[feedback_aluno_responsabilidade]] — apresenta e cobra, sem rastrear "fez X").
+
+## Spec
+Ver issue body #327.
+
+## Phases
+- A (2a base) — `TradeDetailModal` aceita `onSubmitReview`; `<TradeReviewSection>` (linha 465) editável com gate `!isMentor && onSubmitReview && result != null` (já refletido → read-only; aberto → null). Reverte a decisão read-only do #308 pro próprio aluno.
+- B (wire) — `onSubmitReview` no TradeDetailModal do StudentDashboard (supresso em View-As) e TradesJournal (journal do próprio aluno).
+- C (fila) — novo `PendingReflections` (espelha `PendingTakeaways`), card no StudentDashboard perto do PendingTakeaways; suprimido em View-As; abre trade via `setViewingTrade`.
+- D (testes) — PendingReflections (9), TradeDetailModal gate (4).
+
+## Memória de cálculo (contador)
+N = `trades.filter(t => t.result != null && !t.selfReview)`, escopo uid + planId da ContextBar quando definido. `result 0` (breakeven) conta; `result null` (aberto) não. N=0 → card oculto.
+
+## Shared Deltas
+- MAIN (commit `e70892fa`, pushed): lock CHUNK-02+04 (#327) + reserva v1.82.0.
+
+## Decisions
+- Sem campo/collection novo. Escreve `trade.selfReview` via `submitTradeReview` (gateway #308). INV-15 não dispara. Sem CF → sem deploy.
+
+## Chunks
+CHUNK-02 (Student), CHUNK-04 (Trade Ledger).

--- a/src/__tests__/components/TradeDetailModal.test.jsx
+++ b/src/__tests__/components/TradeDetailModal.test.jsx
@@ -84,3 +84,35 @@ describe('TradeDetailModal — tradeId muted no header', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 });
+
+// #327 — Espelho editável no detalhe pro próprio aluno (fila "trades a refletir").
+describe('TradeDetailModal — reflexão editável (#327)', () => {
+  const closedNoReview = { ...baseTrade, result: 60, selfReview: undefined };
+
+  it('aluno + onSubmitReview + fechado sem selfReview → mostra nudge de auto-análise', () => {
+    render(
+      <TradeDetailModal isOpen onClose={() => {}} trade={closedNoReview} onSubmitReview={vi.fn()} />
+    );
+    expect(screen.getByText(/ainda não tem sua auto-análise/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Analisar o trade/i })).toBeInTheDocument();
+  });
+
+  it('mentor (isMentor) NÃO vê o nudge de reflexão', () => {
+    render(
+      <TradeDetailModal isOpen onClose={() => {}} trade={closedNoReview} isMentor onSubmitReview={vi.fn()} />
+    );
+    expect(screen.queryByText(/ainda não tem sua auto-análise/i)).not.toBeInTheDocument();
+  });
+
+  it('sem onSubmitReview NÃO mostra o nudge (read-only)', () => {
+    render(<TradeDetailModal isOpen onClose={() => {}} trade={closedNoReview} />);
+    expect(screen.queryByText(/ainda não tem sua auto-análise/i)).not.toBeInTheDocument();
+  });
+
+  it('trade sem resultado (aberto) NÃO mostra o nudge', () => {
+    render(
+      <TradeDetailModal isOpen onClose={() => {}} trade={{ ...baseTrade, result: null }} onSubmitReview={vi.fn()} />
+    );
+    expect(screen.queryByText(/ainda não tem sua auto-análise/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/reviews/PendingReflections.test.jsx
+++ b/src/__tests__/components/reviews/PendingReflections.test.jsx
@@ -1,0 +1,101 @@
+/**
+ * PendingReflections.test.jsx (issue #327)
+ * @description Fila "trades a refletir": filtra fechados sem selfReview, respeita
+ *              planId, conta, e abre o trade ao clicar.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PendingReflections from '../../../components/reviews/PendingReflections';
+
+const makeTrade = (overrides = {}) => ({
+  id: 't1',
+  symbol: 'WINFUT',
+  date: '2026-06-20',
+  result: 150,
+  currency: 'BRL',
+  planId: 'p1',
+  ...overrides,
+});
+
+describe('<PendingReflections />', () => {
+  it('não renderiza nada quando não há pendência', () => {
+    const { container } = render(
+      <PendingReflections trades={[makeTrade({ selfReview: { wouldRepeat: true } })]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('lista trades fechados sem selfReview', () => {
+    render(<PendingReflections trades={[makeTrade()]} />);
+    expect(screen.getByText('Trades a refletir')).toBeInTheDocument();
+    expect(screen.getByText('WINFUT')).toBeInTheDocument();
+  });
+
+  it('exclui trade já refletido (com selfReview)', () => {
+    render(
+      <PendingReflections
+        trades={[
+          makeTrade({ id: 't1', symbol: 'WINFUT' }),
+          makeTrade({ id: 't2', symbol: 'WDOFUT', selfReview: { wouldRepeat: false } }),
+        ]}
+      />
+    );
+    expect(screen.getByText('WINFUT')).toBeInTheDocument();
+    expect(screen.queryByText('WDOFUT')).not.toBeInTheDocument();
+  });
+
+  it('exclui trade aberto (result null)', () => {
+    render(
+      <PendingReflections
+        trades={[
+          makeTrade({ id: 't1', symbol: 'WINFUT' }),
+          makeTrade({ id: 't2', symbol: 'ABERTO', result: null }),
+        ]}
+      />
+    );
+    expect(screen.getByText('WINFUT')).toBeInTheDocument();
+    expect(screen.queryByText('ABERTO')).not.toBeInTheDocument();
+  });
+
+  it('inclui breakeven (result 0)', () => {
+    render(<PendingReflections trades={[makeTrade({ symbol: 'ZERADO', result: 0 })]} />);
+    expect(screen.getByText('ZERADO')).toBeInTheDocument();
+  });
+
+  it('respeita o filtro de plano (planId)', () => {
+    render(
+      <PendingReflections
+        planId="p1"
+        trades={[
+          makeTrade({ id: 't1', symbol: 'DOPLANO', planId: 'p1' }),
+          makeTrade({ id: 't2', symbol: 'OUTRO', planId: 'p2' }),
+        ]}
+      />
+    );
+    expect(screen.getByText('DOPLANO')).toBeInTheDocument();
+    expect(screen.queryByText('OUTRO')).not.toBeInTheDocument();
+  });
+
+  it('conta com plural correto', () => {
+    render(
+      <PendingReflections
+        trades={[makeTrade({ id: 't1' }), makeTrade({ id: 't2', symbol: 'X' })]}
+      />
+    );
+    expect(screen.getByText('2 trades')).toBeInTheDocument();
+  });
+
+  it('singular quando 1 trade', () => {
+    render(<PendingReflections trades={[makeTrade()]} />);
+    expect(screen.getByText('1 trade')).toBeInTheDocument();
+  });
+
+  it('clicar no item chama onOpenTrade com o trade', () => {
+    const onOpenTrade = vi.fn();
+    const trade = makeTrade();
+    render(<PendingReflections trades={[trade]} onOpenTrade={onOpenTrade} />);
+    fireEvent.click(screen.getByText('WINFUT'));
+    expect(onOpenTrade).toHaveBeenCalledWith(trade);
+  });
+});

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -460,9 +460,15 @@ const TradeDetailModal = ({
                 Substitui ExecutionPatternsPanel + ShadowBehaviorPanel. Aluno vê os dados. */}
             <BehaviorPanel trade={trade} isMentor={isMentor} embedded />
 
-            {/* #308 — Espelho do trade (read-only aqui). Escrita mora no fluxo de edição (lápis);
-                o olho só exibe o espelho já preenchido como contexto. */}
-            <TradeReviewSection trade={trade} />
+            {/* #308 — Espelho do trade. Read-only por padrão (mentor/View-As, ou trade sem resultado).
+                #327 — pro próprio aluno, num trade fechado ainda não refletido, o Espelho fica
+                EDITÁVEL aqui (fila "trades a refletir" cobra importados/pulados). Já refletido →
+                TradeReviewSection cai no branch read-only sozinho. */}
+            <TradeReviewSection
+              trade={trade}
+              canReview={!isMentor && typeof onSubmitReview === 'function' && trade?.result != null}
+              onSubmit={onSubmitReview ? (payload) => onSubmitReview(trade.id, payload) : undefined}
+            />
 
             {/* Observações do Aluno */}
             {notes && (

--- a/src/components/reviews/PendingReflections.jsx
+++ b/src/components/reviews/PendingReflections.jsx
@@ -1,0 +1,73 @@
+/**
+ * PendingReflections (issue #327)
+ * @description Card no dashboard do aluno listando trades FECHADOS ainda sem
+ *              auto-análise (`selfReview`) — importados (CSV/Order) ou pulados no
+ *              registro. Cobra o hábito de refletir todo trade (#325 follow-up 2b).
+ *
+ * Regras de visibilidade:
+ *   - Item = trade com `result != null` (fechado) e SEM `selfReview`.
+ *   - Respeita o filtro de plano da ContextBar (planId) quando definido.
+ *   - Sem pendência → retorna null. Suprimido em View-As (mentor não reflete pelo aluno).
+ *   - Clicar num item abre o TradeDetailModal (onOpenTrade), onde o Espelho fica editável.
+ */
+
+import { useMemo } from 'react';
+import { Eye, ChevronRight } from 'lucide-react';
+import { formatCurrency } from '../../utils/calculations';
+
+const fmtDateBR = (date) => (date ? String(date).split('-').reverse().join('/') : '-');
+
+const PendingReflections = ({ trades = [], planId = null, onOpenTrade = null }) => {
+  const pending = useMemo(() => {
+    const list = Array.isArray(trades) ? trades : [];
+    return list
+      .filter((t) => t && t.result != null && !t.selfReview)
+      .filter((t) => !planId || t.planId === planId)
+      .sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
+  }, [trades, planId]);
+
+  if (pending.length === 0) return null;
+
+  return (
+    <div className="glass-card p-4 mb-6">
+      <div className="flex items-center gap-2 mb-3">
+        <div className="p-1.5 bg-amber-500/10 rounded-lg">
+          <Eye className="w-4 h-4 text-amber-400" />
+        </div>
+        <h3 className="text-sm font-semibold text-white">Trades a refletir</h3>
+        <span className="text-[11px] px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400 font-medium">
+          {pending.length} {pending.length === 1 ? 'trade' : 'trades'}
+        </span>
+      </div>
+      <p className="text-[11px] text-slate-500 mb-2.5">
+        Fechados sem sua auto-análise. Refletir sobre cada trade é parte do processo — abra e olhe no espelho.
+      </p>
+      <div className="border border-slate-800 rounded-lg bg-slate-900/40 p-2">
+        <div className="space-y-0.5">
+          {pending.map((trade) => {
+            const result = Number(trade.result) || 0;
+            const win = result > 0;
+            return (
+              <button
+                key={trade.id}
+                onClick={() => onOpenTrade && onOpenTrade(trade)}
+                className="w-full flex items-center gap-3 px-2 py-1.5 rounded hover:bg-slate-800/50 group text-left transition-colors"
+              >
+                <span className="text-[11px] text-slate-500 tabular-nums shrink-0 w-14">{fmtDateBR(trade.date)}</span>
+                <span className="flex-1 text-[13px] text-slate-200 font-medium truncate">
+                  {trade.symbol || trade.ticker || '—'}
+                </span>
+                <span className={`text-[13px] tabular-nums shrink-0 ${win ? 'text-emerald-400' : 'text-red-400'}`}>
+                  {win ? '+' : ''}{formatCurrency(result, trade.currency)}
+                </span>
+                <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-amber-400 shrink-0 transition-colors" />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PendingReflections;

--- a/src/pages/StudentDashboard.jsx
+++ b/src/pages/StudentDashboard.jsx
@@ -28,6 +28,7 @@ import DashboardHeader from '../components/dashboard/DashboardHeader';
 import PlanCardGrid from '../components/dashboard/PlanCardGrid';
 import MetricsCards from '../components/dashboard/MetricsCards';
 import PendingTakeaways from '../components/reviews/PendingTakeaways';
+import PendingReflections from '../components/reviews/PendingReflections';
 
 // Componentes existentes
 import TradingCalendar from '../components/TradingCalendar';
@@ -604,6 +605,16 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
         onNavigateToFeedback={onNavigateToFeedback}
       />
 
+      {/* #327 — fila "trades a refletir": cobra auto-análise de fechados sem selfReview
+          (importados/pulados). Suprimido em View-As (mentor não reflete pelo aluno). */}
+      {!overrideStudentId && (
+        <PendingReflections
+          trades={trades}
+          planId={studentCtx.planId || null}
+          onOpenTrade={setViewingTrade}
+        />
+      )}
+
       {/* Cards de Planos */}
       <PlanCardGrid
         availablePlans={availablePlans}
@@ -809,7 +820,7 @@ const StudentDashboardBody = ({ viewAs = null, onNavigateToFeedback, onOpenLedge
 
       {/* Modais */}
       <AddTradeModal isOpen={showAddModal} onClose={() => { setShowAddModal(false); setEditingTrade(null); }} onSubmit={handleAddTrade} editTrade={editingTrade} loading={isSubmitting} plans={plans} onSubmitReview={overrideStudentId ? undefined : handleSubmitReview} />
-      <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} orders={orders} allTrades={trades} onViewFeedbackHistory={handleViewFeedbackHistory} onRecalcMepMen={handleRecalcMepMen} getPartials={getPartials} />
+      <TradeDetailModal isOpen={!!viewingTrade} onClose={() => setViewingTrade(null)} trade={viewingTrade} plans={plans} orders={orders} allTrades={trades} onViewFeedbackHistory={handleViewFeedbackHistory} onRecalcMepMen={handleRecalcMepMen} getPartials={getPartials} onSubmitReview={overrideStudentId ? undefined : handleSubmitReview} />
       <PlanManagementModal isOpen={showPlanModal} onClose={() => { setShowPlanModal(false); setEditingPlan(null); }} onSubmit={handleSavePlan} editingPlan={editingPlan} isSubmitting={isSubmitting} defaultAccountId={filters.accountId !== 'all' ? filters.accountId : undefined} />
       {extractPlan && (<PlanExtractModal isOpen={!!extractPlan} onClose={() => setExtractPlan(null)} plan={extractPlan} trades={trades.filter(t => t.planId === extractPlan.id)} />)}
       {/* PlanLedgerExtract: ledger agora é currentView no App.jsx (#102 Fase 0), não modal aqui */}

--- a/src/pages/TradesJournal.jsx
+++ b/src/pages/TradesJournal.jsx
@@ -268,6 +268,7 @@ const TradesJournal = ({ onNavigateToFeedback }) => {
         orders={orders}
         onViewFeedbackHistory={handleViewFeedbackHistory}
         getPartials={getPartials}
+        onSubmitReview={handleSubmitReview}
       />
 
       {/* CSV Import Modais */}


### PR DESCRIPTION
## Contexto
Só o registro manual dispara reflexão (#313). Trades **importados** (CSV/Order) e **pulados** ficam sem `selfReview` e sem forma de refletir depois. Objetivo (Marcio): **forçar o hábito de refletir todo trade**. Follow-up (2) do #325, caminho **2b (fila + contador)**.

## Mudanças
**2a (base):** `TradeDetailModal` — o Espelho (`TradeReviewSection`) fica **editável** pro próprio aluno num trade **fechado ainda não refletido** (gate `!isMentor && onSubmitReview && result != null`). Já refletido → read-only (atual); aberto → nada. Reverte a decisão read-only do #308 **só pro dono do trade**.

**Wire:** `onSubmitReview` chega ao `TradeDetailModal` no **StudentDashboard** (suprimido em View-As via `overrideStudentId`) e no **TradesJournal** (journal do próprio aluno). Ambos já tinham `handleSubmitReview → submitTradeReview`.

**Fila (`PendingReflections`, espelha `PendingTakeaways`):** card no dashboard listando fechados sem `selfReview`, com **contador**, respeitando o filtro de plano da ContextBar. Clique abre o `TradeDetailModal` pra refletir. Vazio → oculto. Suprimido em View-As.

## Memória de cálculo (contador)
N = `trades.filter(t => t.result != null && !t.selfReview)`, escopo uid + planId da ContextBar quando definido. Breakeven (result 0) conta; aberto (result null) não. N=0 → card oculto.

## Persistência
Nenhum campo/collection novo. Escreve `trade.selfReview` via `submitTradeReview` (gateway #308). INV-15 não dispara. **Sem `functions/` → sem deploy de CF.**

## Testes
- `PendingReflections` (9): filtro fechado/refletido/aberto/breakeven, planId, contador sing/plural, clique.
- `TradeDetailModal` gate (4): aluno vê nudge; mentor não; sem onSubmitReview não; aberto não.
- Frontend **3519 passed / 226 files**. Build verde.

Closes #327