### PR TITLE
fix(#341): Contas do mentor esconde alunos sem assinatura ativa

### DIFF
--- a/docs/dev/issues/issue-341-contas-assinatura-ativa.md
+++ b/docs/dev/issues/issue-341-contas-assinatura-ativa.md
@@ -1,0 +1,60 @@
+# Issue #341 — fix: Contas do mentor lista alunos sem assinatura ativa
+
+## Autorização (OBRIGATÓRIA)
+
+**Status atual do documento:**
+- [x] Mockup apresentado (abaixo — modificação de UI trivial: filtro de visibilidade)
+- [x] Memória de cálculo apresentada (regra de filtro, abaixo)
+- [x] Marcio autorizou (19/07/2026 — "vai")
+- [x] Gate Pré-Código liberado
+
+## Context
+A seção **Contas** (visão do mentor) lista todos os alunos que já tiveram conta,
+inclusive inativos/ex-alunos/órfãos. Objetivo: mostrar só alunos com assinatura
+ativa, com paridade de critério à tela de Acompanhamento.
+
+## Spec
+Ver issue body no GitHub: #341.
+
+## Mockup
+Tela `AccountsPage` (mentor), grid de `StudentAccountGroup`.
+
+- **Antes:** N grupos = todo `studentId` distinto presente em `accounts` (+ grupo
+  `unknown` de conta órfã sem `studentId`).
+- **Depois:** só grupos cujo aluno tem `classifyStudent(student, subs) !== null`.
+  VIP ativo, sem-sub, expired/cancelled e `unknown` desaparecem.
+- Busca (searchTerm) opera sobre o conjunto já filtrado.
+- Caminho do aluno (`!isMentor()`) inalterado — vê só as próprias contas.
+- Estado vazio: se nenhum grupo sobra, o grid fica vazio (comportamento atual do
+  grid, sem mensagem nova nesta issue).
+
+## Memória de Cálculo
+- **Inputs:**
+  - `accounts` (via `useAccounts`, modo mentor = todas) — agrupadas por `acc.studentId`.
+  - `students` (via `useStudents`) — doc do aluno por `id`.
+  - `subscriptions` (via `useSubscriptions`) — subs enriquecidas com `studentId` + status canônico.
+- **Regra:** `studentId` é visível ⇔ `classifyStudent(student, subsDoAluno) !== null`.
+  - `classifyStudent` retorna `null` para VIP ativo e para ausência de sub Alpha/Espelho/Trial ativa.
+  - Paridade exata com o Acompanhamento (mesma fonte/shape de `subs`) — ref. negativa #316
+    (assinaturas divergentes de `classifyStudent` front/back).
+- **Casos limites:**
+  - `studentId === 'unknown'` (conta órfã) → sem doc de aluno → `null` → escondido.
+  - Aluno com conta mas sem doc em `students` → `null` → escondido.
+  - Sub `overdue` (grace): classifyStudent trata conforme `findActiveSub`/`ENDED_STATUSES`
+    — replicar o comportamento do Acompanhamento, não reinventar.
+
+## Phases
+1. Teste do filtro (util puro `visibleStudentIds` ou seleção equivalente) — antes da UI.
+2. Fix em `AccountsPage.jsx` (caminho mentor): filtrar `groupedAccounts`/`filteredGroups`.
+3. Build + suíte verdes. PR com `Closes #341`.
+
+## Shared Deltas
+Nenhum além do lock/reserva já feitos no main (v1.83.1, CHUNK-16).
+
+## Decisions
+- Critério = `classifyStudent` (paridade Acompanhamento); VIP escondido — decisão de Marcio (AskUserQuestion 19/07).
+- Inativos escondidos por completo (não seção separada) — decisão de Marcio (idem).
+
+## Chunks
+- CHUNK-16 (Mentor Cockpit) — ESCRITA (lock ativo).
+- CHUNK-02 (`classifyStudent`, `students`) — leitura.

--- a/src/__tests__/utils/mentorAccountsVisibility.test.js
+++ b/src/__tests__/utils/mentorAccountsVisibility.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { visibleStudentIds } from '../../utils/mentorAccountsVisibility';
+
+// Fixtures de sub — shape idêntica ao que useSubscriptions entrega (status já enriquecido).
+const sub = (studentId, over = {}) => ({
+  studentId,
+  status: 'active',
+  type: 'paid',
+  plan: 'alpha',
+  renewalDate: new Date('2099-01-01'),
+  ...over,
+});
+
+describe('visibleStudentIds (#341 — Contas do mentor)', () => {
+  it('inclui aluno com sub Alpha paga ativa', () => {
+    const students = [{ id: 'a' }];
+    const subs = [sub('a')];
+    expect(visibleStudentIds(students, subs).has('a')).toBe(true);
+  });
+
+  it('inclui Espelho (self_service pago) e Trial de alpha', () => {
+    const students = [{ id: 'esp' }, { id: 'tri' }];
+    const subs = [
+      sub('esp', { plan: 'self_service' }),
+      sub('tri', { type: 'trial', status: 'trial', trialEndsAt: new Date('2099-01-01') }),
+    ];
+    const v = visibleStudentIds(students, subs);
+    expect(v.has('esp')).toBe(true);
+    expect(v.has('tri')).toBe(true);
+  });
+
+  it('esconde VIP ativo (classifyStudent → null)', () => {
+    const students = [{ id: 'vip' }];
+    const subs = [sub('vip', { type: 'vip', plan: 'none' })];
+    expect(visibleStudentIds(students, subs).has('vip')).toBe(false);
+  });
+
+  it('esconde aluno sem nenhuma sub', () => {
+    const students = [{ id: 'nada' }];
+    expect(visibleStudentIds(students, []).has('nada')).toBe(false);
+  });
+
+  it('esconde aluno só com sub expired/cancelled', () => {
+    const students = [{ id: 'exp' }, { id: 'can' }];
+    const subs = [
+      sub('exp', { status: 'expired' }),
+      sub('can', { status: 'cancelled' }),
+    ];
+    const v = visibleStudentIds(students, subs);
+    expect(v.has('exp')).toBe(false);
+    expect(v.has('can')).toBe(false);
+  });
+
+  it('mantém aluno overdue (grace) — paridade com Acompanhamento', () => {
+    const students = [{ id: 'ovd' }];
+    const subs = [sub('ovd', { status: 'overdue' })];
+    expect(visibleStudentIds(students, subs).has('ovd')).toBe(true);
+  });
+
+  it('não inclui studentId órfão (sub sem doc de aluno) — grupo "unknown" some', () => {
+    const students = [{ id: 'a' }];
+    const subs = [sub('a'), sub('unknown')];
+    const v = visibleStudentIds(students, subs);
+    expect(v.has('a')).toBe(true);
+    expect(v.has('unknown')).toBe(false);
+  });
+
+  it('esconde aluno com conta mas sem sub atribuída (doc existe, subs vazias)', () => {
+    const students = [{ id: 'semSub' }];
+    const subs = [sub('outro')];
+    expect(visibleStudentIds(students, subs).has('semSub')).toBe(false);
+  });
+
+  it('ignora sub sem studentId e é resiliente a entradas nulas', () => {
+    expect(visibleStudentIds(null, null).size).toBe(0);
+    expect(visibleStudentIds([{ id: 'a' }], [{ status: 'active', type: 'paid', plan: 'alpha' }]).has('a')).toBe(false);
+  });
+});

--- a/src/pages/AccountsPage.jsx
+++ b/src/pages/AccountsPage.jsx
@@ -22,6 +22,9 @@ import { useAuth } from '../contexts/AuthContext';
 import { usePlans } from '../hooks/usePlans';
 import { useTrades } from '../hooks/useTrades';
 import { usePropFirmTemplates } from '../hooks/usePropFirmTemplates';
+import { useStudents } from '../hooks/useStudents';
+import { useSubscriptions } from '../hooks/useSubscriptions';
+import { visibleStudentIds } from '../utils/mentorAccountsVisibility';
 import {
   PROP_FIRM_LABELS,
   PROP_FIRM_PHASES,
@@ -640,7 +643,17 @@ const AccountsPage = ({ initialAccount = null, onInitialConsumed } = {}) => {
       </div>
 
       {isMentor() ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">{Object.entries(filteredGroups).map(([studentId, data]) => (<StudentAccountGroup key={studentId} studentName={data.studentName} studentEmail={data.studentEmail} accounts={data.accounts} plans={plans} trades={trades} balancesByAccountId={balancesByAccountId} onAccountClick={setSelectedAccount} onEditAccount={openModal} onEditPlan={handleOpenEditPlan} getAccountBadge={getAccountBadge} formatCurrency={formatCurrency} />))}</div>
+        <MentorAccountsGrid
+          groups={filteredGroups}
+          plans={plans}
+          trades={trades}
+          balancesByAccountId={balancesByAccountId}
+          onAccountClick={setSelectedAccount}
+          onEditAccount={openModal}
+          onEditPlan={handleOpenEditPlan}
+          getAccountBadge={getAccountBadge}
+          formatCurrency={formatCurrency}
+        />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {accounts.map(acc => {
@@ -1024,6 +1037,60 @@ const AccountsPage = ({ initialAccount = null, onInitialConsumed } = {}) => {
       )}
       <DebugBadge component="AccountsPage" />
       {confirmDialog}
+    </div>
+  );
+};
+
+/**
+ * MentorAccountsGrid — grid de contas por aluno (visão do mentor).
+ * Monta useStudents/useSubscriptions APENAS aqui (renderizado só quando isMentor()),
+ * para o caminho do aluno nunca disparar listeners em /students ou collectionGroup.
+ * Aplica o filtro de visibilidade (#341): esconde grupos sem assinatura ativa.
+ */
+const MentorAccountsGrid = ({
+  groups,
+  plans,
+  trades,
+  balancesByAccountId,
+  onAccountClick,
+  onEditAccount,
+  onEditPlan,
+  getAccountBadge,
+  formatCurrency,
+}) => {
+  const { students } = useStudents();
+  const { subscriptions } = useSubscriptions();
+
+  // #341 — só grupos cujo aluno tem sub ativa Alpha/Espelho/Trial (classifyStudent !== null).
+  // Paridade com Acompanhamento; grupo "unknown" (conta órfã) some por não ter doc de aluno.
+  const visibleIds = useMemo(
+    () => visibleStudentIds(students, subscriptions),
+    [students, subscriptions],
+  );
+
+  const visibleGroups = useMemo(
+    () => Object.entries(groups).filter(([studentId]) => visibleIds.has(studentId)),
+    [groups, visibleIds],
+  );
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      {visibleGroups.map(([studentId, data]) => (
+        <StudentAccountGroup
+          key={studentId}
+          studentName={data.studentName}
+          studentEmail={data.studentEmail}
+          accounts={data.accounts}
+          plans={plans}
+          trades={trades}
+          balancesByAccountId={balancesByAccountId}
+          onAccountClick={onAccountClick}
+          onEditAccount={onEditAccount}
+          onEditPlan={onEditPlan}
+          getAccountBadge={getAccountBadge}
+          formatCurrency={formatCurrency}
+        />
+      ))}
     </div>
   );
 };

--- a/src/utils/mentorAccountsVisibility.js
+++ b/src/utils/mentorAccountsVisibility.js
@@ -1,0 +1,38 @@
+/**
+ * mentorAccountsVisibility — issue #341
+ * @description Set de studentIds visíveis na seção Contas do mentor.
+ *
+ *   Paridade com Acompanhamento (StudentsManagement): um aluno aparece ⇔
+ *   `classifyStudent(student, subs) !== null` — VIP ativo, sem-sub e
+ *   expired/cancelled ficam fora; `overdue` (grace) permanece (não é ENDED).
+ *
+ *   A montagem de `subsByStudent` replica exatamente a de StudentsManagement
+ *   para garantir mesma shape de `subs` ao helper — ref. negativa #316
+ *   (assinaturas divergentes de classifyStudent front/back).
+ */
+
+import { classifyStudent } from './studentClassify';
+
+/**
+ * @param {Array} students       docs de /students ({ id, ... })
+ * @param {Array} subscriptions  subs enriquecidas (useSubscriptions): { studentId, status, type, plan, ... }
+ * @returns {Set<string>} studentIds com assinatura ativa Alpha/Espelho/Trial
+ */
+export const visibleStudentIds = (students, subscriptions) => {
+  const subsByStudent = new Map();
+  for (const sub of subscriptions ?? []) {
+    if (!sub?.studentId) continue;
+    const arr = subsByStudent.get(sub.studentId) ?? [];
+    arr.push(sub);
+    subsByStudent.set(sub.studentId, arr);
+  }
+
+  const visible = new Set();
+  for (const s of students ?? []) {
+    if (!s?.id) continue;
+    if (classifyStudent(s, subsByStudent.get(s.id) ?? []) !== null) visible.add(s.id);
+  }
+  return visible;
+};
+
+export default visibleStudentIds;


### PR DESCRIPTION
## Problema
A seção **Contas** (visão do mentor) listava **todos** os alunos que já tiveram conta — inclusive inativos, ex-alunos e órfãos. `useAccounts` (modo mentor) lê todas as contas sem filtro de assinatura, e `AccountsPage` renderizava todo grupo por `studentId`. A tela de Acompanhamento já filtrava por `classifyStudent`; Contas nunca recebeu esse filtro.

## Fix
Um grupo de aluno só aparece se `classifyStudent(student, subs) !== null` — mesmo critério do Acompanhamento (VIP ativo, sem-sub e expired/cancelled somem; `overdue` em grace permanece; grupo `unknown` órfão some). Busca opera sobre o conjunto filtrado. **Caminho do aluno intacto.**

- Util puro `visibleStudentIds` — mesma montagem de `subsByStudent` do `StudentsManagement` (ref. negativa #316, assinaturas divergentes de `classifyStudent`).
- Grid do mentor extraído em `MentorAccountsGrid`, que monta `useStudents`/`useSubscriptions` **só quando renderizado (mentor)** — o caminho do aluno nunca dispara listener em `/students` ou collectionGroup.

## Escopo / risco
- Só `src/pages/AccountsPage.jsx` + 1 util novo. Sem Firestore novo, sem CF, **sem deploy**.

## Testes
- `mentorAccountsVisibility.test.js` — 9 casos (alpha/espelho/trial visíveis; VIP/sem-sub/expired/cancelled/órfão escondidos; overdue mantido; resiliência a nulos).
- Suíte **3561/3561** + build verdes.

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)