### PR TITLE
fix(#345): reflexão não grava vindo do aviso do dashboard — janela fecha em DISCUSSED

### DIFF
--- a/docs/dev/issues/issue-345-reflection-discussed-window.md
+++ b/docs/dev/issues/issue-345-reflection-discussed-window.md
@@ -1,0 +1,146 @@
+# Issue #345 — fix: reflexão não grava vindo do aviso do dashboard (janela fecha em DISCUSSED)
+
+## Autorização (OBRIGATÓRIA — sem isto é PROIBIDO iniciar desenvolvimento)
+
+**Status atual do documento:**
+- [x] Mockup apresentado — ver seção Mockup (3 estados + copy)
+- [x] Memória de cálculo — **exceção autorizada** por Marcio ("pode pular a memória",
+      09/08/2026). Não há fórmula, score, agregação nem threshold: a única regra nova é
+      booleana (`status === 'DISCUSSED'` fecha a janela).
+- [x] Marcio autorizou — 09/08/2026: "autorizado, pode pular a memória"
+- [x] Gate Pré-Código liberado — leitura completa (fila → modal → componente → gateway →
+      rules → `publishReview`), impacto declarado abaixo, INV-17/INV-18 cumpridas
+
+## Context
+
+Aluno chega pelo aviso "Trades a refletir" do dashboard, preenche a reflexão, clica em
+Salvar e nada acontece — o trade volta pra fila e o aviso cobra o mesmo trade pra sempre.
+
+`publishReview` marca **todos** os membros da revisão como `status: 'DISCUSSED'` sem exigir
+`selfReview` (`functions/reviews/publishReview.js:85-90`). Rules e gateway tratam DISCUSSED
+como terminal/imortal a writes de cliente (#269 v2), mas a fila e os gates de UI não conhecem
+essa regra: oferecem a edição e o erro morre em `console.error`.
+
+Objetivo: a UI passa a **respeitar** a regra que rules e gateway já impõem, e nenhuma falha
+de write volta a ser silenciosa. Nada muda em `firestore.rules`, `publishReview` ou no gateway.
+
+## Spec
+
+Ver issue body no GitHub: #345.
+
+## Mockup
+
+### 1. Fila "Trades a refletir" (dashboard do aluno)
+
+Sem mudança visual. Muda o conjunto: trade com `status === 'DISCUSSED'` **sai da lista** e
+sai do contador do header. Fila que só tinha itens discutidos → card não renderiza (`null`,
+comportamento atual quando `pending.length === 0`). O colapso do #329 (limiar 8) segue
+operando sobre a lista já filtrada.
+
+### 2. Trade DISCUSSED sem `selfReview`, visto pelo próprio aluno
+
+`TradeReviewSection` ganha um estado read-only novo — hoje esse trade cai no formulário
+editável (que não grava). Mesma moldura visual dos outros estados
+(`border border-white/10 rounded-xl p-4 bg-white/5 mt-4`):
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ 🗒  Reflexão            [ Janela fechada ]                     │
+│                                                                │
+│ Este trade foi discutido na revisão sem a sua auto-análise.    │
+│ A reflexão vale antes da revisão — depois de conversar com o   │
+│ mentor ela já não mede o que você pensava na hora do trade.    │
+│                                                             ᴰᴮ │
+└────────────────────────────────────────────────────────────────┘
+```
+
+- Badge "Janela fechada": `border-amber-500/30 text-amber-300`, mesmo formato do badge
+  "Faria de novo: Sim/Não" do estado de leitura.
+- Sem botão. Nada clicável — não promete gravação.
+- Mentor não vê este estado: continua no alerta âmbar do `StudentReflectionPanel` (#323),
+  que não muda.
+
+### 3. Erro ao salvar (qualquer estado editável)
+
+Hoje: exceção → `console.error` → painel volta ao normal, aluno não vê nada.
+Passa a exibir, acima da linha de botões:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ ⚠ Não foi possível salvar sua reflexão. Tente de novo.        │
+│   <mensagem técnica do erro, text-[11px] text-red-300/70>      │
+└────────────────────────────────────────────────────────────────┘
+```
+
+- Caixa `border-red-500/30 bg-red-500/10 text-red-200`, `text-xs`.
+- O formulário **não** é resetado (as respostas digitadas ficam) — hoje `reset()` só roda no
+  sucesso, então isso já está correto; o que falta é a mensagem.
+- Botão "Salvar revisão" reabilita depois da falha; `saving` continua guardando duplo clique.
+- A mensagem técnica é exibida de propósito: é o que evita o próximo chamado invisível.
+
+## Análise de Impacto
+
+| Aspecto | Detalhe |
+|---------|---------|
+| Collections tocadas | nenhuma — nenhum write novo; só leitura de `trade.status` em display-time |
+| Cloud Functions | nenhuma — **sem deploy** |
+| Hooks/listeners | nenhum |
+| Side-effects (PL, compliance, emotional) | nenhum — `selfReview` não entra no score 4D |
+| Blast radius | 3 arquivos de UI/constantes + 2 de teste. Aluno: fila menor + estado novo no trade discutido. Mentor: zero (`StudentReflectionPanel` intocado) |
+| Rollback | revert do PR — sem migração, sem dado gravado |
+
+**INV-17:** nenhum nível de navegação novo; domínio CHUNK-04 (reflexão do trade); zero
+duplicação (o estado nasce dentro do `TradeReviewSection`, não como card novo); budget
++~40 linhas em componente existente.
+
+## Phases
+
+- A1 — `PendingReflections`: excluir DISCUSSED do filtro + teste ✅
+- A2 — gate de edição respeita DISCUSSED ✅ — **desvio de design deliberado** (ver abaixo)
+- B1 — `TradeReviewSection`: estado read-only "janela fechada" + teste ✅
+- C1 — `TradeReviewSection`: `submitError` visível no salvar + teste ✅
+
+### Desvio de A2 (decisão técnica, DEC-AUTO-345-02)
+
+O issue previa repetir `status !== 'DISCUSSED'` nos 3 call sites de `canReview`
+(`TradeDetailModal:454`, `AddTradeModal:839` e `:1205`). Implementado diferente: a regra vira
+predicado único `isReflectionWindowClosed(trade)` em `src/constants/tradeReviewFramework.js`
+— o mesmo módulo que o gateway já importa — e o próprio `TradeReviewSection` decide.
+Nenhum call site muda.
+
+Motivo: `canReview` significa "este usuário pode refletir" (não-mentor, trade fechado);
+"a janela fechou" é outra dimensão. Espalhar a segunda regra por 3 call sites triplicaria
+o ponto de divergência que **causou** este bug. A defesa em profundidade real são as rules
+e o gateway, que já rejeitam. Efeito colateral bom: o `canReview={true}` hardcoded do
+`AddTradeModal` deixa de ser um furo em potencial.
+
+## Sessions
+
+- `task A1+A2+B1+C1 [reflection-discussed-window] commit <sha> ok — 13 testes novos, suíte 3581/3581, lint 0, build ok`
+
+## Shared Deltas
+
+Aplicar no MAIN após o merge:
+- `src/version.js` — bump v1.83.3 (linha `(RESERVA)` já registrada no lock `d8edb524`)
+- `docs/registry/versions.md` — marcar 1.83.3 consumida (PR + squash)
+- `docs/registry/chunks.md` — liberar CHUNK-04
+- `CHANGELOG.md` — entrada `[1.83.3] - DD/MM/2026`
+- `docs/PROJECT.md` — bump + nota de encerramento (gap conhecido do `cc-close-issue.sh`)
+- `docs/decisions.md` — 1 linha para a decisão da janela
+
+## Decisions
+
+- DEC-AUTO-345-01 — a janela de reflexão fecha quando o trade vira DISCUSSED; a UI alinha-se
+  às rules em vez de contradizê-las (alternativa descartada: enfraquecer rules ou criar
+  callable com admin SDK para furar o invariante do #269 v2).
+- DEC-AUTO-345-02 — a regra da janela vira predicado único `isReflectionWindowClosed` no
+  módulo que gateway e componentes já compartilham, em vez de replicada nos call sites de
+  `canReview` (ver "Desvio de A2").
+- DEC-AUTO-345-03 — mensagem de erro de write exibe o motivo técnico ao aluno (`err.message`),
+  não só um texto genérico: é o que transforma "nada acontece" em chamado diagnosticável.
+
+## Chunks
+
+- CHUNK-04 (escrita) — `TradeReviewSection`, `PendingReflections`, gates em
+  `TradeDetailModal` / `AddTradeModal`
+- CHUNK-08 (leitura) — `StudentReflectionPanel` inalterado, só conferir paridade

--- a/src/__tests__/components/Trades/TradeReviewSection.test.jsx
+++ b/src/__tests__/components/Trades/TradeReviewSection.test.jsx
@@ -1,0 +1,136 @@
+/**
+ * TradeReviewSection.test.jsx (issue #345)
+ * @description Janela de reflexão fechada em DISCUSSED + superfície de erro no salvar.
+ *              Cobre a causa raiz do #345: a UI oferecia um write que rules e gateway negam,
+ *              e a exceção morria em console.error ("nada acontece" pro aluno).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TradeReviewSection from '../../../components/Trades/TradeReviewSection';
+
+const makeTrade = (overrides = {}) => ({
+  id: 't1',
+  symbol: 'WINFUT',
+  result: 150,
+  ...overrides,
+});
+
+describe('<TradeReviewSection /> — janela fechada (#345)', () => {
+  it('DISCUSSED sem selfReview → estado janela fechada, sem formulário', () => {
+    render(
+      <TradeReviewSection trade={makeTrade({ status: 'DISCUSSED' })} canReview onSubmit={vi.fn()} />
+    );
+    expect(screen.getByText('Janela fechada')).toBeInTheDocument();
+    expect(screen.getByText(/discutido na revisão sem a sua auto-análise/i)).toBeInTheDocument();
+    // nenhum caminho de edição é oferecido
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByText('Analisar o trade')).not.toBeInTheDocument();
+  });
+
+  it('DISCUSSED sem selfReview + startOpen → ainda janela fechada (não abre o formulário)', () => {
+    render(
+      <TradeReviewSection
+        trade={makeTrade({ status: 'DISCUSSED' })}
+        canReview
+        startOpen
+        onSubmit={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Janela fechada')).toBeInTheDocument();
+    expect(screen.queryByText('Salvar revisão')).not.toBeInTheDocument();
+  });
+
+  it('DISCUSSED COM selfReview → segue mostrando a reflexão (imortal, #269 v2)', () => {
+    render(
+      <TradeReviewSection
+        trade={makeTrade({ status: 'DISCUSSED', selfReview: { wouldRepeat: true, answers: {} } })}
+        canReview
+        onSubmit={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Faria de novo: Sim')).toBeInTheDocument();
+    expect(screen.queryByText('Janela fechada')).not.toBeInTheDocument();
+  });
+
+  it('mentor (canReview=false) num DISCUSSED sem reflexão → não renderiza nada', () => {
+    const { container } = render(
+      <TradeReviewSection trade={makeTrade({ status: 'DISCUSSED' })} canReview={false} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('status não-terminal sem selfReview → nudge editável (comportamento do #327 preservado)', () => {
+    render(
+      <TradeReviewSection trade={makeTrade({ status: 'REVIEWED' })} canReview onSubmit={vi.fn()} />
+    );
+    expect(screen.getByText('Analisar o trade')).toBeInTheDocument();
+    expect(screen.queryByText('Janela fechada')).not.toBeInTheDocument();
+  });
+
+  it('trade sem status → nudge editável (trade legado)', () => {
+    render(<TradeReviewSection trade={makeTrade()} canReview onSubmit={vi.fn()} />);
+    expect(screen.getByText('Analisar o trade')).toBeInTheDocument();
+  });
+});
+
+describe('<TradeReviewSection /> — erro visível no salvar (#345)', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => {}));
+  afterEach(() => vi.restoreAllMocks());
+
+  const openAndAnswer = () => {
+    fireEvent.click(screen.getByText('Sim'));
+  };
+
+  it('onSubmit rejeita → mensagem visível com o motivo técnico', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('Missing or insufficient permissions.'));
+    render(<TradeReviewSection trade={makeTrade()} canReview startOpen onSubmit={onSubmit} />);
+    openAndAnswer();
+    fireEvent.click(screen.getByText('Salvar revisão'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Não foi possível salvar sua reflexão/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText('Missing or insufficient permissions.')).toBeInTheDocument();
+  });
+
+  it('falha preserva as respostas digitadas e reabilita o botão', async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error('falhou'));
+    render(<TradeReviewSection trade={makeTrade()} canReview startOpen onSubmit={onSubmit} />);
+    openAndAnswer();
+
+    const textarea = screen.getAllByRole('textbox')[0];
+    fireEvent.change(textarea, { target: { value: 'minha reflexão' } });
+    fireEvent.click(screen.getByText('Salvar revisão'));
+
+    await waitFor(() => expect(screen.getByText('falhou')).toBeInTheDocument());
+    expect(screen.getAllByRole('textbox')[0].value).toBe('minha reflexão');
+    expect(screen.getByText('Salvar revisão').closest('button')).not.toBeDisabled();
+  });
+
+  it('sucesso não mostra erro e chama onSubmit com o payload', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<TradeReviewSection trade={makeTrade()} canReview startOpen onSubmit={onSubmit} />);
+    openAndAnswer();
+    fireEvent.click(screen.getByText('Salvar revisão'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({ wouldRepeat: true, answers: {} });
+    expect(screen.queryByText(/Não foi possível salvar/i)).not.toBeInTheDocument();
+  });
+
+  it('nova tentativa limpa o erro anterior', async () => {
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('primeira falha'))
+      .mockResolvedValueOnce(undefined);
+    render(<TradeReviewSection trade={makeTrade()} canReview startOpen onSubmit={onSubmit} />);
+    openAndAnswer();
+    fireEvent.click(screen.getByText('Salvar revisão'));
+    await waitFor(() => expect(screen.getByText('primeira falha')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Salvar revisão'));
+    await waitFor(() => expect(screen.queryByText('primeira falha')).not.toBeInTheDocument());
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/components/reviews/PendingReflections.test.jsx
+++ b/src/__tests__/components/reviews/PendingReflections.test.jsx
@@ -63,6 +63,44 @@ describe('<PendingReflections />', () => {
     expect(screen.getByText('ZERADO')).toBeInTheDocument();
   });
 
+  // #345 — janela fechada: trade discutido em revisão não pode mais ser refletido
+  // (rules + gateway negam o write), então não faz sentido cobrar na fila.
+  it('exclui trade DISCUSSED sem selfReview (janela de reflexão fechada)', () => {
+    render(
+      <PendingReflections
+        trades={[
+          makeTrade({ id: 't1', symbol: 'WINFUT' }),
+          makeTrade({ id: 't2', symbol: 'DISCUTIDO', status: 'DISCUSSED' }),
+        ]}
+      />
+    );
+    expect(screen.getByText('WINFUT')).toBeInTheDocument();
+    expect(screen.queryByText('DISCUTIDO')).not.toBeInTheDocument();
+    expect(screen.getByText('1 trade')).toBeInTheDocument();
+  });
+
+  it('fila só de DISCUSSED não renderiza o card', () => {
+    const { container } = render(
+      <PendingReflections trades={[makeTrade({ status: 'DISCUSSED' })]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mantém na fila os outros status (REVIEWED, CLOSED, sem status)', () => {
+    render(
+      <PendingReflections
+        trades={[
+          makeTrade({ id: 't1', symbol: 'REVISADO', status: 'REVIEWED' }),
+          makeTrade({ id: 't2', symbol: 'FECHADO', status: 'CLOSED' }),
+          makeTrade({ id: 't3', symbol: 'LEGADO' }),
+        ]}
+      />
+    );
+    expect(screen.getByText('REVISADO')).toBeInTheDocument();
+    expect(screen.getByText('FECHADO')).toBeInTheDocument();
+    expect(screen.getByText('LEGADO')).toBeInTheDocument();
+  });
+
   it('respeita o filtro de plano (planId)', () => {
     render(
       <PendingReflections

--- a/src/components/Trades/TradeReviewSection.jsx
+++ b/src/components/Trades/TradeReviewSection.jsx
@@ -10,14 +10,16 @@
  *
  * Estados: (A) nudge "Revisar agora/depois" → (B) escolher SIM/NÃO + perguntas →
  * (C) leitura + banner do confronto. Imutável após DISCUSSED (#269).
+ * (D) #345 — janela fechada: discutido SEM reflexão. Read-only, sem promessa de gravação.
  */
-import React, { useMemo, useState } from 'react';
-import { ClipboardCheck, RefreshCw } from 'lucide-react';
+import React, { useState } from 'react';
+import { ClipboardCheck, RefreshCw, Lock, AlertTriangle } from 'lucide-react';
 import DebugBadge from '../DebugBadge';
 import { CONFRONT_TONE_STYLES } from './behaviorDisplay';
 import { classifyTrade, reviewVerdict, REVIEW_VERDICT } from '../../utils/tradeReviewConfront';
 import {
   WOULD_REPEAT_PROMPT, TRADE_REVIEW_QUESTIONS, questionsForQuadrant, REVIEW_DIMENSIONS,
+  isReflectionWindowClosed,
 } from '../../constants/tradeReviewFramework';
 
 /** verdict + declaração → {tone, text} para o banner do espelho (ou null). */
@@ -55,6 +57,9 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
   const [wouldRepeat, setWouldRepeat] = useState(null);
   const [answers, setAnswers] = useState({});
   const [saving, setSaving] = useState(false);
+  // #345 — falha de write era engolida em console.error: o aluno clicava Salvar e "nada
+  // acontecia". A mensagem técnica vai visível de propósito (evita o chamado invisível).
+  const [submitError, setSubmitError] = useState(null);
 
   const families = trade?.behaviorProfile?.families;
 
@@ -98,21 +103,48 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
   }
 
   // Mentor (ou quem não pode revisar) e sem auto-revisão: nada a mostrar.
+  // O mentor tem o alerta próprio na composição de feedback (StudentReflectionPanel, #323).
   if (!canReview || typeof onSubmit !== 'function') return null;
+
+  // ── Estado D: janela fechada (#345) ──
+  // Discutido em revisão publicada SEM reflexão. Rules e gateway negam o write; oferecer o
+  // formulário aqui era o bug. Read-only e sem botão — não promete o que não grava.
+  if (isReflectionWindowClosed(trade)) {
+    return (
+      <div className="relative border border-white/10 rounded-xl p-4 bg-white/5 mt-4">
+        <div className="flex items-center gap-2 mb-2">
+          <Lock className="w-4 h-4 text-zinc-400" />
+          <span className="text-sm font-medium text-zinc-200">Reflexão</span>
+          <span className="text-xs px-1.5 py-0.5 rounded border border-amber-500/30 text-amber-300">
+            Janela fechada
+          </span>
+        </div>
+        <p className="text-sm text-zinc-400">
+          Este trade foi discutido na revisão sem a sua auto-análise. A reflexão vale antes da
+          revisão — depois de conversar com o mentor ela já não mede o que você pensava na hora
+          do trade.
+        </p>
+        <DebugBadge component="TradeReviewSection" />
+      </div>
+    );
+  }
 
   const quadrant = wouldRepeat === null ? null : classifyTrade(trade.result, wouldRepeat);
   const questions = quadrant ? questionsForQuadrant(quadrant) : [];
 
-  const reset = () => { setEditing(false); setWouldRepeat(null); setAnswers({}); };
+  const reset = () => { setEditing(false); setWouldRepeat(null); setAnswers({}); setSubmitError(null); };
 
   const handleSave = async () => {
-    if (wouldRepeat === null) return;
+    if (wouldRepeat === null || saving) return;
     setSaving(true);
+    setSubmitError(null);
     try {
       await onSubmit({ wouldRepeat, answers });
       reset();
     } catch (err) {
+      // Falha NÃO reseta o formulário: as respostas digitadas ficam pra nova tentativa.
       console.error('[TradeReviewSection] erro ao salvar auto-revisão:', err);
+      setSubmitError(err?.message || 'erro desconhecido');
     } finally {
       setSaving(false);
     }
@@ -188,6 +220,16 @@ const TradeReviewSection = ({ trade, canReview = false, onSubmit, startOpen = fa
               />
             </div>
           ))}
+        </div>
+      )}
+
+      {submitError && (
+        <div className="mb-3 text-xs rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-red-200 flex items-start gap-2">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+          <div>
+            <div>Não foi possível salvar sua reflexão. Tente de novo.</div>
+            <div className="text-[11px] text-red-300/70 mt-0.5">{submitError}</div>
+          </div>
         </div>
       )}
 

--- a/src/components/reviews/PendingReflections.jsx
+++ b/src/components/reviews/PendingReflections.jsx
@@ -6,6 +6,9 @@
  *
  * Regras de visibilidade:
  *   - Item = trade com `result != null` (fechado) e SEM `selfReview`.
+ *   - #345 — trade já discutido em revisão (`status: 'DISCUSSED'`) NÃO entra: a janela de
+ *     reflexão fechou e o write é negado por rules + gateway. Cobrar era cobrar o impossível
+ *     (o item nunca saía da fila e o Salvar não gravava).
  *   - Respeita o filtro de plano da ContextBar (planId) quando definido.
  *   - Sem pendência → retorna null. Suprimido em View-As (mentor não reflete pelo aluno).
  *   - Clicar num item abre o TradeDetailModal (onOpenTrade), onde o Espelho fica editável.
@@ -14,6 +17,7 @@
 import { useMemo, useState } from 'react';
 import { Eye, ChevronRight, ChevronDown } from 'lucide-react';
 import { formatCurrency } from '../../utils/calculations';
+import { isReflectionWindowClosed } from '../../constants/tradeReviewFramework';
 
 const fmtDateBR = (date) => (date ? String(date).split('-').reverse().join('/') : '-');
 
@@ -26,6 +30,7 @@ const PendingReflections = ({ trades = [], planId = null, onOpenTrade = null }) 
     const list = Array.isArray(trades) ? trades : [];
     return list
       .filter((t) => t && t.result != null && !t.selfReview)
+      .filter((t) => !isReflectionWindowClosed(t))
       .filter((t) => !planId || t.planId === planId)
       .sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
   }, [trades, planId]);

--- a/src/constants/tradeReviewFramework.js
+++ b/src/constants/tradeReviewFramework.js
@@ -21,6 +21,22 @@ export const REVIEW_DIMENSIONS = Object.freeze({
 export const WOULD_REPEAT_PROMPT = 'Faria de novo sem saber o resultado?';
 
 /**
+ * Janela de reflexão (#345). `status: 'DISCUSSED'` é o terminal do #269 v2: o trade foi
+ * discutido numa revisão publicada e vira imutável a writes de cliente — as rules negam
+ * (firestore.rules, duas cláusulas) e `submitTradeReview` lança. Quem oferece a edição
+ * consulta este predicado; sem ele a UI convida um write que o backend recusa (era o bug
+ * do #345: a fila do #327 cobrava trade discutido e o Salvar não gravava).
+ *
+ * Reflexão pós-discussão também não teria valor: o aluno já ouviu o mentor, então
+ * "faria de novo sem saber o resultado?" deixa de medir o que ele pensava na hora do trade.
+ */
+export const REFLECTION_CLOSING_STATUS = 'DISCUSSED';
+
+/** @returns {boolean} true quando o trade já foi discutido — janela de reflexão fechada. */
+export const isReflectionWindowClosed = (trade) =>
+  trade?.status === REFLECTION_CLOSING_STATUS;
+
+/**
  * Perguntas por quadrante. id = chave estável em trade.selfReview.answers.
  * @type {Record<'good_win'|'bad_win'|'good_loss'|'bad_loss', {label:string, questions:Array<{id:string,dimension:string,text:string}>}>}
  */


### PR DESCRIPTION
## Problema

Aluno clica num trade da fila **"Trades a refletir"**, preenche a reflexão, clica em Salvar e nada acontece. O trade volta pra fila e o aviso cobra o mesmo trade indefinidamente.

`publishReview` marca **todos** os membros da revisão como `status: 'DISCUSSED'` sem exigir `selfReview`. DISCUSSED é imutável a writes de cliente por `firestore.rules` (duas cláusulas independentes) + `submitTradeReview`. A fila do #327 e o gate `canReview` não conheciam essa regra: ofereciam o formulário, o write era negado, e a exceção morria em `console.error` — mesma classe do #343 B.

## Decisão

**A janela de reflexão fecha quando o trade é discutido.** Reflexão pós-discussão é contaminada: o aluno já ouviu o mentor, então "faria de novo sem saber o resultado?" deixa de medir o que ele pensava na hora do trade.

Descartado: permitir reflexão tardia. Exigiria enfraquecer duas cláusulas de segurança das rules ou criar callable com admin SDK pra furar o invariante do #269 v2 — e entregaria dado de qualidade duvidosa.

## Mudanças

- `tradeReviewFramework`: predicado SSoT `isReflectionWindowClosed(trade)` no módulo que o gateway já importa
- `PendingReflections`: DISCUSSED sai da fila e do contador
- `TradeReviewSection`: estado "Janela fechada" (read-only, sem botão, só pro aluno) + `submitError` visível com motivo técnico + guard de duplo clique; falha preserva as respostas digitadas

Desvio deliberado do escopo A2 do issue: em vez de repetir a regra nos 3 call sites de `canReview`, ela vive no predicado e o componente decide — espalhá-la triplicaria o ponto de divergência que causou o bug (DEC-AUTO-345-02, rationale no doc de controle).

`firestore.rules`, `publishReview` e `tradeGateway` **não** mudam: os três já estavam corretos.

## Verificação

- 13 testes novos (`TradeReviewSection.test.jsx` +10, `PendingReflections.test.jsx` +3)
- Suíte **3581/3581**, lint 0 erros / 0 warnings nos arquivos tocados, build verde
- Regressão: `tradeGatewaySelfReview.test.js` (imutabilidade DISCUSSED) verde sem alteração

Sem campo/collection novo (sem INV-15). Sem Cloud Function (**sem deploy**).

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)