### PR TITLE
fix(#343): assessment travado — modelo Claude aposentado derruba 5 CFs

### DIFF
--- a/docs/dev/issues/issue-343-assessment-model-retired.md
+++ b/docs/dev/issues/issue-343-assessment-model-retired.md
@@ -1,0 +1,62 @@
+# Issue #343 — fix: assessment travado — modelo Claude aposentado derruba 5 CFs (404)
+
+> **Branch:** `fix/issue-343-assessment-model-retired`
+> **Worktree:** `~/projects/issue-343`
+> **Versão reservada:** v1.83.2 (patch sobre a consumida 1.83.1 — v1.84.0 reservada por #101, pendente)
+> **Chunks:** CHUNK-09 (escrita), CHUNK-17 (escrita)
+> **PROJECT.md base:** v0.40.11
+
+## Autorização
+
+- [x] Mockup — **exceção autorizada**: fast-track ("sim, abre o issue fast-track", 06/08/2026). Sem tela nova; B altera só estados de erro de UI já existentes.
+- [x] Memória de cálculo — **não aplicável**: nenhuma fórmula, score ou agregação. Troca de identificador de modelo + tratamento de exceção.
+- [x] Marcio autorizou — 06/08/2026: "sim, abre o issue fast-track"
+- [x] Gate Pré-Código liberado
+
+## Context
+
+`claude-sonnet-4-20250514` foi aposentado pela Anthropic; a API responde 404 `not_found_error`. Cinco call sites ainda usam esse ID. O mais visível: `classifyOpenResponse` roda antes de gravar `completedAt` no questionário, então o aluno que responde as 34 perguntas clica em Finalizar e nada acontece — o `catch` só faz `console.error`, sem superfície de erro. Sandra Maria está presa nesse estado com 34/34 respostas.
+
+Objetivo: restaurar o pipeline de assessment ponta a ponta e garantir que a próxima falha de CF seja visível em vez de silenciosa.
+
+## Spec
+
+Ver issue body no GitHub: #343.
+
+## Phases
+
+- A1 — migrar as 4 CFs de assessment para `claude-sonnet-4-6` (`classifyOpenResponse`, `analyzeProbingResponse`, `generateProbingQuestions`, `generateAssessmentReport`)
+- A2 — migrar `functions/propFirm/prompt.js` (2 call sites) para `claude-sonnet-4-6`
+- A3 — sincronizar as 3 strings `aiModelVersion` no front (`useAssessment.js:193`, `useProbing.js:68`, `StudentOnboardingPage.jsx:227`)
+- B1 — superfície de erro em `handleQuestionnaireComplete` e `handleProbingComplete`: estado de erro visível, botão desabilitado durante execução, guard de duplo clique (paridade com o fix do #166 em `ProbingQuestionsFlow`)
+- C1 — `startQuestionnaire`: trocar `setDoc` por escrita que não destrói `responses` existentes (DEC-026 promete preservação no reset)
+- V1 — suíte completa + build; validação manual do fluxo com a Sandra após deploy
+
+## Sessions
+
+_(1 linha por task)_
+
+## Shared Deltas
+
+_(aplicar no MAIN após o merge)_
+- `src/version.js` — bump v1.83.2 + entrada CHANGELOG (resolver contra o estado do main: constante está em 1.84.0 pela reserva do #101)
+- `docs/registry/versions.md` — marcar v1.83.2 consumida
+- `docs/registry/chunks.md` — liberar CHUNK-09 e CHUNK-17
+- `CHANGELOG.md` — nova entrada `[1.83.2] - 06/08/2026`
+- `docs/PROJECT.md` — bump + encerramento
+- `docs/cloud-functions.md` — atualizar modelo documentado das 5 CFs, se citado
+
+## Decisions
+
+- DEC-AUTO-343-01 — alvo `claude-sonnet-4-6` em vez de Sonnet 5 / Opus 5: paridade com `classifyMaturityProgression` e `reviews/prompt.js` já em produção, mesma família do modelo original, rubricas de score não precisam de recalibração. Upgrade de geração fica como decisão separada com teste de qualidade.
+
+## Chunks
+
+- CHUNK-09 (escrita) — CFs de assessment, `useAssessment`, `useProbing`, `StudentOnboardingPage`
+- CHUNK-17 (escrita) — `functions/propFirm/prompt.js`
+
+## Notas operacionais
+
+- Toca `functions/` → `firebase deploy --only functions` obrigatório após o merge.
+- `functions/node_modules` symlinkado no worktree (runner de functions é separado do vitest root).
+- Antonio Pina resetado em 06/08 (DEC-026, `onboardingStatus: lead`, `requiresAssessment: false`); questionário preservado. Não reativar antes de C1 — o `setDoc` apagaria as 34 respostas.

--- a/docs/dev/issues/issue-343-assessment-model-retired.md
+++ b/docs/dev/issues/issue-343-assessment-model-retired.md
@@ -34,7 +34,16 @@ Ver issue body no GitHub: #343.
 
 ## Sessions
 
-_(1 linha por task)_
+- `A1+A2 [migrar-modelo] commit 9ed030ab ok` — 4 CFs assessment + propFirm (2 sites) → `claude-sonnet-4-6`; `RESPONSE_SCHEMA` passa a referenciar `MODEL`/`PROMPT_VERSION`
+- `B1 [superficie-erro] commit 114b80a3 ok` — submitting/submitError no QuestionnaireFlow, guard de duplo clique, `handleProbingComplete` re-lança, `await onComplete()` no ProbingQuestionsFlow, `aiModelVersion` vindo da CF
+- `C1 [preservar-respostas] commit 129e639f ok` — `startQuestionnaire` não sobrescreve `responses`; fallback hardcoded de `aiModelVersion` removido
+- `V1 [validacao] ok` — suíte 3568/3568 (230 arquivos; baseline 3561 + 7 novos), build verde; red-green confirmado revertendo C1
+
+## Verificação pendente (pós-deploy)
+
+O modelo alvo só pode ser exercitado de verdade contra a API depois do
+`firebase deploy --only functions`. Validar com a Sandra: Finalizar → aprofundamento
+→ relatório IA. Enquanto não deployar, as CFs em produção seguem no modelo morto.
 
 ## Shared Deltas
 

--- a/functions/assessment/analyzeProbingResponse.js
+++ b/functions/assessment/analyzeProbingResponse.js
@@ -4,13 +4,16 @@
  * Analisa uma resposta de sondagem adaptativa contra o flag original.
  * Determina se a resposta resolve, reforça ou é inconclusiva sobre a incongruência.
  * 
- * @version 1.0.0 — CHUNK-09 Fase A
+ * Modelo: claude-sonnet-4-6
+ *
+ * @version 1.0.1 — modelo migrado de claude-sonnet-4-20250514 (aposentado, 404)
+ *                  para claude-sonnet-4-6 (DEC-AUTO-343-01, issue #343)
  */
 
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const Anthropic = require('@anthropic-ai/sdk').default;
 
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = 'claude-sonnet-4-6';
 const MAX_TOKENS = 1024;
 
 const client = new Anthropic();

--- a/functions/assessment/classifyOpenResponse.js
+++ b/functions/assessment/classifyOpenResponse.js
@@ -7,19 +7,21 @@
  * Input:  { questionId, questionText, responseText, rubric, closedResponses, dimension, subDimension }
  * Output: { aiScore, aiClassification, aiJustification, aiFinding, aiFlags, aiConfidence }
  *
- * Modelo: claude-sonnet-4-20250514
+ * Modelo: claude-sonnet-4-6
  *
  * v1.1.0 — prompt reescrito com framework completo, âncoras numéricas por dimensão,
  *           constructos teóricos (Kahneman/Tversky, Prospect Theory, TPI), e output
  *           enriquecido com campo `finding` separado de `justification`.
+ * v1.1.1 — modelo migrado de claude-sonnet-4-20250514 (aposentado, 404) para
+ *           claude-sonnet-4-6 (DEC-AUTO-343-01, issue #343).
  *
- * @version 1.1.0 — framework-aligned prompt (DEC-027)
+ * @version 1.1.1 — migração de modelo (DEC-AUTO-343-01)
  */
 
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const Anthropic = require('@anthropic-ai/sdk').default;
 
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = 'claude-sonnet-4-6';
 const MAX_TOKENS = 1500;
 
 const client = new Anthropic();

--- a/functions/assessment/generateAssessmentReport.js
+++ b/functions/assessment/generateAssessmentReport.js
@@ -9,13 +9,16 @@
  * Input: { studentId, responses, incongruenceFlags, probingData, stagePayload }
  * Output: { scores, classifications, stageDigagnosis, reportSummary, developmentPriorities }
  * 
- * @version 1.0.0 — CHUNK-09 Fase A
+ * Modelo: claude-sonnet-4-6
+ *
+ * @version 1.0.1 — modelo migrado de claude-sonnet-4-20250514 (aposentado, 404)
+ *                  para claude-sonnet-4-6 (DEC-AUTO-343-01, issue #343)
  */
 
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const Anthropic = require('@anthropic-ai/sdk').default;
 
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = 'claude-sonnet-4-6';
 const MAX_TOKENS = 2048;
 
 const client = new Anthropic();

--- a/functions/assessment/generateProbingQuestions.js
+++ b/functions/assessment/generateProbingQuestions.js
@@ -11,13 +11,16 @@
  * DEC-016: Sondagem é transparente, acontece pós-questionário/pré-mentor,
  * NÃO altera scores base.
  * 
- * @version 1.0.0 — CHUNK-09 Fase A
+ * Modelo: claude-sonnet-4-6
+ *
+ * @version 1.0.1 — modelo migrado de claude-sonnet-4-20250514 (aposentado, 404)
+ *                  para claude-sonnet-4-6 (DEC-AUTO-343-01, issue #343)
  */
 
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const Anthropic = require('@anthropic-ai/sdk').default;
 
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = 'claude-sonnet-4-6';
 const MAX_TOKENS = 2048;
 
 const client = new Anthropic();

--- a/functions/propFirm/prompt.js
+++ b/functions/propFirm/prompt.js
@@ -14,9 +14,13 @@
  *
  * @version 1.1
  * @since issue #133
+ *
+ * Modelo: claude-sonnet-4-6 — migrado de claude-sonnet-4-20250514 (aposentado, 404)
+ *         em #343 (DEC-AUTO-343-01). O header deste arquivo já dizia "Sonnet 4.6"
+ *         desde a v1.1; a constante é que estava desalinhada.
  */
 
-const MODEL = 'claude-sonnet-4-20250514';
+const MODEL = 'claude-sonnet-4-6';
 const MAX_TOKENS = 4000;
 const TEMPERATURE = 0;
 const PROMPT_VERSION = '1.1';
@@ -349,8 +353,8 @@ const RESPONSE_SCHEMA = {
     },
   ],
   metadata: {
-    model: 'claude-sonnet-4-20250514',
-    promptVersion: '1.1',
+    model: MODEL,
+    promptVersion: PROMPT_VERSION,
     dataSource: '4d_full|indicators|defaults',
     generatedAt: 'ISO timestamp',
   },

--- a/src/__tests__/components/questionnaireFinalizeFeedback.test.jsx
+++ b/src/__tests__/components/questionnaireFinalizeFeedback.test.jsx
@@ -1,0 +1,104 @@
+/**
+ * questionnaireFinalizeFeedback.test.jsx
+ * @description Issue #343 — B1: o botão "Finalizar questionário" precisa de estado
+ *              de submissão e superfície de erro. Antes, uma falha de CF caía num
+ *              console.error e o clique parecia não fazer nada (paridade com o fix
+ *              do #166, que só cobriu o ProbingQuestionsFlow).
+ * @see src/components/Onboarding/QuestionnaireFlow.jsx
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import QuestionnaireFlow from '../../components/Onboarding/QuestionnaireFlow.jsx';
+import { ALL_QUESTIONS } from '../../utils/assessmentQuestions.js';
+
+function makeQuestionnaire(overrides = {}) {
+  const allAnswered = Object.fromEntries(
+    ALL_QUESTIONS.map((q) => [q.id, { questionId: q.id, type: q.type, selectedOption: 'a' }])
+  );
+  return {
+    currentQuestion: ALL_QUESTIONS[ALL_QUESTIONS.length - 1],
+    currentIndex: ALL_QUESTIONS.length - 1,
+    totalQuestions: ALL_QUESTIONS.length,
+    isFirstQuestion: false,
+    isLastQuestion: true,
+    answeredCount: ALL_QUESTIONS.length,
+    progress: 1,
+    progressByDimension: {},
+    responses: allAnswered,
+    getOrderedOptions: () => [],
+    answerClosed: vi.fn(),
+    answerOpen: vi.fn(),
+    goNext: vi.fn(),
+    goPrev: vi.fn(),
+    startTimer: vi.fn(),
+    isComplete: true,
+    getMissingQuestions: () => [],
+    ...overrides,
+  };
+}
+
+describe('QuestionnaireFlow — feedback do botão Finalizar (#343)', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('exibe a mensagem de erro quando a finalização falha', () => {
+    render(
+      <QuestionnaireFlow
+        questionnaire={makeQuestionnaire()}
+        onComplete={vi.fn()}
+        submitError="Não foi possível finalizar o questionário."
+      />
+    );
+
+    expect(
+      screen.getByText('Não foi possível finalizar o questionário.')
+    ).toBeInTheDocument();
+  });
+
+  it('não exibe erro nenhum no estado normal', () => {
+    render(<QuestionnaireFlow questionnaire={makeQuestionnaire()} onComplete={vi.fn()} />);
+
+    expect(screen.queryByText(/não foi possível/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /finalizar questionário/i })).toBeEnabled();
+  });
+
+  it('desabilita o botão e troca o rótulo enquanto submete', () => {
+    render(
+      <QuestionnaireFlow
+        questionnaire={makeQuestionnaire()}
+        onComplete={vi.fn()}
+        submitting
+      />
+    );
+
+    const btn = screen.getByRole('button', { name: /finalizando/i });
+    expect(btn).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /^finalizar questionário$/i })).toBeNull();
+  });
+
+  it('segundo clique durante a submissão não dispara nova chamada', () => {
+    const onComplete = vi.fn();
+    const { rerender } = render(
+      <QuestionnaireFlow questionnaire={makeQuestionnaire()} onComplete={onComplete} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /finalizar questionário/i }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    // O pai passa a submitting=true enquanto processa
+    rerender(
+      <QuestionnaireFlow
+        questionnaire={makeQuestionnaire()}
+        onComplete={onComplete}
+        submitting
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /finalizando/i }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/hooks/startQuestionnairePreservesResponses.test.jsx
+++ b/src/__tests__/hooks/startQuestionnairePreservesResponses.test.jsx
@@ -1,0 +1,111 @@
+/**
+ * startQuestionnairePreservesResponses.test.jsx
+ * @description Issue #343 — C1: reabrir o questionário não pode destruir respostas.
+ *              DEC-026 promete que o reset do mentor preserva o histórico, mas o
+ *              `setDoc` sem merge do startQuestionnaire zerava `responses` na
+ *              reativação. Cobre os dois caminhos: com e sem respostas gravadas.
+ * @see src/hooks/useAssessment.js
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const setDocCalls = [];
+const updateDocCalls = [];
+let questionnaireSnap = { exists: false, data: null };
+
+vi.mock('firebase/firestore', () => ({
+  doc: (_db, ...segments) => ({ __type: 'doc', path: segments.join('/') }),
+  getDoc: async (ref) => ({
+    exists: () => ref.path.endsWith('assessment/questionnaire') && questionnaireSnap.exists,
+    data: () => questionnaireSnap.data,
+  }),
+  setDoc: async (ref, data) => {
+    setDocCalls.push({ path: ref.path, data });
+  },
+  updateDoc: async (ref, data) => {
+    updateDocCalls.push({ path: ref.path, data });
+  },
+  // O hook depende do listener do doc do aluno para popular onboardingStatus —
+  // sem emitir, a state machine rejeita a transição para pre_assessment.
+  onSnapshot: (ref, onNext) => {
+    const isStudentDoc = /^students\/[^/]+$/.test(ref.path);
+    onNext({
+      exists: () => isStudentDoc,
+      data: () => (isStudentDoc ? { onboardingStatus: 'lead' } : null),
+    });
+    return () => {};
+  },
+  serverTimestamp: () => '__serverTimestamp__',
+}));
+
+vi.mock('../../firebase', () => ({ db: { __type: 'db' } }));
+
+import { useAssessment } from '../../hooks/useAssessment.js';
+
+const STUDENT = 'student-abc';
+const qPath = `students/${STUDENT}/assessment/questionnaire`;
+
+function responsesFixture(n) {
+  return Array.from({ length: n }, (_, i) => ({
+    questionId: `EMO-${String(i + 1).padStart(2, '0')}`,
+    type: 'closed',
+    selectedOption: 'a',
+  }));
+}
+
+describe('useAssessment.startQuestionnaire — preservação de respostas (#343)', () => {
+  beforeEach(() => {
+    setDocCalls.length = 0;
+    updateDocCalls.length = 0;
+    questionnaireSnap = { exists: false, data: null };
+  });
+
+  it('cria o doc zerado quando o aluno nunca respondeu nada', async () => {
+    const { result } = renderHook(() => useAssessment(STUDENT));
+
+    await act(async () => {
+      await result.current.startQuestionnaire();
+    });
+
+    const created = setDocCalls.find((c) => c.path === qPath);
+    expect(created).toBeDefined();
+    expect(created.data.responses).toEqual([]);
+    expect(created.data.completedAt).toBeNull();
+  });
+
+  it('NÃO sobrescreve responses quando já existem respostas gravadas', async () => {
+    questionnaireSnap = {
+      exists: true,
+      data: { responses: responsesFixture(34), completedAt: null },
+    };
+
+    const { result } = renderHook(() => useAssessment(STUDENT));
+
+    await act(async () => {
+      await result.current.startQuestionnaire();
+    });
+
+    // Nenhum setDoc no doc do questionário — seria a escrita destrutiva
+    expect(setDocCalls.filter((c) => c.path === qPath)).toHaveLength(0);
+
+    const reopened = updateDocCalls.find((c) => c.path === qPath);
+    expect(reopened).toBeDefined();
+    expect(reopened.data).not.toHaveProperty('responses');
+    expect(reopened.data.completedAt).toBeNull();
+  });
+
+  it('trata doc existente com responses vazio como início do zero', async () => {
+    questionnaireSnap = { exists: true, data: { responses: [] } };
+
+    const { result } = renderHook(() => useAssessment(STUDENT));
+
+    await act(async () => {
+      await result.current.startQuestionnaire();
+    });
+
+    const created = setDocCalls.find((c) => c.path === qPath);
+    expect(created).toBeDefined();
+    expect(created.data.responses).toEqual([]);
+  });
+});

--- a/src/__tests__/utils/propFirmAiValidate.test.js
+++ b/src/__tests__/utils/propFirmAiValidate.test.js
@@ -67,7 +67,7 @@ function baseValidPlan() {
       personalWarnings: [],
     },
     milestones: [{ day: 1, targetBalance: 500, description: 'x' }],
-    metadata: { model: 'claude-sonnet-4-20250514', promptVersion: '1.1', dataSource: '4d_full', generatedAt: '2026-04-14T00:00:00Z' },
+    metadata: { model: 'claude-sonnet-4-6', promptVersion: '1.1', dataSource: '4d_full', generatedAt: '2026-04-14T00:00:00Z' },
   };
 }
 

--- a/src/components/Onboarding/ProbingQuestionsFlow.jsx
+++ b/src/components/Onboarding/ProbingQuestionsFlow.jsx
@@ -34,7 +34,9 @@ export default function ProbingQuestionsFlow({
     setCompleteError(null);
     try {
       await completeAllProbing();
-      if (onComplete) onComplete();
+      // `await` obrigatório: sem ele a promise de onComplete flutua e uma falha
+      // na geração do relatório nunca chega neste catch (#343).
+      if (onComplete) await onComplete();
     } catch (err) {
       setCompleteError('Erro ao finalizar. Tente novamente.');
     } finally {

--- a/src/components/Onboarding/QuestionnaireFlow.jsx
+++ b/src/components/Onboarding/QuestionnaireFlow.jsx
@@ -43,6 +43,8 @@ const SUB_DIMENSION_LABELS = {
 export default function QuestionnaireFlow({
   questionnaire,
   onComplete,
+  submitting = false,
+  submitError = null,
 }) {
   const {
     currentQuestion,
@@ -147,9 +149,19 @@ export default function QuestionnaireFlow({
           {isComplete && (
             <button
               onClick={() => onComplete && onComplete()}
-              className="px-6 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-sm font-medium transition-all"
+              disabled={submitting}
+              className={`
+                flex items-center gap-2 px-6 py-2.5 rounded-lg text-sm font-medium transition-all
+                ${submitting
+                  ? 'bg-emerald-600/40 text-white/70 cursor-wait'
+                  : 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                }
+              `}
             >
-              Finalizar questionário
+              {submitting && (
+                <div className="w-4 h-4 border-2 border-white/70 border-t-transparent rounded-full animate-spin" />
+              )}
+              {submitting ? 'Finalizando...' : 'Finalizar questionário'}
             </button>
           )}
 
@@ -171,6 +183,13 @@ export default function QuestionnaireFlow({
           )}
         </div>
       </div>
+
+      {/* Erro ao finalizar — sem isto a falha some no console (#343) */}
+      {submitError && (
+        <div className="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+          <p className="text-xs text-red-400">{submitError}</p>
+        </div>
+      )}
 
       {/* Missing questions indicator */}
       {isLastQuestion && !isComplete && (

--- a/src/hooks/useAssessment.js
+++ b/src/hooks/useAssessment.js
@@ -147,18 +147,40 @@ export function useAssessment(studentId) {
 
   // ── Questionnaire Actions ─────────────────────────────────
 
+  /**
+   * Abre (ou reabre) o questionário.
+   *
+   * DEC-026 garante que o reset do mentor preserva o histórico no Firestore.
+   * O `setDoc` original sobrescrevia `responses: []` sem merge, então reativar
+   * o assessment de um aluno resetado apagava tudo em silêncio — a promessa de
+   * preservação só valia até a reativação (#343).
+   *
+   * Com respostas já gravadas, reabre limpando apenas o estado de conclusão e
+   * mantém `responses` intacto: o aluno retoma de onde parou.
+   */
   const startQuestionnaire = useCallback(async () => {
     if (!studentId) return;
     const qRef = doc(db, 'students', studentId, 'assessment', 'questionnaire');
-    await setDoc(qRef, {
-      startedAt: serverTimestamp(),
-      completedAt: null,
-      responses: [],
-      incongruenceFlags: [],
-      gamingSuspect: false,
-      aiProcessedAt: null,
-      aiModelVersion: null,
-    });
+    const snap = await getDoc(qRef);
+    const hasResponses = snap.exists() && (snap.data().responses || []).length > 0;
+
+    if (hasResponses) {
+      await updateDoc(qRef, {
+        completedAt: null,
+        aiProcessedAt: null,
+        aiModelVersion: null,
+      });
+    } else {
+      await setDoc(qRef, {
+        startedAt: serverTimestamp(),
+        completedAt: null,
+        responses: [],
+        incongruenceFlags: [],
+        gamingSuspect: false,
+        aiProcessedAt: null,
+        aiModelVersion: null,
+      });
+    }
     await updateOnboardingStatus('pre_assessment');
   }, [studentId, updateOnboardingStatus]);
 
@@ -190,7 +212,9 @@ export function useAssessment(studentId) {
       incongruenceFlags: processedData.incongruenceFlags || [],
       gamingSuspect: processedData.gamingSuspect || false,
       aiProcessedAt: serverTimestamp(),
-      aiModelVersion: processedData.aiModelVersion || 'claude-sonnet-4-20250514',
+      // Sem fallback hardcoded: gravar um ID de modelo que não foi o usado é pior
+      // que gravar nada — foi o que mascarou a aposentadoria do modelo em #343.
+      aiModelVersion: processedData.aiModelVersion || null,
     });
     await updateOnboardingStatus('ai_assessed');
   }, [studentId, updateOnboardingStatus]);

--- a/src/hooks/useProbing.js
+++ b/src/hooks/useProbing.js
@@ -65,7 +65,9 @@ export function useProbing({ onSaveProbing, onCompleteProbingQuestion, onComplet
         await onSaveProbing({
           triggeredBy: probingPayload.triggers || [],
           questions: generatedQuestions,
-          aiModelVersion: 'claude-sonnet-4-20250514',
+          // O modelo é decidido pela CF; o front registra o que ela devolveu em vez
+          // de manter um ID hardcoded que dessincroniza silenciosamente (#343).
+          aiModelVersion: result.data.aiModelVersion || null,
         });
       }
 

--- a/src/pages/StudentOnboardingPage.jsx
+++ b/src/pages/StudentOnboardingPage.jsx
@@ -61,6 +61,7 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
   const params = useParams();
   const studentId = studentIdProp || params?.studentId;
   const [processing, setProcessing] = useState(false);
+  const [actionError, setActionError] = useState(null);
   const [saving, setSaving] = useState(false);
   const [activeTab, setActiveTab] = useState(null); // null = auto from status
   const [assessmentScores, setAssessmentScores] = useState(null);
@@ -175,13 +176,16 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
   }, [startQuestionnaire]);
 
   const handleQuestionnaireComplete = useCallback(async () => {
+    if (processing) return; // guard de duplo clique
     setProcessing(true);
+    setActionError(null);
     try {
       const allResponses = questionnaire.getAllResponses();
 
       // 1. Classify open responses via CF
       const classifyCF = httpsCallable(functions, 'classifyOpenResponse');
       const openResponses = allResponses.filter((r) => r.type === 'open');
+      let aiModelVersion = null;
 
       for (const resp of openResponses) {
         const question = QUESTION_MAP[resp.questionId];
@@ -211,6 +215,7 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
         resp.aiClassification = result.data.aiClassification;
         resp.aiJustification = result.data.aiJustification;
         resp.aiConfidence = result.data.aiConfidence;
+        aiModelVersion = result.data.aiModelVersion || aiModelVersion;
 
         // Persist enriched response
         await saveResponse(resp);
@@ -224,7 +229,7 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
       await completeQuestionnaire({
         incongruenceFlags: [...incongruences.intraFlags, ...incongruences.interFlags],
         gamingSuspect: incongruences.gamingSuspect,
-        aiModelVersion: 'claude-sonnet-4-20250514',
+        aiModelVersion,
       });
 
       // 4. Prepare probing payload
@@ -246,10 +251,14 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
 
     } catch (err) {
       console.error('Questionnaire completion error:', err);
+      setActionError(
+        'Não foi possível finalizar o questionário. Suas respostas estão salvas — '
+        + 'tente novamente em alguns instantes. Se persistir, avise seu mentor.'
+      );
     } finally {
       setProcessing(false);
     }
-  }, [questionnaire, saveResponse, completeQuestionnaire, probing]);
+  }, [processing, questionnaire, saveResponse, completeQuestionnaire, probing]);
 
   const handleProbingStart = useCallback(async () => {
     const allResponses = questionnaire.getAllResponses();
@@ -423,6 +432,9 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
 
     } catch (err) {
       console.error('Report generation error:', err);
+      // Re-lança: o ProbingQuestionsFlow tem tratamento próprio de erro no botão
+      // Finalizar (#166). Engolir aqui neutralizava aquele fix (#343).
+      throw err;
     } finally {
       setProcessing(false);
     }
@@ -644,6 +656,8 @@ export default function StudentOnboardingPage({ studentId: studentIdProp, isMent
         <QuestionnaireFlow
           questionnaire={questionnaire}
           onComplete={handleQuestionnaireComplete}
+          submitting={processing}
+          submitError={actionError}
         />
       )}
 


### PR DESCRIPTION
Closes #343

## Problema

`claude-sonnet-4-20250514` foi aposentado pela Anthropic e responde 404 `not_found_error`. A CF `classifyOpenResponse` roda antes de gravar `completedAt` no questionário do assessment 4D, então o aluno que responde as 34 perguntas clica em **Finalizar** e nada acontece — o `catch` só escrevia em `console.error`. Sandra Maria está presa nesse estado com 34/34 respostas.

## O que muda

**A1/A2 — modelo** (`9ed030ab`)
As 4 CFs de assessment (`classifyOpenResponse`, `analyzeProbingResponse`, `generateProbingQuestions`, `generateAssessmentReport`) e os 2 call sites do Prop Firm migram para `claude-sonnet-4-6` (DEC-AUTO-343-01) — já em produção em `classifyMaturityProgression` e `reviews/prompt.js`, mesma família do modelo original, rubricas de score sem recalibração. O `RESPONSE_SCHEMA` do propFirm passa a referenciar `MODEL`/`PROMPT_VERSION` em vez de repetir o ID: era a cópia que ficou para trás quando o header do arquivo já dizia "Sonnet 4.6".

**B1 — superfície de erro** (`114b80a3`)
O fix do #166 estava neutralizado por dois motivos independentes: `handleProbingComplete` engolia a exceção, e `ProbingQuestionsFlow` chamava `onComplete()` sem `await` (promise flutuante — o catch local nunca via a falha). Ambos corrigidos. `QuestionnaireFlow` ganha `submitting`/`submitError`: botão desabilitado com "Finalizando...", guard de duplo clique, mensagem visível. `aiModelVersion` passa a vir do que a CF devolve, em vez de string hardcoded no front.

**C1 — preservação de respostas** (`129e639f`)
`startQuestionnaire` fazia `setDoc` sem merge e zerava `responses`, então a preservação prometida pelo DEC-026 valia só até alguém reativar o assessment de um aluno resetado. Com respostas gravadas, reabre via `updateDoc` limpando apenas o estado de conclusão.

## Validação

- Suíte 3568/3568 (230 arquivos; baseline 3561 + 7 testes novos)
- Build verde
- Red-green confirmado revertendo C1: o teste de preservação falha sem o fix
- Verificação real do modelo contra a API só é possível pós-deploy

## Deploy

Toca `functions/` → `firebase deploy --only functions` obrigatório após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)