### PR TITLE
fix(#337): TPS fator Consistência real (CV normalizado) + fim do placeholder 0,70

### DIFF
--- a/src/__tests__/utils/cycleClosure/tradingPerformanceScore.test.js
+++ b/src/__tests__/utils/cycleClosure/tradingPerformanceScore.test.js
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import {
   computeTPS,
   computeWinRateConsistency,
+  cvToConsistencyNorm,
   TPS_WEIGHTS,
   TPS_MAX_ACCEPTABLE_DD,
 } from '../../../utils/cycleClosure/tradingPerformanceScore';
@@ -139,6 +140,80 @@ describe('computeTPS — missing fields', () => {
     });
     expect(tps.score).toBeNull();
     expect(tps.missing).toHaveLength(5);
+  });
+});
+
+describe('cvToConsistencyNorm — #337 (CV normalizado → score 0..1)', () => {
+  it('value ≤ 1,0 (no plano ou mais suave) → 1,0', () => {
+    expect(cvToConsistencyNorm(1.0)).toBe(1);
+    expect(cvToConsistencyNorm(0.5)).toBe(1);   // "suspeito" não é punido
+    expect(cvToConsistencyNorm(0.0)).toBe(1);
+  });
+  it('meio da faixa errática → parcial', () => {
+    expect(cvToConsistencyNorm(1.5)).toBeCloseTo(0.5, 6);
+    expect(cvToConsistencyNorm(1.25)).toBeCloseTo(0.75, 6);
+  });
+  it('value ≥ 2,0 (muito errático) → 0', () => {
+    expect(cvToConsistencyNorm(2.0)).toBe(0);
+    expect(cvToConsistencyNorm(3.0)).toBe(0);   // clamp
+  });
+  it('null/NaN/inválido → null (fator vira missing)', () => {
+    expect(cvToConsistencyNorm(null)).toBeNull();
+    expect(cvToConsistencyNorm(undefined)).toBeNull();
+    expect(cvToConsistencyNorm(NaN)).toBeNull();
+    expect(cvToConsistencyNorm('1.0')).toBeNull();
+  });
+});
+
+describe('computeTPS — renormalização de pesos (#337)', () => {
+  it('nada faltando → pesos efetivos = nominais (bit-exato)', () => {
+    const tps = computeTPS({
+      profitFactor: 3, maxDDPercent: 0, expectancy_R: 0.5,
+      winRateConsistency: 1, ruleAdherenceRate: 1,
+    });
+    expect(tps.weights.pf).toBe(TPS_WEIGHTS.profitFactor);
+    expect(tps.weights.dd).toBe(TPS_WEIGHTS.drawdown);
+    expect(tps.weights.consistency).toBe(TPS_WEIGHTS.consistency);
+    expect(tps.score).toBe(100);           // todos os fatores no máximo
+  });
+
+  it('consistência ausente → peso 0,15 redistribuído; sem crédito fantasma nem zero injusto', () => {
+    const tps = computeTPS({
+      profitFactor: 3, maxDDPercent: 0, expectancy_R: 0.5,
+      winRateConsistency: null, ruleAdherenceRate: 1,
+    });
+    // demais fatores no máximo → nota 100 mesmo sem consistência (renormaliza sobre 0,85)
+    expect(tps.score).toBeCloseTo(100, 6);
+    expect(tps.weights.consistency).toBe(0);
+    expect(tps.breakdown.consistency).toBe(0);
+    expect(tps.missing).toContain('winRateConsistency');
+    // peso efetivo do PF sobe de 0,20 → 0,20/0,85
+    expect(tps.weights.pf).toBeCloseTo(0.20 / 0.85, 6);
+    // soma dos pesos efetivos = 1
+    const sumW = Object.values(tps.weights).reduce((s, v) => s + v, 0);
+    expect(sumW).toBeCloseTo(1.0, 6);
+  });
+
+  it('renormalização mantém breakdown somando = score/100', () => {
+    const tps = computeTPS({
+      profitFactor: 1.5, maxDDPercent: 0.02, expectancy_R: 0.3,
+      winRateConsistency: null, ruleAdherenceRate: 0.8,
+    });
+    const total = Object.values(tps.breakdown).reduce((s, v) => s + v, 0);
+    expect(total * 100).toBeCloseTo(tps.score, 6);
+  });
+
+  it('placeholder morto: consistência null não injeta mais 0,70 fixo', () => {
+    // Com consistência ruim explícita (0) a nota é MENOR do que quando o fator é ignorado (null).
+    const comConsistenciaRuim = computeTPS({
+      profitFactor: 3, maxDDPercent: 0, expectancy_R: 0.5,
+      winRateConsistency: 0, ruleAdherenceRate: 1,
+    });
+    const semDado = computeTPS({
+      profitFactor: 3, maxDDPercent: 0, expectancy_R: 0.5,
+      winRateConsistency: null, ruleAdherenceRate: 1,
+    });
+    expect(comConsistenciaRuim.score).toBeLessThan(semDado.score);
   });
 });
 

--- a/src/components/cycleClosure/steps/Step1Read.jsx
+++ b/src/components/cycleClosure/steps/Step1Read.jsx
@@ -19,8 +19,7 @@ import {
 } from '../../../utils/cycleClosure/cycleMetrics';
 import {
   computeTPS,
-  computeWinRateConsistency,
-  TPS_WEIGHTS,
+  cvToConsistencyNorm,
 } from '../../../utils/cycleClosure/tradingPerformanceScore';
 import {
   MetricTile,
@@ -60,7 +59,10 @@ function tpsComponentTone(filled) {
   return 'emerald';
 }
 
-function TPSComponentCard({ label, rawValue, ptsGot, ptsMax, filled, hint, missing }) {
+// #337 — o card mostra só a CONTRIBUIÇÃO do fator (pts ganhos / pts do peso efetivo) + barra de
+// preenchimento; o valor bruto da métrica NÃO é repetido aqui (já aparece no tile de Performance
+// / Consistência Operacional acima). Isto é o "porquê da nota", não uma segunda cópia dos números.
+function TPSComponentCard({ label, ptsGot, ptsMax, filled, hint, missing }) {
   const tone = missing ? 'slate' : tpsComponentTone(filled);
   const toneMap = {
     red:     { border: 'border-red-500/30',     bar: 'bg-red-500',     text: 'text-red-300' },
@@ -69,31 +71,36 @@ function TPSComponentCard({ label, rawValue, ptsGot, ptsMax, filled, hint, missi
     slate:   { border: 'border-slate-700/40',   bar: 'bg-slate-600',   text: 'text-slate-400' },
   };
   const c = toneMap[tone];
-  const pct = missing ? 0 : Math.round(filled * 100);
+  const pct = missing ? 0 : Math.round(clamp01Pct(filled) * 100);
 
   return (
     <div className={`bg-slate-800/30 rounded-xl p-3 border ${c.border}`}>
-      <div className="flex items-baseline justify-between gap-2 mb-1">
+      <div className="flex items-baseline justify-between gap-2 mb-2">
         <p className="text-[11px] text-slate-400 leading-tight">{label}</p>
         <p className={`text-[11px] mono font-semibold ${c.text}`}>
-          {missing ? 'sem dado' : `${ptsGot.toFixed(1)}/${ptsMax} pts`}
+          {missing ? 'sem dado' : `${ptsGot.toFixed(1)}/${ptsMax.toFixed(0)} pts`}
         </p>
       </div>
-      <p className="text-base font-bold text-slate-100 mono mb-2">
-        {missing ? '—' : rawValue}
-      </p>
       <div className="h-1.5 bg-slate-900/60 rounded-full overflow-hidden">
         <div
           className={`h-full ${c.bar} transition-all`}
           style={{ width: `${pct}%` }}
         />
       </div>
-      {!missing && hint && filled < 0.5 && (
-        <p className="text-[10px] text-slate-500 mt-1.5 leading-tight">{hint}</p>
+      {missing ? (
+        <p className="text-[10px] text-slate-500 mt-1.5 leading-tight">
+          sem dados suficientes — peso redistribuído nos demais fatores
+        </p>
+      ) : (
+        hint && filled < 0.5 && (
+          <p className="text-[10px] text-slate-500 mt-1.5 leading-tight">{hint}</p>
+        )
       )}
     </div>
   );
 }
+
+const clamp01Pct = (v) => (Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : 0);
 
 export default function Step1Read({ studentId, planId, cycleStart, cycleEnd, onSnapshot, onMetrics }) {
   const { trades = [], loading: tradesLoading } = useTrades(studentId);
@@ -159,13 +166,15 @@ export default function Step1Read({ studentId, planId, cycleStart, cycleEnd, onS
   }, [cycleTrades, plan]);
 
   // TPS
+  // #337 — consistência vem do CV normalizado do ciclo (mesma SSoT do tile "CV norm." acima),
+  // não mais do placeholder 0,7. CV null (ciclo curto/sem RR alvo) → fator missing → TPS renormaliza.
   const tpsInput = useMemo(() => ({
     profitFactor: metrics.profitFactor,
     maxDDPercent: Math.abs(maxDD.percent),
     expectancy_R: metrics.expectancy_R,
-    winRateConsistency: 0.7,    // placeholder — TODO A5.x: bucketize cycleTrades por semana
+    winRateConsistency: cvToConsistencyNorm(consistency.cvNormalized?.value ?? null),
     ruleAdherenceRate,
-  }), [metrics, maxDD, ruleAdherenceRate]);
+  }), [metrics, maxDD, ruleAdherenceRate, consistency.cvNormalized]);
 
   const tps = useMemo(() => computeTPS(tpsInput), [tpsInput]);
 
@@ -349,7 +358,7 @@ export default function Step1Read({ studentId, planId, cycleStart, cycleEnd, onS
           <div>
             <h4 className="text-sm font-semibold text-slate-200">Nota geral do ciclo</h4>
             <p className="text-[11px] text-slate-500">
-              de 0 a 100 · combina lucro÷prejuízo, queda do capital, ganho médio, taxa de acerto e disciplina
+              de 0 a 100 · combina lucro÷prejuízo, queda do capital, ganho médio (R), consistência dos retornos e disciplina
             </p>
           </div>
           <p className="text-3xl font-bold gradient-text mono">
@@ -377,55 +386,36 @@ export default function Step1Read({ studentId, planId, cycleStart, cycleEnd, onS
               Ver composição (peso de cada fator no total de 100)
             </summary>
             <div className="grid grid-cols-2 md:grid-cols-5 gap-2 mt-3">
-              <TPSComponentCard
-                label="Profit Factor"
-                rawValue={metrics.profitFactor != null ? metrics.profitFactor.toFixed(2) : '—'}
-                ptsGot={tps.breakdown.pf * 100}
-                ptsMax={TPS_WEIGHTS.profitFactor * 100}
-                filled={tps.breakdown.pf / TPS_WEIGHTS.profitFactor}
-                missing={tps.missing.includes('profitFactor')}
-                hint="ganhos médios menores que perdas — alvo escalonado ou alvo maior"
-              />
-              <TPSComponentCard
-                label="Max Drawdown"
-                rawValue={`${(Math.abs(maxDD.percent) * 100).toFixed(1)}%`}
-                ptsGot={tps.breakdown.dd * 100}
-                ptsMax={TPS_WEIGHTS.drawdown * 100}
-                filled={tps.breakdown.dd / TPS_WEIGHTS.drawdown}
-                missing={tps.missing.includes('maxDDPercent')}
-                hint="ficou perto/passou do stop — reduzir size ou parar antes"
-              />
-              <TPSComponentCard
-                label="Expectancy (R)"
-                rawValue={metrics.expectancy_R != null ? `${metrics.expectancy_R >= 0 ? '+' : ''}${metrics.expectancy_R.toFixed(2)}R` : '—'}
-                ptsGot={tps.breakdown.exp * 100}
-                ptsMax={TPS_WEIGHTS.expectancy * 100}
-                filled={tps.breakdown.exp / TPS_WEIGHTS.expectancy}
-                missing={tps.missing.includes('expectancy_R')}
-                hint="< 0,5R por trade — saiu cedo dos vencedores"
-              />
-              <TPSComponentCard
-                label="Consistência semanal"
-                rawValue={`${tpsInput.winRateConsistency.toFixed(2)} (placeholder)`}
-                ptsGot={tps.breakdown.consistency * 100}
-                ptsMax={TPS_WEIGHTS.consistency * 100}
-                filled={tps.breakdown.consistency / TPS_WEIGHTS.consistency}
-                missing={tps.missing.includes('winRateConsistency')}
-                hint="winrate semanal oscila muito — buscar regime estável"
-              />
-              <TPSComponentCard
-                label="Aderência"
-                rawValue={ruleAdherenceRate != null ? `${(ruleAdherenceRate * 100).toFixed(1)}%` : '—'}
-                ptsGot={tps.breakdown.rule * 100}
-                ptsMax={TPS_WEIGHTS.rule * 100}
-                filled={tps.breakdown.rule / TPS_WEIGHTS.rule}
-                missing={tps.missing.includes('ruleAdherenceRate')}
-                hint="violações de RO/RR — gate na entrada antes do envio"
-              />
+              {[
+                { key: 'pf', label: 'Profit Factor', missKey: 'profitFactor',
+                  hint: 'ganhos médios menores que perdas — alvo escalonado ou alvo maior' },
+                { key: 'dd', label: 'Max Drawdown', missKey: 'maxDDPercent',
+                  hint: 'ficou perto/passou do stop — reduzir size ou parar antes' },
+                { key: 'exp', label: 'Expectancy (R)', missKey: 'expectancy_R',
+                  hint: '< 0,5R por trade — saiu cedo dos vencedores' },
+                { key: 'consistency', label: 'Consistência', missKey: 'winRateConsistency',
+                  hint: 'retornos oscilando além do plano — buscar regime mais estável' },
+                { key: 'rule', label: 'Aderência', missKey: 'ruleAdherenceRate',
+                  hint: 'violações de RO/RR — gate na entrada antes do envio' },
+              ].map(({ key, label, missKey, hint }) => {
+                const w = tps.weights?.[key] ?? 0;
+                return (
+                  <TPSComponentCard
+                    key={key}
+                    label={label}
+                    ptsGot={tps.breakdown[key] * 100}
+                    ptsMax={w * 100}
+                    filled={w > 0 ? tps.breakdown[key] / w : 0}
+                    missing={tps.missing.includes(missKey)}
+                    hint={hint}
+                  />
+                );
+              })}
             </div>
             <p className="text-[10px] text-slate-600 mt-2 leading-relaxed">
-              Cards em vermelho puxam a nota pra baixo; em verde, sustentam.
-              Soma das contribuições = nota final.
+              Cada card é a contribuição do fator (pts ganhos / peso). Vermelho puxa a nota pra baixo;
+              verde sustenta. Soma das contribuições = nota final. Fator sem dado tem o peso
+              redistribuído nos demais.
             </p>
           </details>
         )}

--- a/src/utils/cycleClosure/tradingPerformanceScore.js
+++ b/src/utils/cycleClosure/tradingPerformanceScore.js
@@ -9,9 +9,14 @@
  *   TPS = clamp(profitFactor / 3, 0, 1) × 0.20
  *       + (1 - maxDDPercent / 0.05) × 0.25       # maxAcceptableDD = cap fixo 5% (Q3)
  *       + clamp(expectancy_R / 0.5, 0, 1) × 0.20
- *       + winRateConsistency        × 0.15        # weekly/daily buckets
+ *       + consistency               × 0.15        # #337: CV normalizado (cvToConsistencyNorm)
  *       + ruleAdherenceRate         × 0.20        # peso ↑ Mark Douglas
  *       × 100
+ *
+ * #337 — o fator consistência passou a vir do CV normalizado do ciclo (SSoT useCycleConsistency)
+ * via cvToConsistencyNorm, substituindo o placeholder fixo 0.7. Quando um fator não-crítico não
+ * tem dado, os PESOS são renormalizados sobre os presentes (não há mais crédito 0 fantasma) —
+ * ver computeTPS. PF e ruleAdherenceRate seguem obrigatórios.
  */
 
 const WEIGHTS = Object.freeze({
@@ -25,6 +30,28 @@ const WEIGHTS = Object.freeze({
 const MAX_ACCEPTABLE_DD = 0.05;   // 5% — cap fixo (Q3)
 
 const clamp01 = (v) => Math.max(0, Math.min(1, v));
+
+const CV_ON_PLAN_TOP = 1.0;       // ≤ isto = consistência total (no plano ou mais suave)
+const CV_ERRATIC_CEILING = 2.0;   // "muito errático" (bandas cvTheme) = consistência zero
+
+/**
+ * cvToConsistencyNorm — mapeia o CV normalizado do ciclo (SSoT `useCycleConsistency`,
+ * centrado em ~1,0 = "no plano") para o score 0..1 do fator Consistência do TPS.
+ *
+ * O CV é `cvObservado / cvEsperado`: 1,0 = exatamente o esperado; quanto maior, mais errático.
+ * Mapa: `clamp01((2 - value) / 1)` — value ≤ 1 (no plano ou mais suave) → 1,0 (crédito total;
+ * "<0,5 suspeito" é flag de qualidade de dado, não punição de nota); 1,5 → 0,5; ≥ 2,0 → 0.
+ * O 2,0 é a fronteira "muito errático" já usada nas bandas de `cvTheme` (cycleMetricTiles) —
+ * sem constante mágica nova. `null`/inválido → `null` (fator vira missing → TPS renormaliza).
+ *
+ * @param {number|null} cvValue — `cvNormalized.value` (ou null quando insuficiente)
+ * @returns {number|null} 0..1 ou null
+ * @issue #337 — substitui o placeholder `winRateConsistency: 0.7`.
+ */
+export function cvToConsistencyNorm(cvValue) {
+  if (typeof cvValue !== 'number' || !Number.isFinite(cvValue)) return null;
+  return clamp01((CV_ERRATIC_CEILING - cvValue) / (CV_ERRATIC_CEILING - CV_ON_PLAN_TOP));
+}
 
 /**
  * @param {Object} input
@@ -84,22 +111,37 @@ export function computeTPS({ profitFactor, maxDDPercent, expectancy_R, winRateCo
 
   // Score só se tiver pelo menos PF e Rule (os 2 mais críticos do framework Mark Douglas)
   if (pfNorm === null || ruleNorm === null) {
-    return { score: null, breakdown: null, missing };
+    return { score: null, breakdown: null, weights: null, missing };
   }
 
-  const breakdown = {
-    pf:          (pfNorm ?? 0) * WEIGHTS.profitFactor,
-    dd:          (ddNorm ?? 0) * WEIGHTS.drawdown,
-    exp:         (expNorm ?? 0) * WEIGHTS.expectancy,
-    consistency: (consistencyNorm ?? 0) * WEIGHTS.consistency,
-    rule:        (ruleNorm ?? 0) * WEIGHTS.rule,
-  };
+  // #337 — pesos EFETIVOS: quando um fator não tem dado (ex.: CV null em ciclo curto), seu peso
+  // não vira crédito fantasma (placeholder) nem zero injusto — é redistribuído proporcionalmente
+  // sobre os fatores presentes (soma dos pesos efetivos = 1). Caso completo mantém o peso NOMINAL
+  // bit-a-bit (sem divisão), preservando compat exata do score histórico.
+  const norms = { pf: pfNorm, dd: ddNorm, exp: expNorm, consistency: consistencyNorm, rule: ruleNorm };
+  const WKEY = { pf: 'profitFactor', dd: 'drawdown', exp: 'expectancy', consistency: 'consistency', rule: 'rule' };
+  const keys = Object.keys(norms);
+  const presentKeys = keys.filter((k) => norms[k] !== null);
+  const allPresent = presentKeys.length === keys.length;
+  const presentWeightSum = presentKeys.reduce((s, k) => s + WEIGHTS[WKEY[k]], 0);
+
+  const weights = {};
+  const breakdown = {};
+  for (const k of keys) {
+    if (norms[k] === null) {
+      weights[k] = 0;
+      breakdown[k] = 0;
+    } else {
+      weights[k] = allPresent ? WEIGHTS[WKEY[k]] : WEIGHTS[WKEY[k]] / presentWeightSum;
+      breakdown[k] = norms[k] * weights[k];
+    }
+  }
 
   const score =
     100 *
     (breakdown.pf + breakdown.dd + breakdown.exp + breakdown.consistency + breakdown.rule);
 
-  return { score, breakdown, missing };
+  return { score, breakdown, weights, missing };
 }
 
 /**


### PR DESCRIPTION
## Problema
Na etapa 1 do Fechamento de Ciclo, a **'Nota geral do ciclo' (TPS 0–100)** tinha dois defeitos:

1. **Indicador falso:** o fator 'Consistência semanal' era `winRateConsistency: 0.7` **chumbado** (`Step1Read.jsx:166`, TODO A5.x nunca fechado). Mostrava 10,5/15 pts fixos pra **todo aluno**, inflando o score — inaceitável num placar cujo propósito é passar confiança.
2. **Duplicação:** dos 5 cards da composição, 4 (PF, DD, Expectancy, Aderência) copiavam os tiles do bloco 'Performance' logo acima; e o 5º duplicava o conceito de consistência que o bloco 'Consistência Operacional' (Sharpe/CV) já mede de verdade.

## Correção
- **Consistência real:** `cvToConsistencyNorm(cvValue)` mapeia o **CV normalizado do ciclo** (SSoT `useCycleConsistency`, mesma fonte do tile 'CV norm.') para 0..1 — `clamp01((2 - value)/1)`: value ≤ 1 (no plano/mais suave) → 1,0; = 1,5 → 0,5; ≥ 2,0 (muito errático) → 0. O 2,0 é a fronteira 'muito errático' já existente nas bandas de `cvTheme`. Mata o placeholder **e** a duplicação de conceito (uma consistência só).
- **Renormalização:** quando um fator não-crítico não tem dado (ex.: CV null em ciclo curto), `computeTPS` **redistribui o peso** proporcionalmente sobre os presentes — nada de crédito 0,70 fantasma nem zero injusto. Caso completo mantém peso nominal bit-exato. PF + Aderência seguem obrigatórios.
- **Composição enxuta:** os 5 cards param de reimprimir o valor bruto (já está no tile acima) — mostram só **contribuição em pts / peso efetivo** ('por que a nota'). Fator sem dado → 'sem dado' + aviso de redistribuição.

## Memória de cálculo
Em `docs/dev/issues/issue-337-tps-consistency-real.md` + docstring de `tradingPerformanceScore.js`.

## Testes
`tradingPerformanceScore.test.js`: +12 (cvToConsistencyNorm 4 · renormalização 4 · placeholder morto 1 · pesos efetivos). Compat exata dos testes históricos (renorm = identidade quando nada falta). Suíte **src 3539 verde**, build ok.

Closes #337