### PR TITLE
feat(#329): colapso na fila 'trades a refletir' quando há muitos pendentes

### DIFF
--- a/docs/dev/issues/issue-329-pending-reflections-collapse.md
+++ b/docs/dev/issues/issue-329-pending-reflections-collapse.md
@@ -1,0 +1,25 @@
+# Issue #329 — feat: colapso na fila "trades a refletir"
+
+> Follow-up do #327. Polish de UX.
+
+## Autorização
+- [x] Pedido direto de Marcio (02/07/2026): colapso quando há muitos trades pendentes
+- [x] Gate Pré-Código liberado
+
+## Context
+Com import em lote, `PendingReflections` (#327) pode listar dezenas de trades sem `selfReview` — aluno pode não ter tido tempo ou decidir não refletir. Lista longa inunda o dashboard.
+
+## Spec
+- Card colapsável: header (Eye + título + contador + chevron) sempre visível; clique recolhe/expande.
+- Default colapsado quando `pending.length > 8`; poucos → expandido. Toggle do usuário sobrepõe (`userToggled`).
+- Corpo expandido com `max-h-72 overflow-y-auto` (não empurra a página).
+- **Sem** ação de "dispensar"/rastreio de "não vou refletir" ([[feedback_aluno_responsabilidade]]) — contador segue cobrando.
+
+## Decisions
+- Estado só de UI (`useState`, sem persistência). Sem campo/collection/CF.
+
+## Shared Deltas
+- MAIN (commit `08ffec68`, pushed): lock CHUNK-02 (#329) + reserva v1.82.1.
+
+## Chunks
+CHUNK-02 (Student).

--- a/src/__tests__/components/reviews/PendingReflections.test.jsx
+++ b/src/__tests__/components/reviews/PendingReflections.test.jsx
@@ -98,4 +98,32 @@ describe('<PendingReflections />', () => {
     fireEvent.click(screen.getByText('WINFUT'));
     expect(onOpenTrade).toHaveBeenCalledWith(trade);
   });
+
+  // #329 — colapso quando há muitos pendentes.
+  const manyTrades = (n) =>
+    Array.from({ length: n }, (_, i) => makeTrade({ id: `t${i}`, symbol: `SYM${i}` }));
+
+  it('poucos trades (≤8): nasce expandido — itens visíveis', () => {
+    render(<PendingReflections trades={manyTrades(3)} />);
+    expect(screen.getByText('SYM0')).toBeInTheDocument();
+  });
+
+  it('muitos trades (>8): nasce colapsado — contador visível, itens ocultos', () => {
+    render(<PendingReflections trades={manyTrades(12)} />);
+    expect(screen.getByText('12 trades')).toBeInTheDocument();
+    expect(screen.queryByText('SYM0')).not.toBeInTheDocument();
+  });
+
+  it('clicar no header expande a lista colapsada', () => {
+    render(<PendingReflections trades={manyTrades(12)} />);
+    fireEvent.click(screen.getByText('Trades a refletir'));
+    expect(screen.getByText('SYM0')).toBeInTheDocument();
+  });
+
+  it('clicar no header colapsa a lista expandida (poucos)', () => {
+    render(<PendingReflections trades={manyTrades(3)} />);
+    expect(screen.getByText('SYM0')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Trades a refletir'));
+    expect(screen.queryByText('SYM0')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/reviews/PendingReflections.jsx
+++ b/src/components/reviews/PendingReflections.jsx
@@ -11,11 +11,15 @@
  *   - Clicar num item abre o TradeDetailModal (onOpenTrade), onde o Espelho fica editável.
  */
 
-import { useMemo } from 'react';
-import { Eye, ChevronRight } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Eye, ChevronRight, ChevronDown } from 'lucide-react';
 import { formatCurrency } from '../../utils/calculations';
 
 const fmtDateBR = (date) => (date ? String(date).split('-').reverse().join('/') : '-');
+
+// #329 — com import em lote a fila pode ter dezenas de pendentes. Acima do limiar o
+// card nasce colapsado (não inunda o dashboard); o contador segue cobrando no header.
+const COLLAPSE_THRESHOLD = 8;
 
 const PendingReflections = ({ trades = [], planId = null, onOpenTrade = null }) => {
   const pending = useMemo(() => {
@@ -26,11 +30,21 @@ const PendingReflections = ({ trades = [], planId = null, onOpenTrade = null }) 
       .sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
   }, [trades, planId]);
 
+  // null = segue o default (colapsado quando há muitos); toggle do usuário sobrepõe.
+  const [userToggled, setUserToggled] = useState(null);
+  const many = pending.length > COLLAPSE_THRESHOLD;
+  const expanded = userToggled === null ? !many : userToggled;
+
   if (pending.length === 0) return null;
 
   return (
     <div className="glass-card p-4 mb-6">
-      <div className="flex items-center gap-2 mb-3">
+      <button
+        type="button"
+        onClick={() => setUserToggled(!expanded)}
+        className="w-full flex items-center gap-2 text-left"
+        aria-expanded={expanded}
+      >
         <div className="p-1.5 bg-amber-500/10 rounded-lg">
           <Eye className="w-4 h-4 text-amber-400" />
         </div>
@@ -38,34 +52,42 @@ const PendingReflections = ({ trades = [], planId = null, onOpenTrade = null }) 
         <span className="text-[11px] px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400 font-medium">
           {pending.length} {pending.length === 1 ? 'trade' : 'trades'}
         </span>
-      </div>
-      <p className="text-[11px] text-slate-500 mb-2.5">
-        Fechados sem sua auto-análise. Refletir sobre cada trade é parte do processo — abra e olhe no espelho.
-      </p>
-      <div className="border border-slate-800 rounded-lg bg-slate-900/40 p-2">
-        <div className="space-y-0.5">
-          {pending.map((trade) => {
-            const result = Number(trade.result) || 0;
-            const win = result > 0;
-            return (
-              <button
-                key={trade.id}
-                onClick={() => onOpenTrade && onOpenTrade(trade)}
-                className="w-full flex items-center gap-3 px-2 py-1.5 rounded hover:bg-slate-800/50 group text-left transition-colors"
-              >
-                <span className="text-[11px] text-slate-500 tabular-nums shrink-0 w-14">{fmtDateBR(trade.date)}</span>
-                <span className="flex-1 text-[13px] text-slate-200 font-medium truncate">
-                  {trade.symbol || trade.ticker || '—'}
-                </span>
-                <span className={`text-[13px] tabular-nums shrink-0 ${win ? 'text-emerald-400' : 'text-red-400'}`}>
-                  {win ? '+' : ''}{formatCurrency(result, trade.currency)}
-                </span>
-                <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-amber-400 shrink-0 transition-colors" />
-              </button>
-            );
-          })}
-        </div>
-      </div>
+        <span className="ml-auto text-slate-500">
+          {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+        </span>
+      </button>
+
+      {expanded && (
+        <>
+          <p className="text-[11px] text-slate-500 mt-3 mb-2.5">
+            Fechados sem sua auto-análise. Refletir sobre cada trade é parte do processo — abra e olhe no espelho.
+          </p>
+          <div className="border border-slate-800 rounded-lg bg-slate-900/40 p-2">
+            <div className="space-y-0.5 max-h-72 overflow-y-auto">
+              {pending.map((trade) => {
+                const result = Number(trade.result) || 0;
+                const win = result > 0;
+                return (
+                  <button
+                    key={trade.id}
+                    onClick={() => onOpenTrade && onOpenTrade(trade)}
+                    className="w-full flex items-center gap-3 px-2 py-1.5 rounded hover:bg-slate-800/50 group text-left transition-colors"
+                  >
+                    <span className="text-[11px] text-slate-500 tabular-nums shrink-0 w-14">{fmtDateBR(trade.date)}</span>
+                    <span className="flex-1 text-[13px] text-slate-200 font-medium truncate">
+                      {trade.symbol || trade.ticker || '—'}
+                    </span>
+                    <span className={`text-[13px] tabular-nums shrink-0 ${win ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {win ? '+' : ''}{formatCurrency(result, trade.currency)}
+                    </span>
+                    <ChevronRight className="w-4 h-4 text-slate-600 group-hover:text-amber-400 shrink-0 transition-colors" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Contexto
Follow-up do #327. Com **import em lote**, a fila `PendingReflections` pode listar dezenas de trades sem `selfReview` (aluno não teve tempo, ou decidiu não refletir). A lista longa inunda o dashboard.

## Mudança
- Card **colapsável**: header (Eye + título + contador + chevron) sempre visível; clique recolhe/expande.
- **Default colapsado quando `pending > 8`**; poucos → expandido. Toggle do usuário sobrepõe.
- Corpo expandido com `max-h-72 overflow-y-auto` (não empurra a página).
- **Sem** ação de 'dispensar'/rastreio de 'não vou refletir' (aluno carrega a responsabilidade) — o contador segue cobrando mesmo colapsado.

## Persistência
Nenhuma. Só estado de UI (`useState`). Sem campo/collection/CF.

## Testes
`PendingReflections` +4 (13 no total): expandido/colapsado por limiar, toggle expande/colapsa. Frontend **3523 passed / 226 files**. Build verde.

Closes #329