### PR TITLE
fix(#331): SWOT em revisão DRAFT — CF aceita snapshot do cliente

### DIFF
--- a/functions/__tests__/reviews/generateWeeklySwot.test.js
+++ b/functions/__tests__/reviews/generateWeeklySwot.test.js
@@ -1,0 +1,51 @@
+/**
+ * generateWeeklySwot.test.js — #331
+ *
+ * Cobre resolveSwotSnapshot: a CF aceita snapshot montado no cliente (revisão DRAFT sem
+ * frozenSnapshot) e cai no frozenSnapshot persistido (revisão publicada). Regressão original:
+ * a CF exigia frozenSnapshot e retornava HTTP 400 em toda revisão DRAFT.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let resolveSwotSnapshot;
+beforeAll(() => {
+  // O módulo instancia `new Anthropic()` no load; a chave só precisa existir (sem rede na construção).
+  process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || 'test-key';
+  ({ resolveSwotSnapshot } = require('../../reviews/generateWeeklySwot'));
+});
+
+describe('resolveSwotSnapshot (#331)', () => {
+  const clientSnapshot = { planContext: { planId: 'p1' }, kpis: { pl: 100 } };
+  const frozen = { planContext: { planId: 'pF' }, kpis: { pl: 42 } };
+
+  it('usa o snapshot do cliente quando presente (DRAFT, frozenSnapshot null)', () => {
+    const review = { status: 'DRAFT', frozenSnapshot: null };
+    expect(resolveSwotSnapshot(clientSnapshot, review)).toBe(clientSnapshot);
+  });
+
+  it('cai no frozenSnapshot quando o cliente não envia snapshot (revisão publicada)', () => {
+    const review = { status: 'CLOSED', frozenSnapshot: frozen };
+    expect(resolveSwotSnapshot(null, review)).toBe(frozen);
+  });
+
+  it('prioriza o snapshot do cliente mesmo com frozenSnapshot presente (regen em DRAFT)', () => {
+    const review = { status: 'DRAFT', frozenSnapshot: frozen };
+    expect(resolveSwotSnapshot(clientSnapshot, review)).toBe(clientSnapshot);
+  });
+
+  it('retorna null quando ambos ausentes → a CF lança failed-precondition (400)', () => {
+    const review = { status: 'DRAFT', frozenSnapshot: null };
+    expect(resolveSwotSnapshot(null, review)).toBeNull();
+    expect(resolveSwotSnapshot(undefined, review)).toBeNull();
+  });
+
+  it('ignora clientSnapshot não-objeto (defensivo) e cai no frozenSnapshot', () => {
+    const review = { status: 'CLOSED', frozenSnapshot: frozen };
+    expect(resolveSwotSnapshot('lixo', review)).toBe(frozen);
+    expect(resolveSwotSnapshot(123, review)).toBe(frozen);
+  });
+});

--- a/functions/reviews/generateWeeklySwot.js
+++ b/functions/reviews/generateWeeklySwot.js
@@ -3,7 +3,8 @@
  *
  * Gera SWOT (Sonnet 4.6) a partir do frozenSnapshot da revisão.
  *
- * Input:  { studentId, reviewId }
+ * Input:  { studentId, reviewId, snapshot? } — snapshot montado no cliente (#331); usado quando
+ *          a revisão ainda está DRAFT (frozenSnapshot null). Ausente → cai no frozenSnapshot.
  * Output: { swot: {strengths, weaknesses, opportunities, threats, ...meta}, aiUnavailable }
  *
  * Fluxo:
@@ -31,6 +32,14 @@ const { buildStyledSystemPrompt } = require('../_shared/swotPromptBuilder');
 const { isMentor } = require('./validators');
 
 const MAX_VALIDATION_RETRIES = 3;
+
+// #331 — fonte do snapshot do SWOT. Em DRAFT a revisão ainda tem frozenSnapshot: null
+// (congela só no publish), então o cliente (mentor trusted) monta e envia o snapshot.
+// Revisões já publicadas caem no frozenSnapshot persistido. Null quando ambos ausentes.
+const resolveSwotSnapshot = (clientSnapshot, review) =>
+  (clientSnapshot && typeof clientSnapshot === 'object')
+    ? clientSnapshot
+    : (review?.frozenSnapshot || null);
 
 const client = new Anthropic();
 
@@ -71,7 +80,7 @@ module.exports = onCall(
       throw new HttpsError('permission-denied', 'Apenas mentor pode gerar SWOT');
     }
 
-    const { studentId, reviewId } = request.data || {};
+    const { studentId, reviewId, snapshot: clientSnapshot = null } = request.data || {};
     if (!studentId || typeof studentId !== 'string') {
       throw new HttpsError('invalid-argument', 'studentId é obrigatório');
     }
@@ -90,11 +99,13 @@ module.exports = onCall(
     if (review.status === 'ARCHIVED') {
       throw new HttpsError('failed-precondition', 'Review arquivada não pode receber novo SWOT');
     }
-    if (!review.frozenSnapshot) {
-      throw new HttpsError('failed-precondition', 'Review sem frozenSnapshot — não é possível gerar SWOT');
+    // #331 — snapshot do cliente (DRAFT) ou frozenSnapshot persistido (publicada). 400 só se ambos ausentes.
+    const snapshot = resolveSwotSnapshot(clientSnapshot, review);
+    if (!snapshot) {
+      throw new HttpsError('failed-precondition', 'Review sem snapshot — não é possível gerar SWOT');
     }
 
-    const planId = review.frozenSnapshot?.planContext?.planId;
+    const planId = snapshot?.planContext?.planId;
 
     // Busca revisão anterior do mesmo plano para comparação
     let previousSnapshot = null;
@@ -133,7 +144,7 @@ module.exports = onCall(
 
     try {
       const { swot } = await callClaudeWithRetry({
-        currentSnapshot: review.frozenSnapshot,
+        currentSnapshot: snapshot,
         previousSnapshot,
         periodLabel,
         systemPrompt: styledSystemPrompt,
@@ -148,7 +159,7 @@ module.exports = onCall(
       };
     } catch (e) {
       console.warn('[generateWeeklySwot] Fallback determinístico:', e.message);
-      const fallback = buildFallbackSwot(review.frozenSnapshot);
+      const fallback = buildFallbackSwot(snapshot);
       swotPayload = {
         ...fallback,
         generatedAt: admin.firestore.FieldValue.serverTimestamp(),
@@ -166,3 +177,6 @@ module.exports = onCall(
     return { swot: swotPayload, aiUnavailable };
   }
 );
+
+// #331 — exposto para teste unitário da seleção de snapshot (DRAFT vs publicada).
+module.exports.resolveSwotSnapshot = resolveSwotSnapshot;

--- a/src/__tests__/hooks/useWeeklyReviews.test.js
+++ b/src/__tests__/hooks/useWeeklyReviews.test.js
@@ -119,13 +119,23 @@ describe('useWeeklyReviews', () => {
     expect(returned).toEqual({ reviewId: 'x-1', status: 'DRAFT' });
   });
 
-  it('generateSwot injects studentId + reviewId in payload', async () => {
+  it('generateSwot injects studentId + reviewId in payload (snapshot omitido → null)', async () => {
     mockCallable.mockResolvedValueOnce({ data: { swot: { strengths: [] }, aiUnavailable: false } });
     const { result } = renderHook(() => useWeeklyReviews('student-1'));
     await act(async () => {
       await result.current.generateSwot({ reviewId: 'r1' });
     });
-    expect(mockCallable).toHaveBeenCalledWith({ studentId: 'student-1', reviewId: 'r1' });
+    expect(mockCallable).toHaveBeenCalledWith({ studentId: 'student-1', reviewId: 'r1', snapshot: null });
+  });
+
+  it('generateSwot repassa o snapshot do cliente à CF (#331 — DRAFT sem frozenSnapshot)', async () => {
+    mockCallable.mockResolvedValueOnce({ data: { swot: { strengths: [] }, aiUnavailable: false } });
+    const { result } = renderHook(() => useWeeklyReviews('student-1'));
+    const snapshot = { planContext: { planId: 'p1' }, kpis: { pl: 100 } };
+    await act(async () => {
+      await result.current.generateSwot({ reviewId: 'r1', snapshot });
+    });
+    expect(mockCallable).toHaveBeenCalledWith({ studentId: 'student-1', reviewId: 'r1', snapshot });
   });
 
   it('closeReview publica via callable publishReview e persiste links via updateDoc (#269 Fase D)', async () => {

--- a/src/components/reviews/ReviewToolsPanel.jsx
+++ b/src/components/reviews/ReviewToolsPanel.jsx
@@ -24,6 +24,7 @@ import {
 import { useWeeklyReviews } from '../../hooks/useWeeklyReviews';
 import { useAuth } from '../../contexts/AuthContext';
 import { validateReviewUrl } from '../../utils/reviewUrlValidator';
+import { rebuildReviewSnapshot } from '../../utils/rebuildReviewSnapshot';
 import TakeawaysSection from './TakeawaysSection';
 
 
@@ -175,8 +176,13 @@ const ReviewToolsPanel = ({
   const handleGenerateSwot = useCallback(async () => {
     if (swot && !confirmRegen) { setConfirmRegen(true); return; }
     setConfirmRegen(false);
-    try { await generateSwot({ reviewId: review.id }); } catch { /* */ }
-  }, [swot, confirmRegen, generateSwot, review?.id]);
+    try {
+      // #331 — em DRAFT o frozenSnapshot ainda é null; monta o snapshot no cliente e passa à CF.
+      // Revisões já publicadas têm frozenSnapshot → snapshot null e a CF cai nele.
+      const snapshot = isDraft ? await rebuildReviewSnapshot(review, { studentId }) : null;
+      await generateSwot({ reviewId: review.id, snapshot });
+    } catch { /* */ }
+  }, [swot, confirmRegen, generateSwot, review, studentId, isDraft]);
 
   // Salvar SEM publicar — persiste sessionNotes/links no DRAFT.
   // Takeaways são gerenciados via TakeawaysSection (mutações imediatas, sem botão Salvar).

--- a/src/hooks/useWeeklyReviews.js
+++ b/src/hooks/useWeeklyReviews.js
@@ -135,12 +135,14 @@ export const useWeeklyReviews = (studentId) => {
   // A revisão semanal nasce sob demanda no 1º feedback do mentor (trigger onTradeUpdated
   // → getOrCreateOpenReview, server-side) e os trades entram ao virarem REVIEWED.
 
-  const generateSwot = useCallback(async ({ reviewId }) => {
+  // #331 — `snapshot` (montado no cliente via buildClientSnapshot) é passado para a CF quando
+  // a revisão está DRAFT (frozenSnapshot ainda null). Ausente → a CF cai no frozenSnapshot.
+  const generateSwot = useCallback(async ({ reviewId, snapshot = null }) => {
     setActionLoading(true);
     setError(null);
     try {
       const cf = httpsCallable(functions, 'generateWeeklySwot');
-      const res = await cf({ studentId, reviewId });
+      const res = await cf({ studentId, reviewId, snapshot });
       return res.data;
     } catch (err) {
       setError(err.message || 'Erro ao gerar SWOT');

--- a/src/pages/WeeklyReviewPage.jsx
+++ b/src/pages/WeeklyReviewPage.jsx
@@ -20,7 +20,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import {
-  doc, onSnapshot, collection, query, where, orderBy, limit, getDoc, getDocs,
+  doc, onSnapshot, collection, query, orderBy, limit,
 } from 'firebase/firestore';
 import { db } from '../firebase';
 import {
@@ -34,8 +34,7 @@ import MaturityComparisonSection from '../components/reviews/MaturityComparisonS
 import ReviewKpiGrid from '../components/reviews/ReviewKpiGrid';
 import ReviewTradesSection from '../components/reviews/ReviewTradesSection';
 import TakeawaysSection from '../components/reviews/TakeawaysSection';
-import { buildClientSnapshot } from '../utils/clientSnapshotBuilder';
-import { resolveCycle } from '../utils/cycleResolver';
+import { rebuildReviewSnapshot } from '../utils/rebuildReviewSnapshot';
 import { useWeeklyReviews } from '../hooks/useWeeklyReviews';
 import { useReviewMaturitySnapshot } from '../hooks/useReviewMaturitySnapshot';
 import { validateNotesText, validateReviewUrl, MAX_NOTES_LENGTH } from '../utils/reviewUrlValidator';
@@ -416,57 +415,9 @@ const Section = ({ num, title, children, stage }) => (
 //
 // #269 v2: o conjunto da revisão = trades ancorados nela (reviewId === review.id). A FK
 // é carimbada quando o mentor dá feedback (OPEN→REVIEWED). Sem janela ISO, sem includedTradeIds.
-//
-// Parâmetro opcional `maturity` (task 21 — H2): quando fornecido, é congelado em
-// `maturitySnapshot` via buildClientSnapshot. O caller pode ter recomputado antes
-// via `recomputeAndReadMaturity` — se ausente, snapshot segue sem maturitySnapshot.
-const rebuildSnapshotFromFirestore = async (review, { studentId = null } = {}) => {
-  const planId = review?.planId || review?.frozenSnapshot?.planContext?.planId;
-  if (!planId) return null;
-  const planSnap = await getDoc(doc(db, 'plans', planId));
-  if (!planSnap.exists()) return null;
-  const plan = { id: planSnap.id, ...planSnap.data() };
-  const tradesQ = query(collection(db, 'trades'), where('planId', '==', planId));
-  const tradesSnap = await getDocs(tradesQ);
-  const allTrades = tradesSnap.docs.map(d => ({ id: d.id, ...d.data() }));
-  // #269 v2 — conjunto da revisão = trades ancorados nela (reviewId === review.id).
-  // A FK é carimbada no 1º feedback do mentor (OPEN→REVIEWED). Mata o bug original
-  // (SWOT rodava sobre a janela ISO, ignorando a curadoria).
-  const draftTrades = allTrades.filter(t => t.reviewId === review.id);
-  const extraTrades = [];
-
-  // Fetch defensivo de maturity/current — usado em DRAFTs para preview live do
-  // comparativo N vs N-1. No publish (handlePublish) o caller força recompute
-  // antes e passa via closeReviewMaturityPipeline.
-  let maturity = null;
-  try {
-    if (studentId) {
-      const matSnap = await getDoc(doc(db, 'students', studentId, 'maturity', 'current'));
-      maturity = matSnap.exists() ? { id: matSnap.id, ...matSnap.data() } : null;
-    }
-  } catch (err) {
-    console.warn('[rebuildSnapshotFromFirestore] maturity fetch failed:', err?.message || err);
-  }
-
-  // CV normalizado per-ciclo (issue #235 F3.1) usa janela do CICLO, não da semana —
-  // mantém alinhamento com CycleConsistencyCard do dashboard.
-  const cycleRange = resolveCycle(review.cycleKey, plan);
-  const toIso = (d) =>
-    d instanceof Date && !Number.isNaN(d.getTime())
-      ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-      : null;
-
-  return buildClientSnapshot({
-    plan,
-    trades: draftTrades,
-    extraTrades,
-    cycleKey: review.cycleKey || null,
-    cycleStart: cycleRange ? toIso(cycleRange.start) : null,
-    cycleEnd: cycleRange ? toIso(cycleRange.end) : null,
-    emotionalMetrics: null,
-    maturity,
-  });
-};
+// #331 — extraído para src/utils/rebuildReviewSnapshot.js (fonte única, compartilhada com
+// ReviewToolsPanel). Alias local preservado para os call sites existentes.
+const rebuildSnapshotFromFirestore = rebuildReviewSnapshot;
 
 const WeeklyReviewPage = ({
   studentId,
@@ -635,7 +586,10 @@ const WeeklyReviewPage = ({
   const handleGenerateSwot = async () => {
     if (!canEdit || !isDraft) return;
     try {
-      await generateSwot({ reviewId: review.id });
+      // #331 — em DRAFT o frozenSnapshot ainda é null; passa o snapshot montado no cliente
+      // (liveSnapshot já recomputado ao montar; rebuild defensivo se ainda não pronto).
+      const snapshot = liveSnapshot || await rebuildReviewSnapshot(review, { studentId });
+      await generateSwot({ reviewId: review.id, snapshot });
       setConfirmRegen(false);
     } catch { /* error surfaced by hook */ }
   };

--- a/src/utils/rebuildReviewSnapshot.js
+++ b/src/utils/rebuildReviewSnapshot.js
@@ -1,0 +1,66 @@
+/**
+ * rebuildReviewSnapshot
+ * @description Reconstrói o snapshot da revisão semanal a partir do Firestore (plan + trades
+ *              ancorados via reviewId + maturity/current + janela do ciclo). Compute client-side
+ *              (mentor trusted — ver clientSnapshotBuilder.js:7-9) via buildClientSnapshot.
+ *
+ * Origem: extração de WeeklyReviewPage.jsx (#331) para reuso no ReviewToolsPanel (Extrato),
+ * que precisa do mesmo snapshot para gerar SWOT em DRAFT (frozenSnapshot ainda null).
+ *
+ * planId: lê `review.planId` (presente no doc DRAFT desde openReview) com fallback ao
+ * `frozenSnapshot.planContext.planId` (revisões antigas). Conjunto = trades WHERE
+ * reviewId === review.id (#269 v2 — FK carimbada no 1º feedback do mentor).
+ *
+ * @param {Object} review — doc da revisão ({ id, planId, cycleKey, frozenSnapshot? })
+ * @param {Object} [opts]
+ * @param {string} [opts.studentId] — para congelar maturity/current no snapshot
+ * @returns {Promise<Object|null>} frozenSnapshot montado, ou null se plano ausente
+ */
+
+import { doc, getDoc, collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+import { buildClientSnapshot } from './clientSnapshotBuilder';
+import { resolveCycle } from './cycleResolver';
+
+export const rebuildReviewSnapshot = async (review, { studentId = null } = {}) => {
+  const planId = review?.planId || review?.frozenSnapshot?.planContext?.planId;
+  if (!planId) return null;
+  const planSnap = await getDoc(doc(db, 'plans', planId));
+  if (!planSnap.exists()) return null;
+  const plan = { id: planSnap.id, ...planSnap.data() };
+  const tradesQ = query(collection(db, 'trades'), where('planId', '==', planId));
+  const tradesSnap = await getDocs(tradesQ);
+  const allTrades = tradesSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+  // #269 v2 — conjunto da revisão = trades ancorados nela (reviewId === review.id).
+  const draftTrades = allTrades.filter((t) => t.reviewId === review.id);
+  const extraTrades = [];
+
+  // Fetch defensivo de maturity/current para o comparativo N vs N-1.
+  let maturity = null;
+  try {
+    if (studentId) {
+      const matSnap = await getDoc(doc(db, 'students', studentId, 'maturity', 'current'));
+      maturity = matSnap.exists() ? { id: matSnap.id, ...matSnap.data() } : null;
+    }
+  } catch (err) {
+    console.warn('[rebuildReviewSnapshot] maturity fetch failed:', err?.message || err);
+  }
+
+  // CV normalizado per-ciclo (issue #235 F3.1) usa janela do CICLO, não da semana.
+  const cycleRange = resolveCycle(review.cycleKey, plan);
+  const toIso = (d) =>
+    d instanceof Date && !Number.isNaN(d.getTime())
+      ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+      : null;
+
+  return buildClientSnapshot({
+    plan,
+    trades: draftTrades,
+    extraTrades,
+    cycleKey: review.cycleKey || null,
+    cycleStart: cycleRange ? toIso(cycleRange.start) : null,
+    cycleEnd: cycleRange ? toIso(cycleRange.end) : null,
+    emotionalMetrics: null,
+    maturity,
+  });
+};


### PR DESCRIPTION
## Problema
Gerar SWOT na tela de revisão falhava com **HTTP 400** (`failed-precondition`). Regressão do redesign v2 (#269): a revisão nasce DRAFT com `frozenSnapshot: null` (congela só no publish), mas o botão "Gerar SWOT" fica habilitado em DRAFT e a CF `generateWeeklySwot` ainda exigia o `frozenSnapshot`. A CF nunca foi adaptada ao ciclo de vida v2.

## Abordagem — B (client passa snapshot)
Consistente com `publishReview`, que já recebe `frozenSnapshot` do cliente. A (montar server-side) foi descartada: contraria `clientSnapshotBuilder.js:7-9` — a engine de compliance/emotional é client-only por design (mentor trusted).

## Mudanças
- **CF** `generateWeeklySwot`: aceita `data.snapshot` opcional; `resolveSwotSnapshot(clientSnapshot, review)` → snapshot do cliente (DRAFT) ou `frozenSnapshot` (publicada); **400 só quando ambos ausentes**. planId/prompt/fallback usam o snapshot resolvido.
- **Hook** `generateSwot({ reviewId, snapshot })` repassa à CF.
- **Surfaces** `WeeklyReviewPage` e `ReviewToolsPanel` montam e passam o snapshot em DRAFT. (`WeeklyReviewModal` é legado/não montado — intocado.)
- **Refactor**: builder extraído para `src/utils/rebuildReviewSnapshot.js` (fonte única, DRAFT-correta — planId de `review.planId`, membros por `reviewId`); elimina duplicação.

## Testes
- `generateWeeklySwot.test.js` (novo): `resolveSwotSnapshot` — 5 casos (DRAFT usa cliente / publicada cai no frozen / prioridade / null→400 / defensivo não-objeto).
- `useWeeklyReviews.test.js`: pass-through do snapshot (2).
- Suítes completas verdes: **src 3524**, **functions 203**; build ok.

## Deploy
Toca `functions/reviews/generateWeeklySwot.js` → requer `firebase deploy --only functions` após o merge.

Closes #331