### PR TITLE
fix(#335): DISCUSSED restante — seção Feedback do aluno + subcontagem no card do mentor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Version source of truth: `src/version.js`.
 
 ---
 
-## [1.82.4] - 03/07/2026 · #335 · PR #TBD
+## [1.82.4] - 03/07/2026 · #335 · PR #336
 
 **fix:** DISCUSSED restante — seção Feedback do aluno + subcontagem no card do mentor (follow-up #333)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Version source of truth: `src/version.js`.
 
 ---
 
+## [1.82.4] - 03/07/2026 · #335 · PR #TBD
+
+**fix:** DISCUSSED restante — seção Feedback do aluno + subcontagem no card do mentor (follow-up #333)
+
+- **`StudentFeedbackPage.jsx`** (seção Feedback do sidebar do aluno): `STATUS_CONFIG` não tratava `DISCUSSED` → badge caía no fallback OPEN e mostrava **"Pendente"**; contador e pills de filtro também o ignoravam. Agora config própria "Discutido" (índigo, ícone MessageSquare) + bucket no contador + pill de filtro.
+- **`MentorDashboard.jsx`** (`studentsWithPending`): `counts.reviewed` só somava `REVIEWED`; um trade `DISCUSSED` sumia do resumo "revisados" do card do mentor (`StudentFeedbackCard`). Agora DISCUSSED conta como revisado.
+- **`useTrades.js`** (`getStudentFeedbackCounts`): mesmo ajuste no bucket `reviewed`; enum `STATUS` local ganhou `DISCUSSED`.
+- Auditoria completa de todos os consumidores de `trade.status` — demais pontos (guards de pendência, awaiting-feedback, transições, badges de review) tratam DISCUSSED corretamente ou não devem incluí-lo.
+- `useTrades.test.js` +1: `getStudentFeedbackCounts` conta DISCUSSED como revisado.
+- Display/contagem puro — **sem CF, sem Firestore, sem migração**.
+
+
 ## [1.82.3] - 03/07/2026 · #333 · PR #334
 
 **fix:** trade DISCUSSED aparecia como "Pendente" / "Aguardando Revisão"

--- a/docs/registry/versions.md
+++ b/docs/registry/versions.md
@@ -63,3 +63,4 @@
 | 1.82.1 | #329 | `feat/issue-329-pending-reflections-collapse` | 02/07/2026 | consumida (PR #330 squash `07a5f8b9`) |
 | 1.82.2 | #331 | `fix/issue-331-swot-draft-snapshot` | 03/07/2026 | consumida (PR #332 squash `ee70704f`) |
 | 1.82.3 | #333 | `fix/issue-333-discussed-status-badge` | 03/07/2026 | consumida (PR #334 squash `54a065f1`) |
+| 1.82.4 | #335 | `fix/issue-335-discussed-status-remaining` | 03/07/2026 | reservada |

--- a/src/__tests__/hooks/useTrades.test.js
+++ b/src/__tests__/hooks/useTrades.test.js
@@ -157,6 +157,18 @@ describe('useTrades — selectors sobre allTrades', () => {
     });
   });
 
+  it('getStudentFeedbackCounts conta DISCUSSED como revisado (#333)', () => {
+    const { result } = renderMentorWith([
+      { id: 'd1', studentEmail: 'c@x.com', studentId: 'sc', status: 'REVIEWED' },
+      { id: 'd2', studentEmail: 'c@x.com', studentId: 'sc', status: 'DISCUSSED' },
+      { id: 'd3', studentEmail: 'c@x.com', studentId: 'sc', status: 'DISCUSSED' },
+    ]);
+    // DISCUSSED (terminal revisado+discutido) entra no bucket "reviewed", não some da contagem.
+    expect(result.current.getStudentFeedbackCounts('c@x.com')).toEqual({
+      open: 0, question: 0, reviewed: 3, closed: 0, total: 3,
+    });
+  });
+
   it('getTradesByStudentAndStatus cruza email + status', () => {
     const { result } = renderMentorWith(FIXTURE);
     expect(result.current.getTradesByStudentAndStatus('a@x.com', 'REVIEWED').map((t) => t.id)).toEqual(['t2']);

--- a/src/hooks/useTrades.js
+++ b/src/hooks/useTrades.js
@@ -56,7 +56,8 @@ const STATUS = {
   OPEN: 'OPEN',
   REVIEWED: 'REVIEWED',
   QUESTION: 'QUESTION',
-  CLOSED: 'CLOSED'
+  CLOSED: 'CLOSED',
+  DISCUSSED: 'DISCUSSED' // #269 v2 — terminal: revisado + discutido em revisão publicada
 };
 
 const DEFAULT_STATUS = STATUS.OPEN;
@@ -729,7 +730,8 @@ export const useTrades = (overrideStudentId = null) => {
     return {
       open: studentTrades.filter(t => t.status === STATUS.OPEN).length,
       question: studentTrades.filter(t => t.status === STATUS.QUESTION).length,
-      reviewed: studentTrades.filter(t => t.status === STATUS.REVIEWED).length,
+      // #333 — DISCUSSED conta como revisado (terminal revisado+discutido); antes subcontava.
+      reviewed: studentTrades.filter(t => t.status === STATUS.REVIEWED || t.status === STATUS.DISCUSSED).length,
       closed: studentTrades.filter(t => t.status === STATUS.CLOSED).length,
       total: studentTrades.length
     };

--- a/src/pages/MentorDashboard.jsx
+++ b/src/pages/MentorDashboard.jsx
@@ -119,7 +119,9 @@ const MentorDashboard = ({ currentView = 'dashboard', onViewChange, onNavigateTo
     allTrades.forEach(trade => {
       const email = trade.studentEmail;
       if (studentMap[email]) {
-        if (trade.status === 'REVIEWED') studentMap[email].counts.reviewed++;
+        // #333 — DISCUSSED (revisado + discutido em revisão publicada) conta como revisado;
+        // antes sumia do resumo "revisados" do card do mentor.
+        if (trade.status === 'REVIEWED' || trade.status === 'DISCUSSED') studentMap[email].counts.reviewed++;
         if (trade.status === 'CLOSED') studentMap[email].counts.closed++;
       }
     });

--- a/src/pages/StudentFeedbackPage.jsx
+++ b/src/pages/StudentFeedbackPage.jsx
@@ -39,8 +39,10 @@ import ExcursionDisplay from '../components/ExcursionDisplay';
 const STATUS_CONFIG = {
   QUESTION: { label: 'Dúvida', shortLabel: 'Dúvidas', icon: HelpCircle, bg: 'bg-amber-500/20', text: 'text-amber-400', ring: 'ring-amber-500/50', priority: 1 },
   REVIEWED: { label: 'Revisado', shortLabel: 'Revisados', icon: CheckCircle, bg: 'bg-emerald-500/20', text: 'text-emerald-400', ring: 'ring-emerald-500/50', priority: 2 },
-  OPEN: { label: 'Pendente', shortLabel: 'Pendentes', icon: Clock, bg: 'bg-blue-500/20', text: 'text-blue-400', ring: 'ring-blue-500/50', priority: 3 },
-  CLOSED: { label: 'Encerrado', shortLabel: 'Encerrados', icon: Lock, bg: 'bg-slate-500/20', text: 'text-slate-400', ring: 'ring-slate-500/50', priority: 4 }
+  // #333 — status terminal do #269 v2 (revisado + discutido em revisão publicada). Antes caía no fallback OPEN → "Pendente".
+  DISCUSSED: { label: 'Discutido', shortLabel: 'Discutidos', icon: MessageSquare, bg: 'bg-indigo-500/20', text: 'text-indigo-300', ring: 'ring-indigo-500/50', priority: 3 },
+  OPEN: { label: 'Pendente', shortLabel: 'Pendentes', icon: Clock, bg: 'bg-blue-500/20', text: 'text-blue-400', ring: 'ring-blue-500/50', priority: 4 },
+  CLOSED: { label: 'Encerrado', shortLabel: 'Encerrados', icon: Lock, bg: 'bg-slate-500/20', text: 'text-slate-400', ring: 'ring-slate-500/50', priority: 5 }
 };
 
 const PERIOD_OPTIONS = [
@@ -211,7 +213,7 @@ const StudentFeedbackPage = () => {
         t.mentorFeedback?.toLowerCase().includes(term)
       );
     }
-    const c = { all: base.length, QUESTION: 0, REVIEWED: 0, OPEN: 0, CLOSED: 0 };
+    const c = { all: base.length, QUESTION: 0, REVIEWED: 0, DISCUSSED: 0, OPEN: 0, CLOSED: 0 };
     base.forEach(t => {
       const s = t.status || 'OPEN';
       if (c[s] !== undefined) c[s]++;
@@ -288,7 +290,7 @@ const StudentFeedbackPage = () => {
             Meus Feedbacks
           </h1>
           <div className="flex items-center gap-1.5 ml-2">
-            {(['QUESTION', 'REVIEWED', 'OPEN', 'CLOSED']).map(key => (
+            {(['QUESTION', 'REVIEWED', 'DISCUSSED', 'OPEN', 'CLOSED']).map(key => (
               <StatusPill
                 key={key}
                 statusKey={key}

--- a/src/version.js
+++ b/src/version.js
@@ -3,7 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
- * - 1.82.4: #335 fix DISCUSSED restante — StudentFeedbackPage (badge/contador/pill) + card do mentor subcontava revisados (PR #TBD, 03/07/2026)
+ * - 1.82.4: #335 fix DISCUSSED restante — StudentFeedbackPage (badge/contador/pill) + card do mentor subcontava revisados (PR #336, 03/07/2026)
  * - 1.82.3: #333 fix trade DISCUSSED aparecia como "Pendente"/"Aguardando Revisão" — 4 badges de status (PR #334, 03/07/2026)
  * - 1.82.2: #331 fix SWOT em revisão DRAFT — CF aceita snapshot do cliente (PR #332, 03/07/2026)
  * - 1.82.1: #329 feat colapso na fila 'trades a refletir' quando há muitos pendentes (PR #330, 02/07/2026)

--- a/src/version.js
+++ b/src/version.js
@@ -3,6 +3,7 @@
  * @description Versão do produto Acompanhamento 2.0
  *
  * CHANGELOG:
+ * - 1.82.4: #335 fix DISCUSSED restante — StudentFeedbackPage (badge/contador/pill) + card do mentor subcontava revisados (PR #TBD, 03/07/2026)
  * - 1.82.3: #333 fix trade DISCUSSED aparecia como "Pendente"/"Aguardando Revisão" — 4 badges de status (PR #334, 03/07/2026)
  * - 1.82.2: #331 fix SWOT em revisão DRAFT — CF aceita snapshot do cliente (PR #332, 03/07/2026)
  * - 1.82.1: #329 feat colapso na fila 'trades a refletir' quando há muitos pendentes (PR #330, 02/07/2026)
@@ -383,10 +384,10 @@
  * - 1.15.0: Multi-currency (#40), account plan accordion (#39), dashboard partition
  */
 const VERSION = {
-  version: '1.82.3',
+  version: '1.82.4',
   build: '20260703',
-  display: 'v1.82.3',
-  full: '1.82.3+20260703',
+  display: 'v1.82.4',
+  full: '1.82.4+20260703',
 };
 export default VERSION;
 export { VERSION };


### PR DESCRIPTION
Follow-up do #333. A seção **Feedback** do sidebar do aluno ainda mostrava trades `DISCUSSED` como **'Pendente'**, e o card do mentor subcontava 'revisados'.

## Fix
- **`StudentFeedbackPage.jsx`** — `STATUS_CONFIG` ganhou `DISCUSSED` ('Discutido', índigo, `MessageSquare`); DISCUSSED entra no contador e vira pill de filtro. (sintoma reportado)
- **`MentorDashboard.jsx`** (`studentsWithPending`) — `DISCUSSED` conta como 'revisado' no resumo do card; antes sumia.
- **`useTrades.js`** — `getStudentFeedbackCounts` bucket `reviewed` inclui DISCUSSED; enum `STATUS` local ganhou `DISCUSSED`.

Auditoria completa dos consumidores de `trade.status`: os demais (guards de pendência, awaiting-feedback, transições, badges de review) tratam DISCUSSED corretamente ou não devem incluí-lo.

`useTrades.test.js` +1. **Sem CF, sem Firestore, sem migração.** Suíte **3531/3531**, build ok.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)