### PR TITLE
fix(#333): trade DISCUSSED aparecia como 'Pendente'/'Aguardando Revisão'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Version source of truth: `src/version.js`.
 
 ---
 
+## [1.82.3] - 03/07/2026 · #333 · PR #TBD
+
+**fix:** trade DISCUSSED aparecia como "Pendente" / "Aguardando Revisão"
+
+- **Causa-raiz:** o #269 v2 introduziu o status terminal `DISCUSSED` (revisado + discutido numa revisão semanal publicada, setado por `publishReview.js`), mas 4 mapeamentos de badge de status não o tratavam e caíam no fallback — dando a impressão de que a revisão nunca fora feita.
+- `ExtractTable.jsx` (coluna Status do extrato): `DISCUSSED` mostrava **"Pendente"**; agora → **"Discutido"** (índigo, espelhando o `TradeStatusBadge`). `getFeedbackStatusConfig` exportado p/ teste.
+- `FeedbackPage.jsx`: `DISCUSSED` caía no fallback `config.OPEN` → **"Aguardando Revisão"**; agora config própria "Discutido".
+- `TradesList.jsx` e `TradeDetailModal.jsx`: idem, config `DISCUSSED` adicionada.
+- **Recolor** no extrato: "Fechado" (CLOSED) de cinza → roxo (paridade com "Encerrado"); "Pendente" ganhou contraste (`slate-400`) — Pendente e Fechado deixam de compartilhar a mesma cor.
+- `feedbackStatusConfig.test.js` (novo): trava DISCUSSED → "Discutido" (nunca "Pendente"), cores distintas por status, fallback preservado (6 testes).
+- Display puro — **sem CF, sem Firestore, sem migração**.
+
+
 ## [1.82.2] - 03/07/2026 · #331 · PR #332
 
 **fix:** SWOT em revisão DRAFT — CF aceita snapshot do cliente

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Version source of truth: `src/version.js`.
 
 ---
 
-## [1.82.3] - 03/07/2026 · #333 · PR #TBD
+## [1.82.3] - 03/07/2026 · #333 · PR #334
 
 **fix:** trade DISCUSSED aparecia como "Pendente" / "Aguardando Revisão"
 

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -62,3 +62,4 @@
 | 1.82.0 | #327 | `feat/issue-327-pending-reflections-queue` | 01/07/2026 | consumida (PR #328 squash `28e4ce8d`) |
 | 1.82.1 | #329 | `feat/issue-329-pending-reflections-collapse` | 02/07/2026 | consumida (PR #330 squash `07a5f8b9`) |
 | 1.82.2 | #331 | `fix/issue-331-swot-draft-snapshot` | 03/07/2026 | consumida (PR #332 squash `ee70704f`) |
+| 1.82.3 | #333 | `fix/issue-333-discussed-status-badge` | 03/07/2026 | reservada |

--- a/src/__tests__/components/extract/feedbackStatusConfig.test.js
+++ b/src/__tests__/components/extract/feedbackStatusConfig.test.js
@@ -1,0 +1,44 @@
+/**
+ * feedbackStatusConfig.test.js (#333)
+ * @description Trava a regressão: trade em status terminal DISCUSSED (revisado +
+ *   discutido numa revisão semanal publicada, #269 v2) NUNCA pode ser rotulado
+ *   como "Pendente" na coluna Status do extrato. Antes do #333 o switch não
+ *   tratava DISCUSSED e ele caía no default → "Pendente".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getFeedbackStatusConfig } from '../../../components/extract/ExtractTable';
+
+describe('getFeedbackStatusConfig (#333)', () => {
+  it('DISCUSSED → "Discutido" (índigo), jamais "Pendente"', () => {
+    const cfg = getFeedbackStatusConfig('DISCUSSED');
+    expect(cfg.label).toBe('Discutido');
+    expect(cfg.label).not.toBe('Pendente');
+    expect(cfg.color).toContain('indigo');
+  });
+
+  it('OPEN → "Pendente"', () => {
+    expect(getFeedbackStatusConfig('OPEN').label).toBe('Pendente');
+  });
+
+  it('REVIEWED → "Revisado"', () => {
+    expect(getFeedbackStatusConfig('REVIEWED').label).toBe('Revisado');
+  });
+
+  it('QUESTION → "Dúvida"', () => {
+    expect(getFeedbackStatusConfig('QUESTION').label).toBe('Dúvida');
+  });
+
+  it('CLOSED → "Fechado" com cor própria (roxo), distinta de Pendente', () => {
+    const closed = getFeedbackStatusConfig('CLOSED');
+    const pending = getFeedbackStatusConfig('OPEN');
+    expect(closed.label).toBe('Fechado');
+    expect(closed.color).toContain('purple');
+    expect(closed.color).not.toBe(pending.color);
+  });
+
+  it('status desconhecido → fallback "Pendente" (comportamento preservado)', () => {
+    expect(getFeedbackStatusConfig('FOO_BAR').label).toBe('Pendente');
+    expect(getFeedbackStatusConfig(undefined).label).toBe('Pendente');
+  });
+});

--- a/src/components/TradeDetailModal.jsx
+++ b/src/components/TradeDetailModal.jsx
@@ -110,6 +110,7 @@ const StatusBadge = ({ status }) => {
     OPEN: { label: 'Aguardando', icon: Clock, bg: 'bg-blue-500/20', text: 'text-blue-400' },
     REVIEWED: { label: 'Revisado', icon: CheckCircle, bg: 'bg-emerald-500/20', text: 'text-emerald-400' },
     QUESTION: { label: 'Dúvida', icon: HelpCircle, bg: 'bg-amber-500/20', text: 'text-amber-400' },
+    DISCUSSED: { label: 'Discutido', icon: CheckCircle, bg: 'bg-indigo-500/20', text: 'text-indigo-300' }, // #333 — terminal #269 v2
     CLOSED: { label: 'Encerrado', icon: Lock, bg: 'bg-purple-500/20', text: 'text-purple-400' }
   };
 

--- a/src/components/TradesList.jsx
+++ b/src/components/TradesList.jsx
@@ -49,6 +49,7 @@ const StatusBadge = ({ status }) => {
     OPEN: { label: 'Aguardando', icon: Clock, bg: 'bg-slate-500/20', text: 'text-slate-400', border: 'border-slate-500/30' },
     REVIEWED: { label: 'Revisado', icon: CheckCircle, bg: 'bg-emerald-500/20', text: 'text-emerald-400', border: 'border-emerald-500/30' },
     QUESTION: { label: 'Dúvida', icon: HelpCircle, bg: 'bg-amber-500/20', text: 'text-amber-400', border: 'border-amber-500/30', animate: true },
+    DISCUSSED: { label: 'Discutido', icon: CheckCircle, bg: 'bg-indigo-500/20', text: 'text-indigo-300', border: 'border-indigo-500/30' }, // #333 — terminal #269 v2
     CLOSED: { label: 'Encerrado', icon: Lock, bg: 'bg-purple-500/20', text: 'text-purple-400', border: 'border-purple-500/30' }
   };
 

--- a/src/components/extract/ExtractTable.jsx
+++ b/src/components/extract/ExtractTable.jsx
@@ -88,18 +88,22 @@ const getTradeInlineEvents = (row, emotionalEvents) => {
   return events;
 };
 
-/** Badge de status do feedback do trade. */
-const getFeedbackStatusConfig = (status) => {
+/** Badge de status do feedback do trade. Exportado p/ teste de regressão (#333). */
+export const getFeedbackStatusConfig = (status) => {
   switch (status) {
     case 'REVIEWED':
       return { icon: CheckCircle2, color: 'text-emerald-400', label: 'Revisado', bg: 'bg-emerald-500/10' };
     case 'QUESTION':
       return { icon: HelpCircle, color: 'text-amber-400', label: 'Dúvida', bg: 'bg-amber-500/10' };
+    case 'DISCUSSED':
+      // #333 — status terminal do #269 v2 (revisado + discutido em revisão publicada).
+      // Espelha o TradeStatusBadge (índigo, "Discutido"). Antes caía no default → "Pendente".
+      return { icon: CheckCircle2, color: 'text-indigo-300', label: 'Discutido', bg: 'bg-indigo-500/10' };
     case 'CLOSED':
-      return { icon: CheckCheck, color: 'text-slate-500', label: 'Fechado', bg: 'bg-slate-500/10' };
+      return { icon: CheckCheck, color: 'text-purple-400', label: 'Fechado', bg: 'bg-purple-500/10' };
     case 'OPEN':
     default:
-      return { icon: CircleDot, color: 'text-slate-500', label: 'Pendente', bg: 'bg-slate-500/5' };
+      return { icon: CircleDot, color: 'text-slate-400', label: 'Pendente', bg: 'bg-slate-500/10' };
   }
 };
 

--- a/src/pages/FeedbackPage.jsx
+++ b/src/pages/FeedbackPage.jsx
@@ -94,6 +94,7 @@ const StatusBadge = ({ status }) => {
     OPEN: { label: 'Aguardando Revisão', icon: Clock, bg: 'bg-blue-500/20', text: 'text-blue-400', border: 'border-blue-500/30' },
     REVIEWED: { label: 'Revisado', icon: CheckCircle, bg: 'bg-emerald-500/20', text: 'text-emerald-400', border: 'border-emerald-500/30' },
     QUESTION: { label: 'Dúvida Pendente', icon: HelpCircle, bg: 'bg-amber-500/20', text: 'text-amber-400', border: 'border-amber-500/30' },
+    DISCUSSED: { label: 'Discutido', icon: CheckCircle, bg: 'bg-indigo-500/20', text: 'text-indigo-300', border: 'border-indigo-500/30' }, // #333 — terminal #269 v2 (antes caía no fallback OPEN → "Aguardando Revisão")
     CLOSED: { label: 'Encerrado', icon: Lock, bg: 'bg-purple-500/20', text: 'text-purple-400', border: 'border-purple-500/30' }
   };
   const cfg = config[status] || config.OPEN;

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.82.3: #333 fix trade DISCUSSED aparecia como "Pendente"/"Aguardando Revisão" — 4 badges de status (PR #TBD, 03/07/2026)
  * - 1.82.2: #331 fix SWOT em revisão DRAFT — CF aceita snapshot do cliente (PR #332, 03/07/2026)
  * - 1.82.1: #329 feat colapso na fila 'trades a refletir' quando há muitos pendentes (PR #330, 02/07/2026)
  * - 1.82.0: #327 feat fila 'trades a refletir' — cobra reflexão de fechados sem selfReview (PR #328, 02/07/2026)
@@ -382,10 +383,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.82.2',
+  version: '1.82.3',
   build: '20260703',
-  display: 'v1.82.2',
-  full: '1.82.2+20260703',
+  display: 'v1.82.3',
+  full: '1.82.3+20260703',
 };
 export default VERSION;
 export { VERSION };

--- a/src/version.js
+++ b/src/version.js
@@ -3,7 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
- * - 1.82.3: #333 fix trade DISCUSSED aparecia como "Pendente"/"Aguardando Revisão" — 4 badges de status (PR #TBD, 03/07/2026)
+ * - 1.82.3: #333 fix trade DISCUSSED aparecia como "Pendente"/"Aguardando Revisão" — 4 badges de status (PR #334, 03/07/2026)
  * - 1.82.2: #331 fix SWOT em revisão DRAFT — CF aceita snapshot do cliente (PR #332, 03/07/2026)
  * - 1.82.1: #329 feat colapso na fila 'trades a refletir' quando há muitos pendentes (PR #330, 02/07/2026)
  * - 1.82.0: #327 feat fila 'trades a refletir' — cobra reflexão de fechados sem selfReview (PR #328, 02/07/2026)


### PR DESCRIPTION
## Bug
Trade em `status: 'DISCUSSED'` (revisado + discutido numa revisão semanal publicada) aparecia como **'Pendente'** no extrato do plano e **'Aguardando Revisão'** na FeedbackPage — como se a revisão nunca tivesse sido feita.

## Causa-raiz
O #269 v2 introduziu o status terminal `DISCUSSED` (setado por `publishReview.js`), mas 4 mapeamentos de badge de status não o tratavam e caíam no fallback. O `TradeStatusBadge.jsx` (singular) já o tratava — era a SSoT de cor a espelhar.

## Fix (display puro)
- `ExtractTable.jsx` — case `DISCUSSED` → 'Discutido' (índigo); `getFeedbackStatusConfig` exportado p/ teste.
- `FeedbackPage.jsx`, `TradesList.jsx`, `TradeDetailModal.jsx` — config `DISCUSSED` adicionada.
- Recolor no extrato: 'Fechado' cinza → roxo (paridade 'Encerrado'); 'Pendente' com contraste (`slate-400`) — Pendente e Fechado deixam de compartilhar cor.
- `feedbackStatusConfig.test.js` (novo, 6 testes): trava DISCUSSED → 'Discutido' (nunca 'Pendente'), cores distintas, fallback preservado.

**Sem CF, sem Firestore, sem migração.** Suíte **3530/3530**, build ok.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)